### PR TITLE
Refactor tests 

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;
@@ -16,28 +15,28 @@ using System.Threading.Tasks.Sources;
 
 namespace RabbitMQ.Stream.Client
 {
-    internal static class TaskExtensions
-    {
-        public static async Task TimeoutAfter(this Task task, TimeSpan timeout)
-        {
-            if (task == await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false))
-            {
-                await task.ConfigureAwait(false);
-            }
-            else
-            {
-                var supressErrorTask = task.ContinueWith((t, s) =>
-                {
-                    t.Exception?.Handle(e => true);
-                },
-                    null,
-                    CancellationToken.None,
-                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default);
-                throw new TimeoutException();
-            }
-        }
-    }
+    // internal static class TaskExtensions
+    // {
+    //     public static async Task TimeoutAfter(this Task task, TimeSpan timeout)
+    //     {
+    //         if (task == await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false))
+    //         {
+    //             await task.ConfigureAwait(false);
+    //         }
+    //         else
+    //         {
+    //             var supressErrorTask = task.ContinueWith((t, s) =>
+    //             {
+    //                 t.Exception?.Handle(e => true);
+    //             },
+    //                 null,
+    //                 CancellationToken.None,
+    //                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+    //                 TaskScheduler.Default);
+    //             throw new TimeoutException();
+    //         }
+    //     }
+    // }
     public record ClientParameters
     {
         public IDictionary<string, string> Properties { get; } =
@@ -49,6 +48,7 @@ namespace RabbitMQ.Stream.Client
                 {"copyright", "Copyright (c) 2020-2021 VMware, Inc. or its affiliates."},
                 {"information", "Licensed under the MPL 2.0. See https://www.rabbitmq.com/"}
             };
+
         public string UserName { get; set; } = "guest";
         public string Password { get; set; } = "guest";
         public string VirtualHost { get; set; } = "/";
@@ -76,25 +76,33 @@ namespace RabbitMQ.Stream.Client
 
         public Message Data => data;
         public int SizeNeeded => 0;
+
         public int Write(Span<byte> span)
         {
             throw new NotImplementedException();
         }
     }
-    
+
     public class Client
     {
         private uint correlationId = 0; // allow for some pre-amble
         private byte nextPublisherId = 0;
         private readonly ClientParameters parameters;
         private Connection connection;
-        private readonly IDictionary<byte, (Action<ReadOnlyMemory<ulong>>, Action<(ulong, ResponseCode)[]>)> publishers =
-            new ConcurrentDictionary<byte, (Action<ReadOnlyMemory<ulong>>, Action<(ulong, ResponseCode)[]>)>();
+
+        private readonly IDictionary<byte, (Action<ReadOnlyMemory<ulong>>, Action<(ulong, ResponseCode)[]>)>
+            publishers =
+                new ConcurrentDictionary<byte, (Action<ReadOnlyMemory<ulong>>, Action<(ulong, ResponseCode)[]>)>();
+
         private readonly ConcurrentDictionary<uint, IValueTaskSource> requests = new();
-        private TaskCompletionSource<TuneResponse> tuneReceived = new TaskCompletionSource<TuneResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private TaskCompletionSource<TuneResponse> tuneReceived =
+            new TaskCompletionSource<TuneResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         private byte nextSubscriptionId;
-        private readonly IDictionary<byte, Func<Deliver, Task>> consumers = new ConcurrentDictionary<byte, Func<Deliver, Task>>();
+
+        private readonly IDictionary<byte, Func<Deliver, Task>> consumers =
+            new ConcurrentDictionary<byte, Func<Deliver, Task>>();
 
         private object closeResponse;
         private readonly Task outgoingTask;
@@ -109,7 +117,9 @@ namespace RabbitMQ.Stream.Client
         private int confirmFrames;
 
         public int ConfirmFrames => confirmFrames;
+
         public int IncomingFrames => this.connection.NumFrames;
+
         //public int IncomingChannelCount => this.incoming.Reader.Count;
         private static readonly object Obj = new();
 
@@ -120,15 +130,17 @@ namespace RabbitMQ.Stream.Client
             {
                 result = nextSubscriptionId++;
             }
+
             return result;
         }
