### PR TITLE
Change the way to decide when the client socket is open

### DIFF
--- a/RabbitMQ.Stream.Client/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Consumer.cs
@@ -119,7 +119,7 @@ namespace RabbitMQ.Stream.Client
 
         public async Task<ResponseCode> Close()
         {
-            if (_disposed)
+            if (client.IsClosed)
             {
                 return ResponseCode.Ok;
             }

--- a/Tests/Amqp10Tests.cs
+++ b/Tests/Amqp10Tests.cs
@@ -14,7 +14,6 @@ namespace Tests
     public class Amqp10Tests
     {
         [Fact]
-        [WaitTestBeforeAfter]
         public void ReadsThrowsExceptionInvalidType()
         {
             var data = new byte[10];
@@ -119,7 +118,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public void ValidateFormatCode()
         {
             const bool boolTrue = true;
@@ -256,7 +254,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public void Validate32Bytes8BytesLists()
         {
             var value32Bin = new byte[] { 0xD0, 0x0, 0x0, 0x0, 0xF, 0x0, 0x0, 0x1, 0xF };
@@ -278,7 +275,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public void ValidateMessagesFromGo()
         {
             // These files are generated with the Go AMQP 1.0 client
@@ -379,7 +375,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public void MapEntriesWithAnEmptyKeyShouldNotBeWrittenToTheWire()
         {
             // Given we have an annotation with a valid key

--- a/Tests/ApiApproval.Approve.verified.txt
+++ b/Tests/ApiApproval.Approve.verified.txt
@@ -266,6 +266,7 @@ namespace RabbitMQ.Stream.Client
     }
     public class Connection : System.IDisposable
     {
+        public bool IsClosed { get; }
         public void Dispose() { }
         public System.Threading.Tasks.ValueTask<bool> Write<T>(T command)
             where T :  struct, RabbitMQ.Stream.Client.ICommand { }

--- a/Tests/ClientTests.cs
+++ b/Tests/ClientTests.cs
@@ -15,7 +15,6 @@ using Xunit.Abstractions;
 
 namespace Tests
 {
-    [Collection("Sequential")]
     public class ClientTests
     {
         private readonly ITestOutputHelper testOutputHelper;
@@ -26,7 +25,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void CreateDeleteStream()
         {
             var stream = Guid.NewGuid().ToString();
@@ -45,7 +43,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void MetaDataShouldReturn()
         {
             var stream = Guid.NewGuid().ToString();
@@ -75,7 +72,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void MetadataUpdateIsHandled()
         {
             var stream = Guid.NewGuid().ToString();
@@ -98,7 +94,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void DeclarePublisherShouldReturnErrorCode()
         {
             var clientParameters = new ClientParameters { };
@@ -114,7 +109,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void PublishShouldError()
         {
             var stream = Guid.NewGuid().ToString();
@@ -151,7 +145,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void PublishShouldConfirm()
         {
             testOutputHelper.WriteLine("PublishShouldConfirm");
@@ -201,7 +194,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ConsumerShouldReceiveDelivery()
         {
             var stream = Guid.NewGuid().ToString();
@@ -240,7 +232,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ConsumerStoreOffsetShouldReceiveDelivery()
         {
             var stream = Guid.NewGuid().ToString();
@@ -329,7 +320,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ConsumerShouldReceiveDeliveryAfterCredit()
         {
             var stream = Guid.NewGuid().ToString();
@@ -366,7 +356,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void UnsubscribedConsumerShouldNotReceiveDelivery()
         {
             var stream = Guid.NewGuid().ToString();
@@ -398,7 +387,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void VirtualHostFailureAccess()
         {
             var clientParameters = new ClientParameters

--- a/Tests/ConsumerSystemTests.cs
+++ b/Tests/ConsumerSystemTests.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Tests
 {
-    [Collection("Sequential")]
     public class ConsumerSystemTests
     {
         private readonly ITestOutputHelper testOutputHelper;
@@ -27,7 +26,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void CreateConsumer()
         {
             var testPassed = new TaskCompletionSource<Data>();
@@ -63,7 +61,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void CloseProducerTwoTimesShouldBeOk()
         {
             var stream = Guid.NewGuid().ToString();
@@ -86,7 +83,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ConsumerStoreOffset()
         {
             var testPassed = new TaskCompletionSource<int>();
@@ -134,7 +130,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void NotifyConsumerClose()
         {
             var stream = Guid.NewGuid().ToString();
@@ -163,7 +158,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void CreateProducerConsumerAddressResolver()
         {
             var testPassed = new TaskCompletionSource<Data>();
@@ -200,7 +194,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ProducerAndConsumerCompressShouldHaveTheSameMessages()
         {
             void PumpMessages(ICollection<Message> messages, string prefix)
@@ -269,7 +262,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ConsumerValidationAmqpAttributes()
         {
             var testPassed = new TaskCompletionSource<Message>();
@@ -355,7 +347,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void Amqp091MessagesConsumer()
         {
             // Amqp091 interoperability 
@@ -401,7 +392,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ConsumerQueryOffset()
         {
             var testPassed = new TaskCompletionSource<int>();
@@ -461,7 +451,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ShouldConsumeFromStoredOffset()
         {
             // validate restart consume offset
@@ -545,7 +534,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ConsumerMetadataHandlerUpdate()
         {
             // test the Consumer metadata update

--- a/Tests/PermissionTests.cs
+++ b/Tests/PermissionTests.cs
@@ -10,7 +10,6 @@ namespace Tests
     public class PermissionTests
     {
         [Fact]
-        [WaitTestBeforeAfter]
         public async void AccessToStreamWithoutGrantsShouldRaiseErrorTest()
         {
             SystemUtils.HttpPost(

--- a/Tests/ProducerSystemTests.cs
+++ b/Tests/ProducerSystemTests.cs
@@ -24,7 +24,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void CreateProducer()
         {
             var testPassed = new TaskCompletionSource<bool>();
@@ -57,7 +56,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async Task CreateProducerStreamDoesNotExist()
         {
             const string stream = "StreamNotExist";
@@ -71,7 +69,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async Task CloseProducerTwoTimesShouldReturnOk()
         {
             var stream = Guid.NewGuid().ToString();
@@ -89,7 +86,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void NotifyProducerClose()
         {
             var stream = Guid.NewGuid().ToString();
@@ -117,7 +113,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ProducerMessagesListLenValidation()
         {
             // by protocol the subEntryList is ushort
@@ -143,7 +138,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ProducerMixingDifferentConfirmations()
         {
             // we send 150 messages using three different ways:
@@ -205,7 +199,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ProducerMetadataHandlerUpdate()
         {
             // test the producer metadata update
@@ -239,7 +232,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public async void ProducerQuerySequence()
         {
             // test the producer sequence

--- a/Tests/StreamSpecTests.cs
+++ b/Tests/StreamSpecTests.cs
@@ -8,11 +8,9 @@ using Xunit;
 
 namespace Tests
 {
-    [Collection("Sequential")]
     public class StreamSpecTests
     {
         [Fact]
-        [WaitTestBeforeAfter]
         public void DefaultStreamSpecMustHaveAtLeastQueueLeaderLocator()
         {
             var actualSpec = new StreamSpec("theStreamName");
@@ -25,7 +23,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public void CanOverrideAnyStreamSpecAttributes()
         {
             var spec = new StreamSpec("theStreamName");

--- a/Tests/UnitTests.cs
+++ b/Tests/UnitTests.cs
@@ -96,11 +96,9 @@ namespace Tests
     }
 
     // This class is only for unit tests
-    [Collection("Sequential")]
     public class UnitTests
     {
         [Fact]
-        [WaitTestBeforeAfter]
         public void AddressResolverShouldRaiseAnExceptionIfAdvIsNull()
         {
             var addressResolver = new AddressResolver(new IPEndPoint(IPAddress.Loopback, 5552));
@@ -116,7 +114,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public void AddressResolverLoadBalancerSimulate()
         {
             var addressResolver = new AddressResolver(new IPEndPoint(IPAddress.Parse("192.168.10.99"), 5552));
@@ -136,7 +133,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public void RandomReplicaLeader()
         {
             // this test is not completed yet should add also some replicas
@@ -155,7 +151,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public void CompressUnCompressShouldHaveTheSize()
         {
             void PumpMessages(ICollection<Message> messages)
@@ -193,7 +188,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public void CodeNotFoundException()
         {
             // Raise an exception for the codec not implemented.
@@ -237,7 +231,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public void AddRemoveCodecsForType()
         {
             // the following codec aren't provided by builtin.
@@ -269,7 +262,6 @@ namespace Tests
         }
 
         [Fact]
-        [WaitTestBeforeAfter]
         public void CodecAlreadyExistException()
         {
             // the following codec aren't provided by builtin.


### PR DESCRIPTION
When the tcp connection is forced the client sets the status as closed.

Fixes: https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/97

See the comment on https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/97#issue-1189533103 or the test `CloseProducerConsumerAfterForceCloseShouldNotRaiseError` to reproduce the error.