### PR TITLE
#74 Console.WriteLine has been replaced with EventSource

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -462,7 +462,7 @@ namespace RabbitMQ.Stream.Client
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                LogEventSource.Log.LogError($"An error occurred while calling { nameof(connection.Dispose) }.", e);
             }
 
             return result;

--- a/RabbitMQ.Stream.Client/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Consumer.cs
@@ -138,8 +138,7 @@ namespace RabbitMQ.Stream.Client
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Error during disposing Consumer: {subscriberId}, " +
-                                  $"error: {e}");
+                LogEventSource.Log.LogError($"Error during disposing Consumer: {subscriberId}.", e);
             }
 
             GC.SuppressFinalize(this);

--- a/RabbitMQ.Stream.Client/ILogEventSource.cs
+++ b/RabbitMQ.Stream.Client/ILogEventSource.cs
@@ -17,12 +17,34 @@ namespace RabbitMQ.Stream.Client
         ILogEventSource LogInformation(string message);
 
         /// <summary>
+        /// Writes an informational log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        /// 
+        /// <param name="args">
+        /// </param>
+        ILogEventSource LogInformation(string message, params object[] args);
+
+        /// <summary>
         /// Writes a warning log message.
         /// </summary>
         /// 
         /// <param name="message">
         /// </param>
         ILogEventSource LogWarning(string message);
+
+        /// <summary>
+        /// Writes a warning log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        /// 
+        /// <param name="args">
+        /// </param>
+        ILogEventSource LogWarning(string message, params object[] args);
 
         /// <summary>
         /// Writes an error log message.
@@ -43,5 +65,20 @@ namespace RabbitMQ.Stream.Client
         /// The exception to log.
         /// </param>
         ILogEventSource LogError(string message, Exception exception);
+
+        /// <summary>
+        /// Writes an error log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        /// 
+        /// <param name="exception">
+        /// The exception to log.
+        /// </param>
+        /// 
+        /// <param name="args">
+        /// </param>
+        ILogEventSource LogError(string message, Exception exception, params object[] args);
     }
 }

--- a/RabbitMQ.Stream.Client/ILogEventSource.cs
+++ b/RabbitMQ.Stream.Client/ILogEventSource.cs
@@ -1,0 +1,47 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2007-2020 VMware, Inc.
+
+using System;
+
+namespace RabbitMQ.Stream.Client
+{
+    internal interface ILogEventSource
+    {
+        /// <summary>
+        /// Writes an informational log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        ILogEventSource LogInformation(string message);
+
+        /// <summary>
+        /// Writes a warning log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        ILogEventSource LogWarning(string message);
+
+        /// <summary>
+        /// Writes an error log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        ILogEventSource LogError(string message);
+
+        /// <summary>
+        /// Writes an error log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        /// 
+        /// <param name="exception">
+        /// The exception to log.
+        /// </param>
+        ILogEventSource LogError(string message, Exception exception);
+    }
+}

--- a/RabbitMQ.Stream.Client/LogEventListener.cs
+++ b/RabbitMQ.Stream.Client/LogEventListener.cs
@@ -1,0 +1,46 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2007-2020 VMware, Inc.
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace RabbitMQ.Stream.Client
+{
+    public sealed class LogEventListener : EventListener, IDisposable
+    {
+        public LogEventListener()
+        {
+            EnableEvents((EventSource)LogEventSource.Log, EventLevel.Verbose, Keywords.Log);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks
+        /// associated with freeing, releasing,
+        /// or resetting unmanaged resources.
+        /// </summary>
+        public override void Dispose()
+        {
+            DisableEvents((EventSource)LogEventSource.Log);
+        }
+
+        /// <summary>
+        /// Called whenever an event has been written by
+        /// an event source for which the event listener
+        /// has enabled events.
+        /// </summary>
+        /// 
+        /// <param name="eventData">
+        /// The event arguments that describe the event.
+        /// </param>
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            for (var i = 0; i < eventData.Payload.Count; i++)
+            {
+                Console.WriteLine("{0}: {1}: {2}", eventData.Level, eventData.PayloadNames[i], eventData.Payload[i]);
+            }
+
+            base.OnEventWritten(eventData);
+        }
+    }
+}