+
         public bool IsClosed => closeResponse != null;
 
         private Client(ClientParameters parameters)
         {
             //this.connection = connection;
             this.parameters = parameters;
-            
+
             // connection.CommandCallback = async (command) =>
             // {
             //     await HandleIncoming(command, parameters.MetadataHandler);
@@ -142,33 +154,40 @@ namespace RabbitMQ.Stream.Client
         {
             var client = new Client(parameters);
             client.connection = await Connection.Create(parameters.Endpoint, client.HandleIncoming);
-            
+
             // exchange properties
-            var peerPropertiesResponse = await client.Request<PeerPropertiesRequest, PeerPropertiesResponse>(corr => new PeerPropertiesRequest(corr, parameters.Properties));
+            var peerPropertiesResponse =
+                await client.Request<PeerPropertiesRequest, PeerPropertiesResponse>(corr =>
+                    new PeerPropertiesRequest(corr, parameters.Properties));
             foreach (var (k, v) in peerPropertiesResponse.Properties)
                 Debug.WriteLine($"server Props {k} {v}");
 
             //auth
-            var saslHandshakeResponse = await client.Request<SaslHandshakeRequest, SaslHandshakeResponse>(corr => new SaslHandshakeRequest(corr));
+            var saslHandshakeResponse =
+                await client.Request<SaslHandshakeRequest, SaslHandshakeResponse>(
+                    corr => new SaslHandshakeRequest(corr));
             foreach (var m in saslHandshakeResponse.Mechanisms)
                 Debug.WriteLine($"sasl mechanism: {m}");
 
             var saslData = Encoding.UTF8.GetBytes($"\0{parameters.UserName}\0{parameters.Password}");
-            var authResponse = await client.Request<SaslAuthenticateRequest, SaslAuthenticateResponse>(corr => new SaslAuthenticateRequest(corr, "PLAIN", saslData));
+            var authResponse =
+                await client.Request<SaslAuthenticateRequest, SaslAuthenticateResponse>(corr =>
+                    new SaslAuthenticateRequest(corr, "PLAIN", saslData));
             Debug.WriteLine($"auth: {authResponse.ResponseCode} {authResponse.Data}");
 
             //tune
             var tune = await client.tuneReceived.Task;
             await client.Publish(new TuneRequest(0, 0));
-            
+
             // open 
-            var open = await client.Request<OpenRequest, OpenResponse>(corr => new OpenRequest(corr, parameters.VirtualHost));
+            var open = await client.Request<OpenRequest, OpenResponse>(corr =>
+                new OpenRequest(corr, parameters.VirtualHost));
             ClientExceptions.MaybeThrowException(open.ResponseCode, parameters.VirtualHost);
-            
+
             Debug.WriteLine($"open: {open.ResponseCode} {open.ConnectionProperties.Count}");
             foreach (var (k, v) in open.ConnectionProperties)
                 Debug.WriteLine($"open prop: {k} {v}");
-            
+
             client.correlationId = 100;
             return client;
         }
@@ -176,7 +195,7 @@ namespace RabbitMQ.Stream.Client
         public async ValueTask<bool> Publish(Publish publishMsg)
         {
             var publishTask = Publish<Publish>(publishMsg);
-            if(!publishTask.IsCompletedSuccessfully)
+            if (!publishTask.IsCompletedSuccessfully)
             {
                 await publishTask.ConfigureAwait(false);
             }
@@ -199,36 +218,42 @@ namespace RabbitMQ.Stream.Client
             var publisherId = nextPublisherId++;
             publishers.Add(publisherId, (confirmCallback, errorCallback));
             return (publisherId, await Request<DeclarePublisherRequest, DeclarePublisherResponse>(corr =>
-               new DeclarePublisherRequest(corr, publisherId, publisherRef, stream)));
+                new DeclarePublisherRequest(corr, publisherId, publisherRef, stream)));
         }
-        
+
         public async Task<DeletePublisherResponse> DeletePublisher(byte publisherId)
         {
-            var result = await Request<DeletePublisherRequest, DeletePublisherResponse>(corr => new DeletePublisherRequest(corr, publisherId));
+            var result =
+                await Request<DeletePublisherRequest, DeletePublisherResponse>(corr =>
+                    new DeletePublisherRequest(corr, publisherId));
             publishers.Remove(publisherId);
             return result;
         }
 
 
-        public async Task<(byte, SubscribeResponse)> Subscribe(string stream, IOffsetType offsetType, ushort initialCredit,
+        public async Task<(byte, SubscribeResponse)> Subscribe(string stream, IOffsetType offsetType,
+            ushort initialCredit,
             Dictionary<string, string> properties, Func<Deliver, Task> deliverHandler)
         {
             var subscriptionId = GetNextSubscriptionId();
             consumers.Add(subscriptionId, deliverHandler);
             return (subscriptionId,
                 await Request<SubscribeRequest, SubscribeResponse>(corr =>
-                   new SubscribeRequest(corr, subscriptionId, stream, offsetType, initialCredit, properties)));
+                    new SubscribeRequest(corr, subscriptionId, stream, offsetType, initialCredit, properties)));
         }
