### PR TITLE
Allocation reductions and CPU/Task optimizations

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -225,6 +225,7 @@ namespace RabbitMQ.Stream.Client
             {
                 var valueTask = new ValueTask<ICommand>(tcs, tcs.Version);
                 var result = await valueTask;
+                PooledTaskSource<ICommand>.Return(tcs);
                 return (TOut)result;
             }
         }

--- a/RabbitMQ.Stream.Client/CloseResponse.cs
+++ b/RabbitMQ.Stream.Client/CloseResponse.cs
@@ -26,7 +26,7 @@ namespace RabbitMQ.Stream.Client
         {
             throw new NotImplementedException();
         }
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out CloseResponse command)
         {
             ushort tag;
             ushort version;

--- a/RabbitMQ.Stream.Client/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Consumer.cs
@@ -70,7 +70,7 @@ namespace RabbitMQ.Stream.Client
                     }
 
                     // give one credit after each chunk
-                    client.Credit(deliver.SubscriptionId, 1);
+                    await client.Credit(deliver.SubscriptionId, 1);
                 });
             if (response.Code == ResponseCode.Ok)
             {

--- a/RabbitMQ.Stream.Client/Create.cs
+++ b/RabbitMQ.Stream.Client/Create.cs
@@ -72,7 +72,7 @@ namespace RabbitMQ.Stream.Client
         {
             throw new NotImplementedException();
         }
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out CreateResponse command)
         {
             var offset = WireFormatting.ReadUInt16(frame, out var tag);
             offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var version);

--- a/RabbitMQ.Stream.Client/DeclarePublisherResponse.cs
+++ b/RabbitMQ.Stream.Client/DeclarePublisherResponse.cs
@@ -25,7 +25,7 @@ namespace RabbitMQ.Stream.Client
         {
             throw new NotImplementedException();
         }
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out DeclarePublisherResponse command)
         {
             ushort tag;
             ushort version;

--- a/RabbitMQ.Stream.Client/Delete.cs
+++ b/RabbitMQ.Stream.Client/Delete.cs
@@ -51,7 +51,7 @@ namespace RabbitMQ.Stream.Client
         {
             throw new NotImplementedException();
         }
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out DeleteResponse command)
         {
             var offset = WireFormatting.ReadUInt16(frame, out var tag);
             offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var version);

--- a/RabbitMQ.Stream.Client/DeletePublisherResponse.cs
+++ b/RabbitMQ.Stream.Client/DeletePublisherResponse.cs
@@ -25,7 +25,7 @@ namespace RabbitMQ.Stream.Client
         {
             throw new NotImplementedException();
         }
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out DeletePublisherResponse command)
         {
             ushort tag;
             ushort version;

--- a/RabbitMQ.Stream.Client/Deliver.cs
+++ b/RabbitMQ.Stream.Client/Deliver.cs
@@ -46,7 +46,7 @@ namespace RabbitMQ.Stream.Client
         {
             throw new NotImplementedException();
         }
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out Deliver command)
         {
             var offset = WireFormatting.ReadUInt16(frame, out var tag);
             offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var version);
@@ -120,10 +120,9 @@ namespace RabbitMQ.Stream.Client
             offset += WireFormatting.ReadUInt32(seq.Slice(offset), out var trailerLen);
             offset += 4; // reserved
             //TODO: rather than copying at this point we may want to do codec / message parsing here
-            var data = seq.Slice(offset, dataLen).ToArray();
+            var data = seq.Slice(offset, dataLen);
             offset += (int)dataLen;
-            chunk = new Chunk(magicVersion, numEntries, numRecords, timestamp, epoch, chunkId, crc,
-                new ReadOnlySequence<byte>(data));
+            chunk = new Chunk(magicVersion, numEntries, numRecords, timestamp, epoch, chunkId, crc, data);
             return offset;
         }
     }

