### PR TITLE
Fix a bug with Heartbeat values >59s

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -161,7 +161,7 @@ namespace RabbitMQ.Stream.Client
             _heartBeatHandler = new HeartBeatHandler(
                 SendHeartBeat,
                 Close,
-                parameters.Heartbeat.TotalSeconds);
+                (int) parameters.Heartbeat.TotalSeconds);
             IsClosed = false;
         }
 


### PR DESCRIPTION
Noticed that our heartbeat was 0 when we set it to 60. This fixes that.
Not sure if it's totally okay since timespans can be negative and casting negatives to `uint` will produce big numbers. Anyhow, maybe that's an edge case that shouldn't be covered :D