-        
+
         public async Task<UnsubscribeResponse> Unsubscribe(byte subscriptionId)
         {
-            var result = await Request<UnsubscribeRequest, UnsubscribeResponse>(corr => new UnsubscribeRequest(corr, subscriptionId));
+            var result =
+                await Request<UnsubscribeRequest, UnsubscribeResponse>(corr =>
+                    new UnsubscribeRequest(corr, subscriptionId));
             // remove consumer after RPC returns, this should avoid uncorrelated data being sent
             consumers.Remove(subscriptionId);
             return result;
         }
 
-        private async ValueTask<TOut> Request<TIn, TOut>(Func<uint, TIn> request, int timeout = 10000) where TIn : struct, ICommand where TOut : struct, ICommand
+        private async ValueTask<TOut> Request<TIn, TOut>(Func<uint, TIn> request, int timeout = 10000)
+            where TIn : struct, ICommand where TOut : struct, ICommand
         {
             var corr = NextCorrelationId();
             var tcs = PooledTaskSource<TOut>.Rent();
@@ -236,7 +261,9 @@ namespace RabbitMQ.Stream.Client
             await Publish(request(corr));
             using (CancellationTokenSource cts = new CancellationTokenSource(timeout))
             {
-                await using (cts.Token.Register(valueTaskSource => ((ManualResetValueTaskSource<TOut>)valueTaskSource).SetException(new TimeoutException()), tcs))
+                await using (cts.Token.Register(
+                    valueTaskSource =>
+                        ((ManualResetValueTaskSource<TOut>) valueTaskSource).SetException(new TimeoutException()), tcs))
                 {
                     var valueTask = new ValueTask<TOut>(tcs, tcs.Version);
                     var result = await valueTask;
@@ -257,7 +284,7 @@ namespace RabbitMQ.Stream.Client
             WireFormatting.ReadUInt16(frame, out ushort tag);
             if ((tag & 0x8000) != 0)
             {
-                tag = (ushort)(tag ^ 0x8000);
+                tag = (ushort) (tag ^ 0x8000);
             }
 
             switch (tag)
@@ -271,6 +298,7 @@ namespace RabbitMQ.Stream.Client
                     {
                         ArrayPool<ulong>.Shared.Return(confirmSegment.Array);
                     }
+
                     break;
                 case Deliver.Key:
                     Deliver.Read(frame, out Deliver deliver);
@@ -295,7 +323,7 @@ namespace RabbitMQ.Stream.Client
                     break;
             }
 
-            if(MemoryMarshal.TryGetArray(frameMemory, out ArraySegment<byte> segment))
+            if (MemoryMarshal.TryGetArray(frameMemory, out ArraySegment<byte> segment))
             {
                 ArrayPool<byte>.Shared.Return(segment.Array);
             }
@@ -303,7 +331,7 @@ namespace RabbitMQ.Stream.Client
 
         private void HandleCorrelatedCommand(ushort tag, ref ReadOnlySequence<byte> frame)
         {
-            switch(tag)
+            switch (tag)
             {
                 case DeclarePublisherResponse.Key:
                     DeclarePublisherResponse.Read(frame, out var declarePublisherResponse);
@@ -380,7 +408,7 @@ namespace RabbitMQ.Stream.Client
 
             if (requests.TryRemove(command.CorrelationId, out var tsc))
             {
-                ((ManualResetValueTaskSource<T>)tsc).SetResult(command);
+                ((ManualResetValueTaskSource<T>) tsc).SetResult(command);
             }
         }
 
@@ -404,23 +432,25 @@ namespace RabbitMQ.Stream.Client
 
             return result;
         }
-        
+
         // Safe close 
         // the client can be closed only if the publishers are == 0
         // not a public method used internally by producers and consumers
-        internal  CloseResponse MaybeClose(string reason)
+        internal CloseResponse MaybeClose(string reason)
         {
-            if (publishers.Count == 0 && consumers.Count ==0)
+            if (publishers.Count == 0 && consumers.Count == 0)
             {
                 return this.Close(reason).Result;
             }
+
             var result = new CloseResponse(0, ResponseCode.Ok);
             return result;
         }
 
         public async ValueTask<QueryPublisherResponse> QueryPublisherSequence(string publisherRef, string stream)
         {
-            return await Request<QueryPublisherRequest, QueryPublisherResponse>(corr => new QueryPublisherRequest(corr, publisherRef, stream));
+            return await Request<QueryPublisherRequest, QueryPublisherResponse>(corr =>
+                new QueryPublisherRequest(corr, publisherRef, stream));
         }
 
         public async ValueTask<bool> StoreOffset(string reference, string stream, ulong offsetValue)
@@ -435,7 +465,8 @@ namespace RabbitMQ.Stream.Client
 
         public async ValueTask<QueryOffsetResponse> QueryOffset(string reference, string stream)
         {
-            return await Request<QueryOffsetRequest, QueryOffsetResponse>(corr => new QueryOffsetRequest(stream, corr, reference));
+            return await Request<QueryOffsetRequest, QueryOffsetResponse>(corr =>
+                new QueryOffsetRequest(stream, corr, reference));
         }
 
         public async ValueTask<CreateResponse> CreateStream(string stream, IDictionary<string, string> args)
@@ -455,19 +486,20 @@ namespace RabbitMQ.Stream.Client
     }
 
 
-
     public static class PooledTaskSource<T>
     {
-        private static ConcurrentStack<ManualResetValueTaskSource<T>> stack = new ConcurrentStack<ManualResetValueTaskSource<T>>();
+        private static ConcurrentStack<ManualResetValueTaskSource<T>> stack =
+            new ConcurrentStack<ManualResetValueTaskSource<T>>();
+
         public static ManualResetValueTaskSource<T> Rent()
         {
-            if(stack.TryPop(out ManualResetValueTaskSource<T> task))
+            if (stack.TryPop(out ManualResetValueTaskSource<T> task))
             {
                 return task;
             }
             else
             {
-                return new ManualResetValueTaskSource<T>() { RunContinuationsAsynchronously = true };
+                return new ManualResetValueTaskSource<T>() {RunContinuationsAsynchronously = true};
             }
         }
 
@@ -498,7 +530,10 @@ namespace RabbitMQ.Stream.Client
         ValueTaskSourceStatus IValueTaskSource.GetStatus(short token) => _logic.GetStatus(token);
         ValueTaskSourceStatus IValueTaskSource<T>.GetStatus(short token) => _logic.GetStatus(token);
 
-        void IValueTaskSource.OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags) => _logic.OnCompleted(continuation, state, token, flags);
-        void IValueTaskSource<T>.OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags) => _logic.OnCompleted(continuation, state, token, flags);
+        void IValueTaskSource.OnCompleted(Action<object> continuation, object state, short token,
+            ValueTaskSourceOnCompletedFlags flags) => _logic.OnCompleted(continuation, state, token, flags);
+
+        void IValueTaskSource<T>.OnCompleted(Action<object> continuation, object state, short token,
+            ValueTaskSourceOnCompletedFlags flags) => _logic.OnCompleted(continuation, state, token, flags);
     }
 }