--- a/RabbitMQ.Stream.Client/ICommand.cs
+++ b/RabbitMQ.Stream.Client/ICommand.cs
@@ -5,7 +5,7 @@ namespace RabbitMQ.Stream.Client
 {
     public interface ICommand
     {
-        ushort Version => 1;
+        ushort Version { get => 1; }
         uint CorrelationId => uint.MaxValue;
         static ushort Key { get; }
         public int SizeNeeded { get; }

--- a/RabbitMQ.Stream.Client/Message.cs
+++ b/RabbitMQ.Stream.Client/Message.cs
@@ -4,7 +4,7 @@ using RabbitMQ.Stream.Client.AMQP;
 
 namespace RabbitMQ.Stream.Client
 {
-    public class Message
+    public readonly struct Message
     {
         private readonly Properties properties;
         

--- a/RabbitMQ.Stream.Client/MetaData.cs
+++ b/RabbitMQ.Stream.Client/MetaData.cs
@@ -100,7 +100,7 @@ namespace RabbitMQ.Stream.Client
 
         public IDictionary<string, StreamInfo> StreamInfos => streamInfos;
 
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out MetaDataResponse command)
         {
             var offset = WireFormatting.ReadUInt16(frame, out var tag);
             offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var version);

--- a/RabbitMQ.Stream.Client/MetaData.cs
+++ b/RabbitMQ.Stream.Client/MetaData.cs
@@ -162,7 +162,7 @@ namespace RabbitMQ.Stream.Client
 
         public string Stream => stream;
 
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out MetaDataUpdate command)
         {
             var offset = WireFormatting.ReadUInt16(frame, out var tag);
             offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var version);

--- a/RabbitMQ.Stream.Client/OpenResponse.cs
+++ b/RabbitMQ.Stream.Client/OpenResponse.cs
@@ -30,7 +30,7 @@ namespace RabbitMQ.Stream.Client
         {
             throw new NotImplementedException();
         }
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out OpenResponse command)
         {
             ushort tag;
             ushort version;

--- a/RabbitMQ.Stream.Client/PeerProperties.cs
+++ b/RabbitMQ.Stream.Client/PeerProperties.cs
@@ -75,7 +75,7 @@ namespace RabbitMQ.Stream.Client
         public int SizeNeeded => throw new NotImplementedException();
 
 
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out PeerPropertiesResponse command)
         {
             ushort tag;
             ushort version;

--- a/RabbitMQ.Stream.Client/Publish.cs
+++ b/RabbitMQ.Stream.Client/Publish.cs
@@ -25,11 +25,13 @@ namespace RabbitMQ.Stream.Client
 
         private readonly byte publisherId;
         private readonly List<(ulong, Message)> messages;
+        public int MessageCount { get; }
 
         public Publish(byte publisherId, List<(ulong, Message)> messages)
         {
             this.publisherId = publisherId;
             this.messages = messages;
+            this.MessageCount = messages.Count;
         }
 
         public int Write(Span<byte> span)
@@ -38,7 +40,7 @@ namespace RabbitMQ.Stream.Client
             offset += WireFormatting.WriteUInt16(span.Slice(offset), Version);
             offset += WireFormatting.WriteByte(span.Slice(offset), publisherId);
             // this assumes we never write an empty publish frame
-            offset += WireFormatting.WriteInt32(span.Slice(offset), messages.Count);
+            offset += WireFormatting.WriteInt32(span.Slice(offset), MessageCount);
             foreach(var (publishingId, msg) in messages)
             {
                 offset += WireFormatting.WriteUInt64(span.Slice(offset), publishingId);

--- a/RabbitMQ.Stream.Client/PublishError.cs
+++ b/RabbitMQ.Stream.Client/PublishError.cs
@@ -21,7 +21,7 @@ namespace RabbitMQ.Stream.Client
 
         public int SizeNeeded => throw new NotImplementedException();
 
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out PublishError command)
         {
             var offset = WireFormatting.ReadUInt16(frame, out var tag);
             offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var version);

--- a/RabbitMQ.Stream.Client/QueryOffsetResponse.cs
+++ b/RabbitMQ.Stream.Client/QueryOffsetResponse.cs
@@ -29,7 +29,7 @@ namespace RabbitMQ.Stream.Client
             throw new NotImplementedException();
         }
 
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out QueryOffsetResponse command)
         {
             ushort key;
             ushort version;

--- a/RabbitMQ.Stream.Client/QueryPublisherResponse.cs
+++ b/RabbitMQ.Stream.Client/QueryPublisherResponse.cs
@@ -30,7 +30,7 @@ namespace RabbitMQ.Stream.Client
         {
             throw new NotImplementedException();
         }
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out QueryPublisherResponse command)
         {
             ushort tag;
             ushort version;

--- a/RabbitMQ.Stream.Client/SaslAuthenticateResponse.cs
+++ b/RabbitMQ.Stream.Client/SaslAuthenticateResponse.cs
@@ -25,7 +25,7 @@ namespace RabbitMQ.Stream.Client
 
         public int SizeNeeded => throw new NotImplementedException();
 
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out SaslAuthenticateResponse command)
         {
             ushort tag;
             ushort version;

--- a/RabbitMQ.Stream.Client/SaslHandshakeResponse.cs
+++ b/RabbitMQ.Stream.Client/SaslHandshakeResponse.cs
@@ -23,7 +23,7 @@ namespace RabbitMQ.Stream.Client
 
         public IList<string> Mechanisms => mechanisms;
 
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out SaslHandshakeResponse command)
         {
             ushort tag;
             ushort version;

--- a/RabbitMQ.Stream.Client/Subscribe.cs
+++ b/RabbitMQ.Stream.Client/Subscribe.cs
@@ -113,7 +113,7 @@ namespace RabbitMQ.Stream.Client
             throw new NotImplementedException();
 
         }
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out SubscribeResponse command)
         {
             var offset = WireFormatting.ReadUInt16(frame, out var tag);
             offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var version);