--- a/RabbitMQ.Stream.Client/LogEventListener.cs
+++ b/RabbitMQ.Stream.Client/LogEventListener.cs
@@ -37,7 +37,7 @@ namespace RabbitMQ.Stream.Client
         {
             for (var i = 0; i < eventData.Payload.Count; i++)
             {
-                Console.WriteLine("{0}: {1}: {2}", eventData.Level, eventData.PayloadNames[i], eventData.Payload[i]);
+                Console.WriteLine("{0}: {1}: {2}", eventData.Level, eventData.Message, eventData.Payload[i]);
             }
 
             base.OnEventWritten(eventData);

--- a/RabbitMQ.Stream.Client/LogEventSource.cs
+++ b/RabbitMQ.Stream.Client/LogEventSource.cs
@@ -1,0 +1,108 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2007-2020 VMware, Inc.
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace RabbitMQ.Stream.Client
+{
+    public static class Keywords
+    {
+        public const EventKeywords Log = (EventKeywords)1;
+    }
+
+    [EventSource(Name = "rabbitmq-client-stream")]
+    internal sealed class LogEventSource : EventSource, ILogEventSource
+    {
+        private static readonly char[] _newLineChars = Environment.NewLine.ToCharArray();
+
+        /// <summary>
+        /// Default <see cref="LogEventSource" /> implementation for logging.
+        /// </summary>
+        public static readonly
+            ILogEventSource Log = new
+             LogEventSource
+            ();
+
+        private LogEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat)
+        { }
+
+        /// <summary>
+        /// </summary>
+        [NonEvent]
+        private static string ConvertToString(Exception exception)
+        {
+            return exception?.ToString();
+        }
+
+        /// <summary>
+        /// Writes an informational log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        [Event(1, Level = EventLevel.Informational)]
+        public ILogEventSource LogInformation(string message)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(1, message);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Writes a warning log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        [Event(2, Level = EventLevel.Warning)]
+        public ILogEventSource LogWarning(string message)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(2, message);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Writes an error log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        [Event(3, Level = EventLevel.Error)]
+        public ILogEventSource LogError(string message)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(3, message);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Writes an error log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        /// 
+        /// <param name="exception">
+        /// The exception to log.
+        /// </param>
+        [NonEvent]
+        public ILogEventSource LogError(string message, Exception exception)
+        {
+            LogError($"{message}{Environment.NewLine}{ConvertToString(exception)}".Trim(_newLineChars));
+
+            return this;
+        }
+    }
+}

--- a/RabbitMQ.Stream.Client/LogEventSource.cs
+++ b/RabbitMQ.Stream.Client/LogEventSource.cs
@@ -15,8 +15,6 @@ namespace RabbitMQ.Stream.Client
     [EventSource(Name = "rabbitmq-client-stream")]
     internal sealed class LogEventSource : EventSource, ILogEventSource
     {
-        private static readonly char[] _newLineChars = Environment.NewLine.ToCharArray();
-
         /// <summary>
         /// Default <see cref="LogEventSource" /> implementation for logging.
         /// </summary>
@@ -33,7 +31,7 @@ namespace RabbitMQ.Stream.Client
         [NonEvent]
         private static string ConvertToString(Exception exception)
         {
-            return exception?.ToString();
+            return exception == default ? default : $"{Environment.NewLine}{ exception?.ToString() }";
         }
 
         /// <summary>
@@ -42,7 +40,7 @@ namespace RabbitMQ.Stream.Client
         /// 
         /// <param name="message">
         /// </param>
-        [Event(1, Level = EventLevel.Informational)]
+        [Event(1, Message = "INFO", Keywords = Keywords.Log, Level = EventLevel.Informational)]
         public ILogEventSource LogInformation(string message)
         {
             if (IsEnabled())
@@ -54,12 +52,27 @@ namespace RabbitMQ.Stream.Client
         }
 
         /// <summary>
+        /// Writes an informational log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        /// 
+        /// <param name="args">
+        /// </param>
+        [NonEvent]
+        public ILogEventSource LogInformation(string message, params object[] args)
+        {
+            return LogInformation(string.Format(message, args));
+        }
+
+        /// <summary>
         /// Writes a warning log message.
         /// </summary>
         /// 
         /// <param name="message">
         /// </param>
-        [Event(2, Level = EventLevel.Warning)]
+        [Event(2, Message = "WARN", Keywords = Keywords.Log, Level = EventLevel.Warning)]
         public ILogEventSource LogWarning(string message)
         {
             if (IsEnabled())
@@ -71,12 +84,26 @@ namespace RabbitMQ.Stream.Client
         }
 
         /// <summary>
+        /// Writes a warning log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        /// 
+        /// <param name="args">
+        /// </param>
+        public ILogEventSource LogWarning(string message, params object[] args)
+        {
+            return LogWarning(string.Format(message, args));
+        }
+
+        /// <summary>
         /// Writes an error log message.
         /// </summary>
         /// 
         /// <param name="message">
         /// </param>
-        [Event(3, Level = EventLevel.Error)]
+        [Event(3, Message = "ERROR", Keywords = Keywords.Log, Level = EventLevel.Error)]
         public ILogEventSource LogError(string message)
         {
             if (IsEnabled())
@@ -100,9 +127,28 @@ namespace RabbitMQ.Stream.Client
         [NonEvent]
         public ILogEventSource LogError(string message, Exception exception)
         {
-            LogError($"{message}{Environment.NewLine}{ConvertToString(exception)}".Trim(_newLineChars));
+            LogError($"{ message }{ ConvertToString(exception) }");
 
             return this;
+        }
+
+        /// <summary>
+        /// Writes an error log message.
+        /// </summary>
+        /// 
+        /// <param name="message">
+        /// </param>
+        /// 
+        /// <param name="exception">
+        /// The exception to log.
+        /// </param>
+        /// 
+        /// <param name="args">
+        /// </param>
+        [NonEvent]
+        public ILogEventSource LogError(string message, Exception exception, params object[] args)
+        {
+            return LogError(string.Format(message, args), exception);
         }
     }
 }