--- a/RabbitMQ.Stream.Client/ClientExceptions.cs
+++ b/RabbitMQ.Stream.Client/ClientExceptions.cs
@@ -4,35 +4,42 @@ namespace RabbitMQ.Stream.Client
 {
     internal static class ClientExceptions
     {
-        
         public static void MaybeThrowException(ResponseCode responseCode, string message)
         {
             if (responseCode != ResponseCode.Ok)
             {
                 throw responseCode switch
                 {
-                    ResponseCode.VirtualHostAccessFailure => new VirtualHostAccessFailureException(message),
-                    //TODO Implement the other responses
-                    _ => new NotImplementedException()
+                    ResponseCode.VirtualHostAccessFailure => new VirtualHostAccessFailureException(responseCode,
+                        message),
+                    //TODO Implement for all the response code
+                    _ => new GenericProtocolException(responseCode, message)
                 };
             }
         }
-        
     }
-    
+
     public class ProtocolException : Exception
     {
-        protected ProtocolException(string s) : base(s)
+        protected ProtocolException(ResponseCode responseCode, string s) :
+            base($"response code: {responseCode} - {s}")
         {
+        }
+    }
 
+    public class GenericProtocolException : ProtocolException
+    {
+        public GenericProtocolException(ResponseCode responseCode, string s) :
+            base(responseCode, s)
+        {
         }
     }
 
     public class VirtualHostAccessFailureException : ProtocolException
     {
-        public VirtualHostAccessFailureException(string s) : base(s)
+        public VirtualHostAccessFailureException(ResponseCode responseCode, string s) :
+            base(responseCode, s)
         {
-
         }
     }
 }

