### PR TITLE
Fix close consumer

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -281,12 +281,18 @@ namespace RabbitMQ.Stream.Client
 
         public async Task<UnsubscribeResponse> Unsubscribe(byte subscriptionId)
         {
-            var result =
-                await Request<UnsubscribeRequest, UnsubscribeResponse>(corr =>
-                    new UnsubscribeRequest(corr, subscriptionId));
-            // remove consumer after RPC returns, this should avoid uncorrelated data being sent
-            consumers.Remove(subscriptionId);
-            return result;
+            try
+            {
+                var result =
+                    await Request<UnsubscribeRequest, UnsubscribeResponse>(corr =>
+                        new UnsubscribeRequest(corr, subscriptionId));
+                return result;
+            }
+            finally
+            {
+                // remove consumer after RPC returns, this should avoid uncorrelated data being sent
+                consumers.Remove(subscriptionId);
+            }
         }
 
         private async ValueTask<TOut> Request<TIn, TOut>(Func<uint, TIn> request, TimeSpan? timeout = null)

--- a/Tests/SystemTests.cs
+++ b/Tests/SystemTests.cs
@@ -224,13 +224,14 @@ namespace Tests
             // by a network problem or forced by the management UI
             // see issues/97
             var stream = Guid.NewGuid().ToString();
+            var clientProvidedName = Guid.NewGuid().ToString();
             var config = new StreamSystemConfig();
             var system = await StreamSystem.Create(config);
             await system.CreateStream(new StreamSpec(stream));
             var producer = await system.CreateProducer(new ProducerConfig { Stream = stream, ClientProvidedName = "to_kill" });
             SystemUtils.Wait();
             var consumer = await system.CreateConsumer(
-                new ConsumerConfig { Stream = stream, ClientProvidedName = "to_kill" });
+                new ConsumerConfig { Stream = stream, ClientProvidedName = clientProvidedName });
             SystemUtils.Wait();
 
             // Here we have to wait the management stats refresh time before killing the connections.
@@ -238,7 +239,7 @@ namespace Tests
 
             // we kill _only_ producer and consumer connection
             // leave the locator up and running to delete the stream
-            Assert.Equal(2, SystemUtils.HttpKillConnections("to_kill").Result);
+            Assert.Equal(2, SystemUtils.HttpKillConnections(clientProvidedName).Result);
             Assert.Equal(ResponseCode.Ok, await producer.Close());
             Assert.Equal(ResponseCode.Ok, await producer.Close());
             // close two time it should not raise an exception

--- a/Tests/SystemTests.cs
+++ b/Tests/SystemTests.cs
@@ -228,7 +228,7 @@ namespace Tests
             var config = new StreamSystemConfig();
             var system = await StreamSystem.Create(config);
             await system.CreateStream(new StreamSpec(stream));
-            var producer = await system.CreateProducer(new ProducerConfig { Stream = stream, ClientProvidedName = "to_kill" });
+            var producer = await system.CreateProducer(new ProducerConfig { Stream = stream, ClientProvidedName = clientProvidedName });
             SystemUtils.Wait();
             var consumer = await system.CreateConsumer(
                 new ConsumerConfig { Stream = stream, ClientProvidedName = clientProvidedName });


### PR DESCRIPTION
When the consumer is removed from the server for some reason the call Unsubscribe could fail.
This fix avoids to wait too much time in case the server doesn't respond.

Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>