--- a/RabbitMQ.Stream.Client/Message.cs
+++ b/RabbitMQ.Stream.Client/Message.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Buffers;
+
 using RabbitMQ.Stream.Client.AMQP;
 
 namespace RabbitMQ.Stream.Client
@@ -129,7 +130,7 @@ namespace RabbitMQ.Stream.Client
                         offset += AmqpWireFormatting.ReadAny(amqpData.Slice(offset), out amqpValue);
                         break;
                     default:
-                        Console.WriteLine($"dataCode: {dataCode} not handled. Please open an issue.");
+                        LogEventSource.Log.LogError($"dataCode: {dataCode} not handled. Please open an issue.");
                         throw new ArgumentOutOfRangeException($"dataCode: {dataCode} not handled");
                 }
             }

--- a/RabbitMQ.Stream.Client/Producer.cs
+++ b/RabbitMQ.Stream.Client/Producer.cs
@@ -137,7 +137,7 @@ namespace RabbitMQ.Stream.Client
                 // Nope, we have maxed our In-Flight messages, let's asynchronously wait for confirms
                 if (!await semaphore.WaitAsync(1000).ConfigureAwait(false))
                 {
-                    Console.WriteLine("Semaphore Wait timeout during publishing.");
+                    LogEventSource.Log.LogWarning("Semaphore Wait timeout during publishing.");
                 }
             }
         }
@@ -240,8 +240,7 @@ namespace RabbitMQ.Stream.Client
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Error during disposing producer: {publisherId}, " +
-                                  $"error: {e}");
+                LogEventSource.Log.LogError($"Error during disposing Consumer: {publisherId}.", e);
             }
 
             GC.SuppressFinalize(this);

--- a/Tests/ApiApproval.Approve.verified.txt
+++ b/Tests/ApiApproval.Approve.verified.txt
@@ -452,12 +452,22 @@ namespace RabbitMQ.Stream.Client
         bool ValidateDns { get; set; }
         RabbitMQ.Stream.Client.IClient CreateClient(RabbitMQ.Stream.Client.ClientParameters clientParameters);
     }