--- a/RabbitMQ.Stream.Client/ClientExceptions.cs
+++ b/RabbitMQ.Stream.Client/ClientExceptions.cs
@@ -10,8 +10,7 @@ namespace RabbitMQ.Stream.Client
             {
                 throw responseCode switch
                 {
-                    ResponseCode.VirtualHostAccessFailure => new VirtualHostAccessFailureException(responseCode,
-                        message),
+                    ResponseCode.VirtualHostAccessFailure => new VirtualHostAccessFailureException(message),
                     //TODO Implement for all the response code
                     _ => new GenericProtocolException(responseCode, message)
                 };
@@ -21,8 +20,8 @@ namespace RabbitMQ.Stream.Client
 
     public class ProtocolException : Exception
     {
-        protected ProtocolException(ResponseCode responseCode, string s) :
-            base($"response code: {responseCode} - {s}")
+        protected ProtocolException(string s) :
+            base(s)
         {
         }
     }
@@ -30,15 +29,15 @@ namespace RabbitMQ.Stream.Client
     public class GenericProtocolException : ProtocolException
     {
         public GenericProtocolException(ResponseCode responseCode, string s) :
-            base(responseCode, s)
+            base($"response code: {responseCode} - {s}")
         {
         }
     }
 
     public class VirtualHostAccessFailureException : ProtocolException
     {
-        public VirtualHostAccessFailureException(ResponseCode responseCode, string s) :
-            base(responseCode, s)
+        public VirtualHostAccessFailureException(string s) :
+            base(s)
         {
         }
     }

--- a/RabbitMQ.Stream.Client/ICommand.cs
+++ b/RabbitMQ.Stream.Client/ICommand.cs
@@ -7,7 +7,6 @@ namespace RabbitMQ.Stream.Client
     {
         ushort Version { get => 1; }
         uint CorrelationId => uint.MaxValue;
-        static ushort Key { get; }
         public int SizeNeeded { get; }
         int Write(Span<byte> span);
     }

--- a/Tests/ConsumerSystemTests.cs
+++ b/Tests/ConsumerSystemTests.cs
@@ -93,9 +93,7 @@ namespace Tests
             var system = await StreamSystem.Create(config);
             await system.CreateStream(new StreamSpec(stream));
             const int numberOfMessages = 10;
-            testOutputHelper.WriteLine($"Staring...");
             await SystemUtils.PublishMessages(system, stream, numberOfMessages, testOutputHelper);
-            testOutputHelper.WriteLine($"End...");
             var count = 0;
             using var consumer = await system.CreateConsumer(
                 new ConsumerConfig

--- a/Tests/ProducerSystemTests.cs
+++ b/Tests/ProducerSystemTests.cs
@@ -36,11 +36,7 @@ namespace Tests
                     ConfirmHandler = conf =>
                     {
                         testOutputHelper.WriteLine($"CreateProducer Confirm Handler #{conf.Code}");
-
-                        if (conf.Code == ResponseCode.Ok)
-                            testPassed.SetResult(true);
-                        else
-                            testPassed.SetResult(false);
+                        testPassed.SetResult(conf.Code == ResponseCode.Ok);
                     }
                 });
 

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -52,10 +52,8 @@ namespace Tests
                     ConfirmHandler = confirmation =>
                     {
                         count++;
-
                         testOutputHelper.WriteLine($"Published and Confirmed: {count} messages");
                         if (count != numberOfMessages) return;
-                        testOutputHelper.WriteLine($"Published and Confirmed: {count} messages");
                         testPassed.SetResult(count);
                     }
                 });

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -66,6 +66,8 @@ namespace Tests
             }
 
             testPassed.Task.Wait(10000);
+            Assert.Equal(producer.Client.MessagesSent, numberOfMessages);
+            Assert.True(producer.Client.ConfirmFrames >= 1);
             producer.Dispose();
         }
     }

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -54,11 +54,9 @@ namespace Tests
                         count++;
 
                         testOutputHelper.WriteLine($"Published and Confirmed: {count} messages");
-                        if (count == numberOfMessages)
-                        {
-                            testOutputHelper.WriteLine($"Published and Confirmed: {count} messages");
-                            testPassed.SetResult(count);
-                        }
+                        if (count != numberOfMessages) return;
+                        testOutputHelper.WriteLine($"Published and Confirmed: {count} messages");
+                        testPassed.SetResult(count);
                     }
                 });
 


### PR DESCRIPTION
- Make the writer thread-safe
- Refactor a bit the tests
- Add `GenericProtocolException` to handle the protocol exceptions from the `ResponseCode` protocol