### PR TITLE
Get version via reflection

### DIFF
--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -845,4 +845,4 @@ static RabbitMQ.Stream.Client.StreamCompressionCodecs.RegisterCodec<T>(RabbitMQ.
 static RabbitMQ.Stream.Client.StreamCompressionCodecs.UnRegisterCodec(RabbitMQ.Stream.Client.CompressionType compressionType) -> void
 static RabbitMQ.Stream.Client.StreamSystem.Create(RabbitMQ.Stream.Client.StreamSystemConfig config) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.StreamSystem>
 static RabbitMQ.Stream.Client.SubEntryPublish.Version.get -> byte
-static readonly RabbitMQ.Stream.Client.Version.VersionString -> string
+static RabbitMQ.Stream.Client.Version.VersionString.get -> string

--- a/RabbitMQ.Stream.Client/RabbitMQ.Stream.Client.csproj
+++ b/RabbitMQ.Stream.Client/RabbitMQ.Stream.Client.csproj
@@ -62,30 +62,4 @@
     <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />
   </ItemGroup>
 
-  <Target Name="AfterMinVer" AfterTargets="MinVer">
-    <SetLibraryVersion Version="$(MinVerVersion)" />
-  </Target>
-
-  <UsingTask TaskName="SetLibraryVersion" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <Version ParameterType="System.String" Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System" />
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Text.RegularExpressions" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-          string pattern = "VersionString = \"[^\"]+\";";
-          string replacement = string.Format("VersionString = \"{0}\";", Version);
-          Regex rx = new Regex(pattern);
-          string text = File.ReadAllText("Version.cs");
-          string repl = rx.Replace(text, replacement);
-          File.WriteAllText("Version.cs.tmp", repl, Encoding.UTF8);
-          File.Replace("Version.cs.tmp", "Version.cs", "Version.cs.bak");
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
 </Project>

--- a/RabbitMQ.Stream.Client/Version.cs
+++ b/RabbitMQ.Stream.Client/Version.cs
@@ -2,10 +2,22 @@
 // 2.0, and the Mozilla Public License, version 2.0.
 // Copyright (c) 2007-2020 VMware, Inc.
 
+using System.Diagnostics;
+using System.Reflection;
+
 namespace RabbitMQ.Stream.Client
 {
     public static class Version
     {
-        public static readonly string VersionString = "1.0.0-beta.5.8";
+        private static readonly string _versionString;
+
+        static Version()
+        {
+            var a = Assembly.GetAssembly(typeof(Version));
+            var fvi = FileVersionInfo.GetVersionInfo(a.Location);
+            _versionString = fvi.ProductVersion;
+        }
+
+        public static string VersionString => _versionString;
     }
 }


### PR DESCRIPTION
This removes a build step that would result in a modified file every time.

The version shown is what MinVer sets as the "ProductVersion" assembly attribute. It's also what you see when you right-click on the `.dll`

![Screenshot 2022-05-11 203819](https://user-images.githubusercontent.com/514926/167987414-173f3154-bf4b-4a43-8117-85fdd7938f91.png)