### PR TITLE
Rename solution CMD to PerfTest

### DIFF
--- a/RabbitMQ.Stream.Client.PerfTest/Program.fs
+++ b/RabbitMQ.Stream.Client.PerfTest/Program.fs
@@ -19,7 +19,8 @@ let main argv =
     let mutable consumed = 0
     let mutable confirmed = 0
     let mutable prod = null
-    let consumerConfig = ConsumerConfig(Stream = "s1",
+    let streamName = "dotnet-perftest"
+    let consumerConfig = ConsumerConfig(Stream = streamName,
                                         Reference = Guid.NewGuid().ToString(),
                                         MessageHandler =
                                             fun c ctx m ->
@@ -30,9 +31,10 @@ let main argv =
         let config = StreamSystemConfig(UserName = "guest",
                                         Password = "guest")
         let! system = StreamSystem.Create config
+        let! stream = system.CreateStream(StreamSpec(streamName))
+        printfn $"Stream: {streamName}"
         let! consumer = system.CreateConsumer(consumerConfig)
-        let producerConfig = ProducerConfig(Stream = "s1",
-                                            //Reference = Guid.NewGuid().ToString(),
+        let producerConfig = ProducerConfig(Stream = streamName,
                                             Reference = null,
                                             MaxInFlight = 10000,
                                             ConfirmHandler = fun c -> confirmed <- confirmed + 1)

--- a/RabbitMQ.Stream.Client.PerfTest/README.md
+++ b/RabbitMQ.Stream.Client.PerfTest/README.md
@@ -1,0 +1,4 @@
+Basic performances test
+---
+
+Test the Stream performances with the dotnet library.

--- a/RabbitMQ.Stream.Client.PerfTest/RabbitMQ.Stream.Client.PerfTest.fsproj
+++ b/RabbitMQ.Stream.Client.PerfTest/RabbitMQ.Stream.Client.PerfTest.fsproj
@@ -3,10 +3,12 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net5.0</TargetFramework>
+        <RootNamespace>RabbitMQ.Stream.Client.Cmd</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
         <Compile Include="Program.fs" />
+        <Content Include="README.md" />
     </ItemGroup>
 
     <ItemGroup>

--- a/rabbitmq-stream-dotnet-client.sln
+++ b/rabbitmq-stream-dotnet-client.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RabbitMQ.Stream.Client", "R
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{57283B49-FC40-4910-9647-DC51433B3A79}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "RabbitMQ.Stream.Client.Cmd", "RabbitMQ.Stream.Client.Cmd\RabbitMQ.Stream.Client.Cmd.fsproj", "{8EEF75BF-F0E5-493B-B642-40A4860733BA}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "RabbitMQ.Stream.Client.PerfTest", "RabbitMQ.Stream.Client.PerfTest\RabbitMQ.Stream.Client.PerfTest.fsproj", "{8EEF75BF-F0E5-493B-B642-40A4860733BA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Just a small refactor.  
- Changed the name to `RabbitMQ.Stream.Client.PerfTest` which is more appropriate. 
- Create the `dotnet-perftest`
