### PR TITLE
Bug: ConsumerShouldReceiveDelivery_MultipleChunks fails

### DIFF
--- a/Tests/ClientTests.cs
+++ b/Tests/ClientTests.cs
@@ -110,7 +110,7 @@ namespace Tests
                 testOutputHelper.WriteLine($"publish error code ${errors[0]}");
                 testPassed.SetResult(true);
             };
-            
+
             var publisherRef = Guid.NewGuid().ToString();
 
             var (publisherId, result) = await client.DeclarePublisher(publisherRef, stream, confirmed, errored);
@@ -192,7 +192,7 @@ namespace Tests
             var delivery = testPassed.Task.Result;
             Assert.Equal(2, delivery.Messages.Count());
         }
-        
+
         [Fact]
         public async void ConsumerShouldReceiveDelivery_MultipleChunks()
         {
@@ -207,6 +207,7 @@ namespace Tests
             Action<Deliver> deliverHandler = deliver =>
             {
                 chunksReceived++;
+                Assert.False(deliver.Messages.Count() > 1, "Chunk should have 1 message");
                 if (chunksReceived == 2)
                 {
                     testPassed.SetResult();

--- a/Tests/ClientTests.cs
+++ b/Tests/ClientTests.cs
@@ -201,7 +201,7 @@ namespace Tests
             var client = await Client.Create(clientParameters);
             var testPassed = new TaskCompletionSource();
             await client.CreateStream(stream, new Dictionary<string, string>());
-            var initialCredit = 1;
+            var initialCredit = 2;
             var offsetType = new OffsetTypeFirst();
             int chunksReceived = 0;
             Action<Deliver> deliverHandler = deliver =>


### PR DESCRIPTION
While testing correlations, I discovered I only get 1 chunk in my deliverHandler. Even though I have multiple chunks in my stream.
I have added a test case to showcase the issue