### PR TITLE
Handle infinite looping when encountering a misconfigured load balancer

### DIFF
--- a/Tests/UnitTests.cs
+++ b/Tests/UnitTests.cs
@@ -94,6 +94,26 @@ namespace Tests
 
         public bool ValidateDns { get; set; } = false;
     }
+    
+    public class MisconfiguredLoadBalancerRouting : IRouting
+    {
+
+        public IClient CreateClient(ClientParameters clientParameters)
+        {
+
+            var fake = new FakeClient(clientParameters)
+            {
+                ConnectionProperties = new Dictionary<string, string>()
+                {
+                    ["advertised_host"] = "node4",
+                    ["advertised_port"] = "5552"
+                }
+            };
+            return fake;
+        }
+
+        public bool ValidateDns { get; set; } = false;
+    }
 
     // This class is only for unit tests
     public class UnitTests
@@ -148,6 +168,21 @@ namespace Tests
             var res = (client.Result.ConnectionProperties["advertised_host"] == "leader" ||
                        client.Result.ConnectionProperties["advertised_host"] == "replica");
             Assert.True(res);
+        }
+        
+        [Fact]
+        public void RoutingHelperShouldThrowIfLoadBalancerIsMisconfigured()
+        {
+            var addressResolver = new AddressResolver(new IPEndPoint(IPAddress.Parse("192.168.10.99"), 5552));
+            var clientParameters = new ClientParameters()
+            {
+                AddressResolver = addressResolver,
+            };
+            var metaDataInfo = new StreamInfo("stream", ResponseCode.Ok, new Broker("node2", 5552),
+                new List<Broker>() { new Broker("replica", 5552) });
+            
+            Assert.ThrowsAsync<RoutingClientException>(
+                () => RoutingHelper<MisconfiguredLoadBalancerRouting>.LookupLeaderConnection(clientParameters, metaDataInfo));
         }
 
         [Fact]


### PR DESCRIPTION
Proposal to handle infinite looping when connecting to a load balancer where nodes are misconfigured, causing client to hang indefinitely.

Logic can be replaced by time-based loop, separate exception could be used if necessary (maybe even exposing nodes that were tried for easier diagnostics).