+    public static class Keywords
+    {
+        public const System.Diagnostics.Tracing.EventKeywords Log = 1;
+    }
     public readonly struct LeaderLocator
     {
         public static RabbitMQ.Stream.Client.LeaderLocator ClientLocal { get; }
         public static RabbitMQ.Stream.Client.LeaderLocator LeastLeaders { get; }
         public static RabbitMQ.Stream.Client.LeaderLocator Random { get; }
         public override string ToString() { }
+    }
+    public sealed class LogEventListener : System.Diagnostics.Tracing.EventListener, System.IDisposable
+    {
+        public LogEventListener() { }
+        public override void Dispose() { }
+        protected override void OnEventWritten(System.Diagnostics.Tracing.EventWrittenEventArgs eventData) { }
     }
     public sealed class ManualResetValueTaskSource<T> : System.Threading.Tasks.Sources.IValueTaskSource, System.Threading.Tasks.Sources.IValueTaskSource<T>
     {

--- a/Tests/EventSourceTests.cs
+++ b/Tests/EventSourceTests.cs
@@ -49,7 +49,11 @@ namespace Tests
                 resultException = Record.Exception(() => args.ValidateEventData(EventLevel.Informational, ExpectedPayloadName, new string[] { nameof(GenerateInfoEvent) }));
             };
 
+            // Simple message.
             LogEventSource.Log.LogInformation(nameof(GenerateInfoEvent));
+
+            // Simple message formatted with string.Format().
+            LogEventSource.Log.LogInformation("{0}{1}{2}", "Generate", "Info", "Event");
 
             Assert.Null(resultException);
         }
@@ -69,7 +73,11 @@ namespace Tests
                 resultException = Record.Exception(() => args.ValidateEventData(EventLevel.Warning, ExpectedPayloadName, new string[] { nameof(GenerateWarningEvent) }));
             };
 
+            // Simple message.
             LogEventSource.Log.LogWarning(nameof(GenerateWarningEvent));
+
+            // Simple message formatted with string.Format().
+            LogEventSource.Log.LogWarning("{0}{1}{2}", "Generate", "Warning", "Event");
 
             Assert.Null(resultException);
         }
@@ -89,8 +97,14 @@ namespace Tests
                 resultException = Record.Exception(() => args.ValidateEventData(EventLevel.Error, ExpectedPayloadName, new string[] { nameof(GenerateErrorEvent) }));
             };
 
+            // Simple message.
             LogEventSource.Log.LogError(nameof(GenerateErrorEvent));
+
+            // Simple message with null exception.
             LogEventSource.Log.LogError(nameof(GenerateErrorEvent), default);
+
+            // Simple message formatted with string.Format().
+            LogEventSource.Log.LogError("{0}{1}{2}", default, "Generate", "Error", "Event");
 
             Assert.Null(resultException);
         }
