### PR TITLE
hide the tcp client

### DIFF
--- a/RabbitMQ.Stream.Client.PerfTest/Program.fs
+++ b/RabbitMQ.Stream.Client.PerfTest/Program.fs
@@ -53,11 +53,11 @@ let main argv =
     async{
         while run do
             do! Async.Sleep 1000
-            let p = prod.Client.MessagesSent
-            let f = prod.Client.PublishCommandsSent
+            let p = prod.MessagesSent
+            let f = prod.PublishCommandsSent
             let c = confirmed
             let cs = consumed;
-            printfn $"published %i{p - lastPublishingId} msg/s in %i{f - lastFrames} publish frames, confirmed %i{c - lastConfirmed} msg/s, consumed: %i{c - lastConsumed} msg/sec total confirm frames %i{prod.Client.ConfirmFrames} %i{prod.Client.IncomingFrames} pending commands: {prod.PendingCount} "
+            printfn $"published %i{p - lastPublishingId} msg/s in %i{f - lastFrames} publish frames, confirmed %i{c - lastConfirmed} msg/s, consumed: %i{c - lastConsumed} msg/sec total confirm frames %i{prod.ConfirmFrames} %i{prod.IncomingFrames} pending commands: {prod.PendingCount} "
             lastConsumed <- cs
             lastFrames <- f
             lastPublishingId <- p

--- a/RabbitMQ.Stream.Client/Producer.cs
+++ b/RabbitMQ.Stream.Client/Producer.cs
@@ -52,12 +52,9 @@ namespace RabbitMQ.Stream.Client
             this.semaphore = new(config.MaxInFlight, config.MaxInFlight);
         }
 
-        //public Client Client => client;
-
         public int MessagesSent => client.MessagesSent;
         public int ConfirmFrames => client.ConfirmFrames;
         public int IncomingFrames => client.IncomingFrames;
-
         public int PublishCommandsSent => client.PublishCommandsSent;
 
         private async Task Init()

--- a/RabbitMQ.Stream.Client/Producer.cs
+++ b/RabbitMQ.Stream.Client/Producer.cs
@@ -52,7 +52,13 @@ namespace RabbitMQ.Stream.Client
             this.semaphore = new(config.MaxInFlight, config.MaxInFlight);
         }
 
-        public Client Client => client;
+        //public Client Client => client;
+
+        public int MessagesSent => client.MessagesSent;
+        public int ConfirmFrames => client.ConfirmFrames;
+        public int IncomingFrames => client.IncomingFrames;
+
+        public int PublishCommandsSent => client.PublishCommandsSent;
 
         private async Task Init()
         {

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -92,8 +92,10 @@ namespace Tests
             }
 
             testPassed.Task.Wait(10000);
-            Assert.Equal(producer.Client.MessagesSent, numberOfMessages);
-            Assert.True(producer.Client.ConfirmFrames >= 1);
+            Assert.Equal(producer.MessagesSent, numberOfMessages);
+            Assert.True(producer.ConfirmFrames >= 1);
+            Assert.True(producer.IncomingFrames >= 1);
+            Assert.True(producer.PublishCommandsSent >= 1);
             producer.Dispose();
         }
 


### PR DESCRIPTION
A small refactor to hide the TCP client. 
The user should not access the client directly. 