### PR TITLE
fix test

### DIFF
--- a/Tests/ConsumerSystemTests.cs
+++ b/Tests/ConsumerSystemTests.cs
@@ -505,7 +505,7 @@ namespace Tests
                 });
 
             new Utils<ulong>(testOutputHelper).WaitUntilTaskCompletes(storedOffset);
-            
+
             // we need to wait a bit because the StoreOffset is async
             // and `QueryOffset` could raise NoOffsetFound
             SystemUtils.Wait();

--- a/Tests/ConsumerSystemTests.cs
+++ b/Tests/ConsumerSystemTests.cs
@@ -505,8 +505,7 @@ namespace Tests
                 });
 
             new Utils<ulong>(testOutputHelper).WaitUntilTaskCompletes(storedOffset);
-
-            await consumer.Close();
+            
 
             // new consumer that should start from stored offset
             var offset = await system.QueryOffset(Reference, stream);
@@ -538,6 +537,7 @@ namespace Tests
             Assert.Equal(storedOffset.Task.Result, messagesConsumed.Task.Result);
 
             await consumerWithOffset.Close();
+            await consumer.Close();
             await system.DeleteStream(stream);
             await system.Close();
         }

--- a/Tests/ConsumerSystemTests.cs
+++ b/Tests/ConsumerSystemTests.cs
@@ -505,7 +505,10 @@ namespace Tests
                 });
 
             new Utils<ulong>(testOutputHelper).WaitUntilTaskCompletes(storedOffset);
-
+            
+            // we need to wait a bit because the StoreOffset is async
+            // and `QueryOffset` could raise NoOffsetFound
+            SystemUtils.Wait();
             // new consumer that should start from stored offset
             var offset = await system.QueryOffset(Reference, stream);
             // the offset received must be the same from the last stored

--- a/Tests/ConsumerSystemTests.cs
+++ b/Tests/ConsumerSystemTests.cs
@@ -505,7 +505,6 @@ namespace Tests
                 });
 
             new Utils<ulong>(testOutputHelper).WaitUntilTaskCompletes(storedOffset);
-            
 
             // new consumer that should start from stored offset
             var offset = await system.QueryOffset(Reference, stream);

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -62,7 +62,7 @@ namespace Tests
     {
         public static void Wait()
         {
-            Thread.Sleep(300);
+            Thread.Sleep(400);
         }
 
         public static async Task PublishMessages(StreamSystem system, string stream, int numberOfMessages,


### PR DESCRIPTION
Fix the `ShouldConsumeFromStoredOffset` 
Sometimes it failed because the `QueryOffset` could return an error. 