--- a/RabbitMQ.Stream.Client/Tune.cs
+++ b/RabbitMQ.Stream.Client/Tune.cs
@@ -30,7 +30,7 @@ namespace RabbitMQ.Stream.Client
             return offset;
         }
 
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out TuneResponse command)
         {
             ushort tag;
             ushort version;

--- a/RabbitMQ.Stream.Client/TuneRequest.cs
+++ b/RabbitMQ.Stream.Client/TuneRequest.cs
@@ -22,9 +22,8 @@ namespace RabbitMQ.Stream.Client
 
         public int Write(Span<byte> span)
         {
-            var command = (ICommand)this;
             int offset = WireFormatting.WriteUInt16(span, Key);
-            offset += WireFormatting.WriteUInt16(span.Slice(offset), command.Version);
+            offset += WireFormatting.WriteUInt16(span.Slice(offset), ((ICommand)this).Version);
             offset += WireFormatting.WriteUInt32(span.Slice(offset), frameMax);
             offset += WireFormatting.WriteUInt32(span.Slice(offset), heartbeat);
             return offset;

--- a/RabbitMQ.Stream.Client/Unubscribe.cs
+++ b/RabbitMQ.Stream.Client/Unubscribe.cs
@@ -26,7 +26,7 @@ namespace RabbitMQ.Stream.Client
             throw new NotImplementedException();
         }
         
-        internal static int Read(ReadOnlySequence<byte> frame, out ICommand command)
+        internal static int Read(ReadOnlySequence<byte> frame, out UnsubscribeResponse command)
         {
             var offset = WireFormatting.ReadUInt16(frame, out var tag);
             offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var version);


### PR DESCRIPTION
* Removed channels from Client and Connection. This reduced the number of tasks that need be running and gets rid of double-buffering for frames sent/received.
* Added a bounded channel on the Producer to batch `Publish` messages sent.
* Made the Request operations generic so it's now `Request<TIn, TOut>`
* Added a pooled `IValueTaskSource` to reuse `ValueTask` objects for Request operations.
* Added generic optimizations for the `Connection.Write` method for better code generation and to eliminate struct boxing for ICommand objects.
* Added array pooling for `ulong` arrays in message confirmations and for frame handling. Arrays are returned after confirmations have been processed and after frames have been handled.