### PR TITLE
Converted calls to Console.WriteLine to ILogger<T>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ projects/Unit*/TestResult.xml
 # Vim
 .sw?
 .*.sw?
+
+# JetBrains Rider
+.idea/

--- a/RabbitMQ.Stream.Client/RabbitMQ.Stream.Client.csproj
+++ b/RabbitMQ.Stream.Client/RabbitMQ.Stream.Client.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="system.io.pipelines" Version="5.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Added a Logger property to ClientParameters of type Microsoft.Extensions.Logging.Abstractions.ILogger<Client>.  
- This required adding a dependency on Microsoft.Extensions.Logging.Abstractions.
- Added an entry into the .gitignore for JetBrains Rider IDE configuration directory: .idea/
- Converted Console.WriteLine calls to use the ILogger<T> abstraction.