### PR TITLE
Refactor Confirmation Pipe and HeartBeat start

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -85,7 +85,7 @@ namespace RabbitMQ.Stream.Client
 
     public class Client : IClient
     {
-        private bool isClosed = false;
+        private bool isClosed = true;
 
         private readonly TimeSpan defaultTimeout = TimeSpan.FromSeconds(10);
 
@@ -165,6 +165,11 @@ namespace RabbitMQ.Stream.Client
             IsClosed = false;
         }
 
+        private void StartHeartBeat()
+        {
+            _heartBeatHandler.Start();
+        }
+
         public delegate Task ConnectionCloseHandler(string reason);
 
         public event ConnectionCloseHandler ConnectionClosed;
@@ -228,6 +233,8 @@ namespace RabbitMQ.Stream.Client
             client.ConnectionProperties = open.ConnectionProperties;
 
             client.correlationId = 100;
+            // start heart beat only when the client is connected
+            client.StartHeartBeat();
             return client;
         }
 

--- a/RabbitMQ.Stream.Client/HeartBeatHandler.cs
+++ b/RabbitMQ.Stream.Client/HeartBeatHandler.cs
@@ -30,7 +30,7 @@ public class HeartBeatHandler
         // }
         if (heartbeat > 0)
         {
-            _timer.Enabled = true;
+            _timer.Enabled = false;
             _timer.Interval = heartbeat * 1000;
             _timer.Elapsed += (_, _) =>
             {
@@ -70,6 +70,11 @@ public class HeartBeatHandler
     internal void Close()
     {
         _timer.Close();
+    }
+
+    internal void Start()
+    {
+        _timer.Enabled = true;
     }
 
     internal bool IsActive()

--- a/RabbitMQ.Stream.Client/Reliable/ReliableProducer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableProducer.cs
@@ -61,7 +61,6 @@ public class ReliableProducer : ReliableBase
             reliableProducerConfig.ConfirmationHandler,
             reliableProducerConfig.TimeoutMessageAfter
         );
-        _confirmationPipe.Start();
     }
 
     public static async Task<ReliableProducer> CreateReliableProducer(ReliableProducerConfig reliableProducerConfig)
@@ -114,6 +113,9 @@ public class ReliableProducer : ReliableBase
                 // Init the publishing id
                 Interlocked.Exchange(ref _publishingId,
                     await _producer.GetLastPublishingId());
+
+                // confirmation Pipe can start only if the producer is ready
+                _confirmationPipe.Start();
             }
         }
         catch (Exception e)

--- a/Tests/UnitTests.cs
+++ b/Tests/UnitTests.cs
@@ -322,7 +322,7 @@ namespace Tests
                     return null;
                 },
                 1);
-
+            hBeatHandler.Start();
             var r = testPassed.Task.Wait(6_000);
             Assert.True(r);
             Assert.False(hBeatHandler.IsActive());


### PR DESCRIPTION
Some small improvements. In some cases, some threads could remain pending. 


* Move the confirmation pipe after the Producer initialization to avoid
pending thread in case the producer init fails

* Move the heartbeat start after the login to avoid pending threads
in case the client fails to connect for some reason.

Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>