### PR TITLE
Refactor QueryMetadata

### DIFF
--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography;
@@ -63,8 +64,10 @@ namespace RabbitMQ.Stream.Client
         public async Task<Producer> CreateProducer(ProducerConfig producerConfig)
         {
             var meta = await client.QueryMetadata(new []{producerConfig.Stream});
-            //TODO: error handling
             var info = meta.StreamInfos[producerConfig.Stream];
+            if (info.ResponseCode != ResponseCode.Ok) {
+                throw new CreateProducerException($"producer could not be created code: {info.ResponseCode}");
+            }
             var hostEntry = await Dns.GetHostEntryAsync(info.Leader.Host);
             var ipEndpoint = new IPEndPoint(hostEntry.AddressList.First(), (int)info.Leader.Port);
             // first look up meta data for stream
@@ -103,6 +106,11 @@ namespace RabbitMQ.Stream.Client
     public class CreateStreamException : Exception
     {
         public CreateStreamException(string s) : base(s) { }
+    }
+    
+    public class CreateProducerException : Exception
+    {
+        public CreateProducerException(string s) : base(s) { }
     }
 
     public struct Properties

--- a/Tests/ClientTests.cs
+++ b/Tests/ClientTests.cs
@@ -51,9 +51,19 @@ namespace Tests
             var streamInfoPair = metaDataResponse.StreamInfos.First();
             Assert.Equal(stream, streamInfoPair.Key);
             var streamInfo = streamInfoPair.Value;
-            Assert.Equal(1, streamInfo.Code);
+            Assert.Equal(ResponseCode.Ok, streamInfo.ResponseCode);
             Assert.Equal(5552, (int)streamInfo.Leader.Port);
             Assert.Empty(streamInfo.Replicas);
+            
+            // Test result when the Stream Does Not Exist
+            const string streamNotExist = "StreamNotExist";
+            var metaDataResponseNo = await client.QueryMetadata(new[] { streamNotExist});
+            Assert.Equal(1, metaDataResponseNo.StreamInfos.Count);
+            var streamInfoPairNo = metaDataResponseNo.StreamInfos.First();
+            Assert.Equal(streamNotExist, streamInfoPairNo.Key);
+            var streamInfoNo = streamInfoPairNo.Value;
+            Assert.Equal(ResponseCode.StreamDoesNotExist, streamInfoNo.ResponseCode);
+            
             await client.Close("done");
         }
 

--- a/Tests/SystemTests.cs
+++ b/Tests/SystemTests.cs
@@ -106,7 +106,25 @@ namespace Tests
             Assert.True(testPassed.Task.Result);
             await system.Close();
         }
-        
+
+        [Fact]
+      
+        public async Task CreateProducerStreamDoesNotExist()
+        {
+            const string stream = "StreamNotExist";
+            var config = new StreamSystemConfig();
+            var system = await StreamSystem.Create(config);
+           
+            await Assert.ThrowsAsync<CreateProducerException>(() => system.CreateProducer(
+                new ProducerConfig{
+                    Reference = "producer",
+                    Stream = stream,
+                }));
+            
+            await system.Close();
+        }
+
+
         [Fact]
         public async void CreateConsumer()
         {


### PR DESCRIPTION
- Add the response code error.
- Handle when the stream does not exist.
- Producer Creation: Raise an Exception when the stream does not exist
- Add tests


Fix the following error when a stream does not exist.

Code:
```csharp
  var stream = "StreamNotExist"
  var producer = await system.CreateProducer(
                    new ProducerConfig
                    {
                        Reference = "producer",
                        Stream = stream,
                        ConfirmHandler = conf => { }
                    });

```

error

```csharp
System.TimeoutException: The operation has timed out.
   at RabbitMQ.Stream.Client.ManualResetValueTaskSource`1.System.Threading.Tasks.Sources.IValueTaskSource<T>.GetResult(Int16 token) in /Users/gas/git/rabbitmq/rabbitmq-stream-dotnet-client/RabbitMQ.Stream.Client/Client.cs:line 463
   at RabbitMQ.Stream.Client.Client.Request[TIn,TOut](Func`2 request, Int32 timeout) in /Users/gas/git/rabbitmq/rabbitmq-stream-dotnet-client/RabbitMQ.Stream.Client/Client.cs:line 228
   at RabbitMQ.Stream.Client.Client.QueryMetadata(String[] streams) in /Users/gas/git/rabbitmq/rabbitmq-stream-dotnet-client/RabbitMQ.Stream.Client/Client.cs:line 399
   at example.StreamExample.Connect() in /Users/gas/test/donetExamples/donetstream/example/StreamExample.cs:line 28
```






