### PR TITLE
Ensured CorrelationId is always exposed on ICommand

### DIFF
--- a/RabbitMQ.Stream.Client/CloseRequest.cs
+++ b/RabbitMQ.Stream.Client/CloseRequest.cs
@@ -8,6 +8,8 @@ namespace RabbitMQ.Stream.Client
         private readonly string reason;
         public const ushort Key = 22;
 
+        public uint CorrelationId => correlationId;
+
         public CloseRequest(uint correlationId, string reason)
         {
             this.correlationId = correlationId;

--- a/RabbitMQ.Stream.Client/Create.cs
+++ b/RabbitMQ.Stream.Client/Create.cs
@@ -12,6 +12,8 @@ namespace RabbitMQ.Stream.Client
         private readonly IDictionary<string, string> arguments;
         public const ushort Key = 13;
 
+        public uint CorrelationId => correlationId;
+
         public CreateRequest(uint correlationId, string stream, IDictionary<string, string> arguments)
         {
             this.correlationId = correlationId;

--- a/RabbitMQ.Stream.Client/Credit.cs
+++ b/RabbitMQ.Stream.Client/Credit.cs
@@ -9,6 +9,8 @@ namespace RabbitMQ.Stream.Client
         private readonly ushort credit;
         public const ushort Key = 9;
 
+        public uint CorrelationId => uint.MaxValue;
+
         public CreditRequest(byte subscriptionId, ushort credit)
         {
             this.subscriptionId = subscriptionId;

--- a/RabbitMQ.Stream.Client/DeclarePublisherRequest.cs
+++ b/RabbitMQ.Stream.Client/DeclarePublisherRequest.cs
@@ -10,6 +10,8 @@ namespace RabbitMQ.Stream.Client
         private readonly string stream;
         public const ushort Key = 1;
 
+        public uint CorrelationId => correlationId;
+
         public DeclarePublisherRequest(uint correlationId, byte publisherId, string publisherRef, string stream)
         {
             this.correlationId = correlationId;

--- a/RabbitMQ.Stream.Client/Delete.cs
+++ b/RabbitMQ.Stream.Client/Delete.cs
@@ -11,6 +11,8 @@ namespace RabbitMQ.Stream.Client
         private readonly string stream;
         public const ushort Key = 14;
 
+        public uint CorrelationId => correlationId;
+
         public DeleteRequest (uint correlationId, string stream)
         {
             this.correlationId = correlationId;

--- a/RabbitMQ.Stream.Client/DeletePublisherRequest.cs
+++ b/RabbitMQ.Stream.Client/DeletePublisherRequest.cs
@@ -7,6 +7,7 @@ namespace RabbitMQ.Stream.Client
         private readonly uint correlationId;
         private readonly byte publisherId;
         public const ushort Key = 6;
+        public uint CorrelationId => correlationId;
 
         public DeletePublisherRequest(uint correlationId, byte publisherId)
         {

--- a/RabbitMQ.Stream.Client/Deliver.cs
+++ b/RabbitMQ.Stream.Client/Deliver.cs
@@ -21,6 +21,8 @@ namespace RabbitMQ.Stream.Client
             this.chunk = chunk;
         }
 
+        public uint CorrelationId => uint.MaxValue;
+
         public IEnumerable<MsgEntry> Messages
         {
             get

--- a/RabbitMQ.Stream.Client/ICommand.cs
+++ b/RabbitMQ.Stream.Client/ICommand.cs
@@ -6,7 +6,7 @@ namespace RabbitMQ.Stream.Client
     public interface ICommand
     {
         ushort Version => 1;
-        uint CorrelationId => uint.MaxValue;
+        uint CorrelationId { get; }
         static ushort Key { get; }
         public int SizeNeeded { get; }
         int Write(Span<byte> span);

--- a/RabbitMQ.Stream.Client/MetaData.cs
+++ b/RabbitMQ.Stream.Client/MetaData.cs
@@ -17,6 +17,8 @@ namespace RabbitMQ.Stream.Client
             this.streams = streams.ToList();
         }
 
+        public uint CorrelationId => correlationId;
+
         public int SizeNeeded
         {
             get
@@ -149,6 +151,8 @@ namespace RabbitMQ.Stream.Client
         public const ushort Key = 16;
         private readonly ResponseCode code;
         private readonly string stream;
+
+        public uint CorrelationId => uint.MaxValue;
 
         public MetaDataUpdate(string stream, ResponseCode code)
         {

--- a/RabbitMQ.Stream.Client/OpenRequest.cs
+++ b/RabbitMQ.Stream.Client/OpenRequest.cs
@@ -15,6 +15,8 @@ namespace RabbitMQ.Stream.Client
         }
         public int SizeNeeded => 8 + WireFormatting.StringSize(vhost);
 
+        public uint CorrelationId => correlationId;
+
         public int Write(Span<byte> span)
         {
             int offset = WireFormatting.WriteUInt16(span, Key);

--- a/RabbitMQ.Stream.Client/PeerProperties.cs
+++ b/RabbitMQ.Stream.Client/PeerProperties.cs
@@ -16,6 +16,9 @@ namespace RabbitMQ.Stream.Client
             this.properties = properties;
         }
 
+
+        public uint CorrelationId => correlationId;
+
         public int SizeNeeded
         {
             get

--- a/RabbitMQ.Stream.Client/Publish.cs
+++ b/RabbitMQ.Stream.Client/Publish.cs
@@ -8,6 +8,8 @@ namespace RabbitMQ.Stream.Client
     {
         private const ushort Key = 2;
 
+        public uint CorrelationId => uint.MaxValue;
+
         public int SizeNeeded
         {
             get
@@ -19,7 +21,7 @@ namespace RabbitMQ.Stream.Client
                 }
                 
                 return size;
-             }
+            }
         }
 
         private readonly byte publisherId;
@@ -44,7 +46,7 @@ namespace RabbitMQ.Stream.Client
                 offset += WireFormatting.WriteUInt64(span.Slice(offset), publishingId);
                 // this only write "simple" messages, we assume msg is just the binary body
                 // not stream encoded data
-                offset += WireFormatting.WriteUInt32(span.Slice(offset), (uint) msg.Length);
+                offset += WireFormatting.WriteUInt32(span.Slice(offset), (uint)msg.Length);
                 offset += WireFormatting.Write(span.Slice(offset), msg);
             }
 

--- a/RabbitMQ.Stream.Client/PublishConfirm.cs
+++ b/RabbitMQ.Stream.Client/PublishConfirm.cs
@@ -15,6 +15,9 @@ namespace RabbitMQ.Stream.Client
             this.publishingIds = publisingIds;
         }
 
+
+        public uint CorrelationId => uint.MaxValue;
+
         public byte PublisherId => publisherId;
 
         public ulong[] PublishingIds => publishingIds;

--- a/RabbitMQ.Stream.Client/PublishError.cs
+++ b/RabbitMQ.Stream.Client/PublishError.cs
@@ -19,6 +19,8 @@ namespace RabbitMQ.Stream.Client
 
         public (ulong, ResponseCode)[] PublishingErrors => publishingErrors;
 
+        public uint CorrelationId => uint.MaxValue;
+
         public int SizeNeeded => throw new NotImplementedException();
 
         internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)

--- a/RabbitMQ.Stream.Client/QueryOffsetRequest.cs
+++ b/RabbitMQ.Stream.Client/QueryOffsetRequest.cs
@@ -6,16 +6,18 @@ namespace RabbitMQ.Stream.Client
     {
         public const ushort Key = 11;
         private readonly string stream;
-        private readonly uint corrId;
+        private readonly uint correlationId;
         private readonly string reference;
 
-        public QueryOffsetRequest(string stream, uint corrId, string reference)
+        public QueryOffsetRequest(string stream, uint correlationId, string reference)
         {
             this.stream = stream;
-            this.corrId = corrId;
+            this.correlationId = correlationId;
             this.reference = reference;
         }
 
+
+        public uint CorrelationId => correlationId;
 
         public int SizeNeeded =>
             2 + 2 + 4 +  WireFormatting.StringSize(reference) + WireFormatting.StringSize(stream);
@@ -26,7 +28,7 @@ namespace RabbitMQ.Stream.Client
             var command = (ICommand)this;
             int offset = WireFormatting.WriteUInt16(span, Key);
             offset += WireFormatting.WriteUInt16(span.Slice(offset), command.Version);
-            offset += WireFormatting.WriteUInt32(span.Slice(offset), corrId);
+            offset += WireFormatting.WriteUInt32(span.Slice(offset), correlationId);
             offset += WireFormatting.WriteString(span.Slice(offset), reference);
             offset += WireFormatting.WriteString(span.Slice(offset), stream);
             return offset;

--- a/RabbitMQ.Stream.Client/QueryPublisherRequest.cs
+++ b/RabbitMQ.Stream.Client/QueryPublisherRequest.cs
@@ -9,6 +9,8 @@ namespace RabbitMQ.Stream.Client
         private readonly string stream;
         public const ushort Key = 5;
 
+        public uint CorrelationId => correlationId;
+
         public QueryPublisherRequest(uint correlationId, string publisherRef, string stream)
         {
             this.correlationId = correlationId;

--- a/RabbitMQ.Stream.Client/SaslAuthenticateRequest.cs
+++ b/RabbitMQ.Stream.Client/SaslAuthenticateRequest.cs
@@ -11,6 +11,9 @@ namespace RabbitMQ.Stream.Client
         private readonly byte[] data;
         public const ushort Key = 19;
 
+
+        public uint CorrelationId => correlationId;
+
         public SaslAuthenticateRequest(uint correlationId, string mechanism, byte[] data)
         {
             this.correlationId = correlationId;

--- a/RabbitMQ.Stream.Client/SaslHandshakeRequest.cs
+++ b/RabbitMQ.Stream.Client/SaslHandshakeRequest.cs
@@ -7,6 +7,8 @@ namespace RabbitMQ.Stream.Client
         private readonly uint correlationId;
         public const ushort Key = 18;
 
+        public uint CorrelationId => correlationId;
+
         public SaslHandshakeRequest(uint correlationId)
         {
             this.correlationId = correlationId;

--- a/RabbitMQ.Stream.Client/StoreOffsetRequest.cs
+++ b/RabbitMQ.Stream.Client/StoreOffsetRequest.cs
@@ -8,6 +8,8 @@ namespace RabbitMQ.Stream.Client
         private readonly string stream;
         private readonly string reference;
         private readonly ulong offsetValue;
+        
+        public uint CorrelationId => uint.MaxValue;
 
         public StoreOffsetRequest(string stream, string reference, ulong offsetValue)
         {

--- a/RabbitMQ.Stream.Client/Subscribe.cs
+++ b/RabbitMQ.Stream.Client/Subscribe.cs
@@ -144,6 +144,8 @@ namespace RabbitMQ.Stream.Client
             this.properties = properties;
         }
 
+        public uint CorrelationId => correlationId;
+
         public int SizeNeeded
         {
             get

--- a/RabbitMQ.Stream.Client/Tune.cs
+++ b/RabbitMQ.Stream.Client/Tune.cs
@@ -14,6 +14,9 @@ namespace RabbitMQ.Stream.Client
             this.frameMax = frameMax;
             this.heartbeat = heartbeat;
         }
+
+        public uint CorrelationId => uint.MaxValue;
+
         public int SizeNeeded => 12;
 
         public uint FrameMax => frameMax;

--- a/RabbitMQ.Stream.Client/TuneRequest.cs
+++ b/RabbitMQ.Stream.Client/TuneRequest.cs
@@ -16,6 +16,8 @@ namespace RabbitMQ.Stream.Client
         }
         public int SizeNeeded => 12;
 
+        public uint CorrelationId => uint.MaxValue;
+
         public uint FrameMax => frameMax;
 
         public uint Heartbeat => heartbeat;

--- a/RabbitMQ.Stream.Client/Unubscribe.cs
+++ b/RabbitMQ.Stream.Client/Unubscribe.cs
@@ -43,6 +43,8 @@ namespace RabbitMQ.Stream.Client
         private readonly byte subscriptionId;
         public const ushort Key = 12;
 
+        public uint CorrelationId => correlationId;
+
         public UnsubscribeRequest(uint correlationId, byte subscriptionId)
         {
             this.correlationId = correlationId;


### PR DESCRIPTION
https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/10