### PR TITLE
Implement IDisposable method to Producer and Consumer Class

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test Tests/Tests.csproj --no-build --verbosity normal
+      run: dotnet test Tests/Tests.csproj --no-build --logger "console;verbosity=detailed"
     - name: Publish RabbitMQ.Stream.Client
       uses: brandedoutcast/publish-nuget@v2.5.2
       with:

--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -102,7 +102,8 @@ namespace RabbitMQ.Stream.Client
         {
         }
     }
-
+    
+ 
     public class CreateStreamException : Exception
     {
         public CreateStreamException(string s) : base(s) { }
@@ -112,6 +113,7 @@ namespace RabbitMQ.Stream.Client
     {
         public CreateProducerException(string s) : base(s) { }
     }
+    
 
     public struct Properties
     {

--- a/RabbitMQ.Stream.Client/Unubscribe.cs
+++ b/RabbitMQ.Stream.Client/Unubscribe.cs
@@ -19,7 +19,7 @@ namespace RabbitMQ.Stream.Client
 
         public uint CorrelationId => correlationId;
 
-        public ResponseCode Code => responseCode;
+        public ResponseCode ResponseCode => responseCode;
 
         public int Write(Span<byte> span)
         {

--- a/Tests/ConsumerSystemTests.cs
+++ b/Tests/ConsumerSystemTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using RabbitMQ.Stream.Client;
+using RabbitMQ.Stream.Client.AMQP;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests
+{
+    public class ConsumerSystemTests
+    {
+        private readonly ITestOutputHelper testOutputHelper;
+
+        public ConsumerSystemTests(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async void CreateConsumer()
+        {
+            var testPassed = new TaskCompletionSource<Data>();
+            var stream = Guid.NewGuid().ToString();
+            var config = new StreamSystemConfig();
+            var system = await StreamSystem.Create(config);
+            await system.CreateStream(new StreamSpec(stream));
+            var producer = await system.CreateProducer(
+                new ProducerConfig
+                {
+                    Reference = "producer",
+                    Stream = stream
+                });
+            var consumer = await system.CreateConsumer(
+                new ConsumerConfig
+                {
+                    Reference = "consumer",
+                    Stream = stream,
+                    MessageHandler = async (consumer, ctx, message) =>
+                    {
+                        testPassed.SetResult(message.Data);
+                        await Task.CompletedTask;
+                    }
+                });
+            var msgData = new Data("apple".AsReadonlySequence());
+            var message = new Message(msgData);
+            await producer.Send(1, message);
+            //wait for sent message to be delivered
+
+            new Utils<Data>(testOutputHelper).WaitUntilTaskCompletes(testPassed);
+
+
+            Assert.Equal(msgData.Contents.ToArray(), testPassed.Task.Result.Contents.ToArray());
+            producer.Dispose();
+            consumer.Dispose();
+            await system.Close();
+        }
+
+        [Fact]
+        public async Task CloseProducerTwoTimesShouldBeOk()
+        {
+            var stream = Guid.NewGuid().ToString();
+            var config = new StreamSystemConfig();
+            var system = await StreamSystem.Create(config);
+            await system.CreateStream(new StreamSpec(stream));
+            var consumer = await system.CreateConsumer(
+                new ConsumerConfig
+                {
+                    Reference = "consumer",
+                    Stream = stream,
+                    MessageHandler = async (consumer, ctx, message) => { await Task.CompletedTask; }
+                });
+
+            Assert.Equal(ResponseCode.Ok, await consumer.Close());
+            Assert.Equal(ResponseCode.Ok, await consumer.Close());
+            consumer.Dispose();
+
+            await system.Close();
+        }
+    }
+}

--- a/Tests/ProducerSystemTests.cs
+++ b/Tests/ProducerSystemTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using RabbitMQ.Stream.Client;
+using RabbitMQ.Stream.Client.AMQP;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests
+{
+    public class ProducerSystemTests
+    {
+        private readonly ITestOutputHelper testOutputHelper;
+
+        public ProducerSystemTests(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async void CreateProducer()
+        {
+            var testPassed = new TaskCompletionSource<bool>();
+            var stream = Guid.NewGuid().ToString();
+            var config = new StreamSystemConfig();
+            var system = await StreamSystem.Create(config);
+            await system.CreateStream(new StreamSpec(stream));
+            var producer = await system.CreateProducer(
+                new ProducerConfig
+                {
+                    Reference = "producer",
+                    Stream = stream,
+                    ConfirmHandler = conf =>
+                    {
+                        testOutputHelper.WriteLine($"CreateProducer Confirm Handler #{conf.Code}");
+
+                        if (conf.Code == ResponseCode.Ok)
+                            testPassed.SetResult(true);
+                        else
+                            testPassed.SetResult(false);
+                    }
+                });
+
+            var readonlySequence = "apple".AsReadonlySequence();
+            var message = new Message(new Data(readonlySequence));
+            await producer.Send(1, message);
+
+
+            new Utils<bool>(testOutputHelper).WaitUntilTaskCompletes(testPassed);
+            
+            
+            Assert.True(testPassed.Task.Result);
+            producer.Dispose();
+
+            await system.Close();
+        }
+
+        [Fact]
+        public async Task CreateProducerStreamDoesNotExist()
+        {
+            const string stream = "StreamNotExist";
+            var config = new StreamSystemConfig();
+            var system = await StreamSystem.Create(config);
+
+            await Assert.ThrowsAsync<CreateProducerException>(() => system.CreateProducer(
+                new ProducerConfig
+                {
+                    Reference = "producer",
+                    Stream = stream,
+                }));
+
+            await system.Close();
+        }
+
+        [Fact]
+        public async Task CloseProducerTwoTimesShouldReturnOk()
+        {
+            var stream = Guid.NewGuid().ToString();
+            var config = new StreamSystemConfig();
+            var system = await StreamSystem.Create(config);
+            await system.CreateStream(new StreamSpec(stream));
+            var producer = await system.CreateProducer(
+                new ProducerConfig
+                {
+                    Reference = "producer",
+                    Stream = stream,
+                });
+
+            Assert.Equal(ResponseCode.Ok, await producer.Close());
+            Assert.Equal(ResponseCode.Ok, await producer.Close());
+            producer.Dispose();    
+
+            await system.Close();
+        }
+    }
+}

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests
+{
+    public class Utils<TResult>
+    {
+        private readonly ITestOutputHelper testOutputHelper;
+
+        public Utils(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+        }
+        
+        // Added this generic function to trap error during the 
+        // tests
+        public void WaitUntilTaskCompletes(TaskCompletionSource<TResult> tasks, 
+            bool expectToComplete = true,
+            int timeOut = 10000)
+        {
+            try
+            {
+                var resultTestWait = tasks.Task.Wait(timeOut);
+                Assert.Equal(resultTestWait, expectToComplete );
+            }
+            catch (Exception e)
+            {
+                testOutputHelper.WriteLine($"wait until task completes error #{e}");
+                throw;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implement `IDisposble` method for `Producer` and `Consumer` class.



That's the idea:
```csharp

    using var producer1 = await system.CreateProducer(
                     new ProducerConfig
                     {
                         Reference = Guid.NewGuid().ToString(),
                         Stream = stream,
                         ConfirmHandler = conf => { }
                     });
                await producer1.Send(1, message);
             
```

user can also call directly `Close()` to remove the producer from the server ( not mandatory btw)


for `Consumer`:
```csharp
   using var consumer = await system.CreateConsumer(
                    new ConsumerConfig
                    {
                        Reference = "consumer",
                        Stream = stream,
                        MessageHandler = async (consumer, ctx, message) => { await Task.CompletedTask; }
                    });
```

user can also call directly `Close()` to remove the consumer from the server ( not mandatory btw)



 