@@ -103,20 +117,18 @@ namespace Tests
         [Fact]
         public void GenerateErrorWithExceptionEvent()
         {
-            const string exception1Message = "TextExceptionMessage1";
-            const string exception2Message = "TextExceptionMessage2";
-
-            var message = $"GenerateErrorEvent{ Environment.NewLine }System.Exception: { exception2Message }{ Environment.NewLine } ---> System.Exception: { exception1Message }{ Environment.NewLine }   --- End of inner exception stack trace ---";
+            const string Exception1Message = "TextExceptionMessage1";
+            const string Exception2Message = "TextExceptionMessage2";
 
             Exception resultException = default;
 
             var exception =
-                new Exception(exception2Message,
-                new Exception(exception1Message));
+                new Exception(Exception2Message,
+                new Exception(Exception1Message));
 
             new LogEventListener().EventWritten += (sender, args) =>
             {
-                resultException = Record.Exception(() => args.ValidateEventData(EventLevel.Error, ExpectedPayloadName, new string[] { message }));
+                resultException = Record.Exception(() => args.ValidateEventData(EventLevel.Error, ExpectedPayloadName, new string[] { nameof(GenerateErrorEvent), Exception1Message, Exception2Message }));
             };
 
             LogEventSource.Log.LogError(nameof(GenerateErrorEvent), exception);

--- a/Tests/EventSourceTests.cs
+++ b/Tests/EventSourceTests.cs
@@ -1,0 +1,127 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2007-2020 VMware, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+using RabbitMQ.Stream.Client;
+
+using Xunit;
+
+namespace Tests
+{
+    public static class EventSourceTestsHelper
+    {
+        public static void ValidateEventData(this EventWrittenEventArgs args, EventLevel level, string expectedPayloadName, IEnumerable<string> expectedPayloadText)
+        {
+            Assert.Equal(level, args.Level);
+
+            Assert.Equal(expectedPayloadName, args.PayloadNames[0]);
+
+            foreach (var payloadText in expectedPayloadText)
+            {
+                Assert.Contains(payloadText, args.Payload[0].ToString());
+            }
+        }
+    }
+
+    public class EventSourceTests
+    {
+        /// <summary>
+        /// The name of the argument whose value is used as the payload when writing the event.
+        /// </summary>
+        private const string ExpectedPayloadName = "message";
+
+        /// <summary>
+        /// Verifies the contents of the event
+        /// object: event level match, payload
+        /// name match, payload match.
+        /// </summary>
+        [Fact]
+        public void GenerateInfoEvent()
+        {
+            Exception resultException = default;
+
+            new LogEventListener().EventWritten += (sender, args) =>
+            {
+                resultException = Record.Exception(() => args.ValidateEventData(EventLevel.Informational, ExpectedPayloadName, new string[] { nameof(GenerateInfoEvent) }));
+            };
+
+            LogEventSource.Log.LogInformation(nameof(GenerateInfoEvent));
+
+            Assert.Null(resultException);
+        }
+
+        /// <summary>
+        /// Verifies the contents of the event
+        /// object: event level match, payload
+        /// name match, payload match.
+        /// </summary>
+        [Fact]
+        public void GenerateWarningEvent()
+        {
+            Exception resultException = default;
+
+            new LogEventListener().EventWritten += (sender, args) =>
+            {
+                resultException = Record.Exception(() => args.ValidateEventData(EventLevel.Warning, ExpectedPayloadName, new string[] { nameof(GenerateWarningEvent) }));
+            };
+
+            LogEventSource.Log.LogWarning(nameof(GenerateWarningEvent));
+
+            Assert.Null(resultException);
+        }
+
+        /// <summary>
+        /// Verifies the contents of the event
+        /// object: event level match, payload
+        /// name match, payload match.
+        /// </summary>
+        [Fact]
+        public void GenerateErrorEvent()
+        {
+            Exception resultException = default;
+
+            new LogEventListener().EventWritten += (sender, args) =>
+            {
+                resultException = Record.Exception(() => args.ValidateEventData(EventLevel.Error, ExpectedPayloadName, new string[] { nameof(GenerateErrorEvent) }));
+            };
+
+            LogEventSource.Log.LogError(nameof(GenerateErrorEvent));
+            LogEventSource.Log.LogError(nameof(GenerateErrorEvent), default);
+
+            Assert.Null(resultException);
+        }
+
+        /// <summary>
+        /// Verifies the contents of the event
+        /// object: event level match, payload
+        /// name match, payload match.
+        /// </summary>
+        [Fact]
+        public void GenerateErrorWithExceptionEvent()
+        {
+            const string exception1Message = "TextExceptionMessage1";
+            const string exception2Message = "TextExceptionMessage2";
+
+            var message = $"GenerateErrorEvent{ Environment.NewLine }System.Exception: { exception2Message }{ Environment.NewLine } ---> System.Exception: { exception1Message }{ Environment.NewLine }   --- End of inner exception stack trace ---";
+
+            Exception resultException = default;
+
+            var exception =
+                new Exception(exception2Message,
+                new Exception(exception1Message));
+
+            new LogEventListener().EventWritten += (sender, args) =>
+            {
+                resultException = Record.Exception(() => args.ValidateEventData(EventLevel.Error, ExpectedPayloadName, new string[] { message }));
+            };
+
+            LogEventSource.Log.LogError(nameof(GenerateErrorEvent), exception);
+
+            Assert.Null(resultException);
+        }
+    }
+}


### PR DESCRIPTION
EventSource-based logger that implements the following interface:

```
    internal interface ILogEventSource
    {
        /// <summary>
        /// Writes an informational log message.
        /// </summary>
        /// 
        /// <param name="message">
        /// </param>
        ILogEventSource LogInformation(string message);

        /// <summary>
        /// Writes a warning log message.
        /// </summary>
        /// 
        /// <param name="message">
        /// </param>
        ILogEventSource LogWarning(string message);

        /// <summary>
        /// Writes an error log message.
        /// </summary>
        /// 
        /// <param name="message">
        /// </param>
        ILogEventSource LogError(string message);

        /// <summary>
        /// Writes an error log message.
        /// </summary>
        /// 
        /// <param name="message">
        /// </param>
        /// 
        /// <param name="exception">
        /// The exception to log.
        /// </param>
        ILogEventSource LogError(string message, Exception exception);
    }
```

Also added several tests verifying the basic aspects: event level match, payload name match, payload match (occurrence).

Fixes #74