### PR TITLE
Batch send

### DIFF
--- a/Examples/Performances/BatchVsBatchSend.cs
+++ b/Examples/Performances/BatchVsBatchSend.cs
@@ -1,0 +1,245 @@
+using RabbitMQ.Stream.Client;
+using RabbitMQ.Stream.Client.Reliable;
+
+namespace Performances;
+
+public class BatchVsBatchSend
+{
+    private const int TotalMessages = 20_000_000;
+    private const int MessageSize = 100;
+    private const int AggregateBatchSize = 300;
+    private const int ModPrintMessages = 10_000_000;
+
+    public async Task Start()
+    {
+        Console.WriteLine("Stream Client Performance Test");
+        Console.WriteLine("==============================");
+        Console.WriteLine("Client will test Batch vs Batch Send");
+        Console.WriteLine("Total Messages: {0}", TotalMessages);
+        Console.WriteLine("Message Size: {0}", MessageSize);
+        Console.WriteLine("Aggregate Batch Size: {0}", AggregateBatchSize);
+        Console.WriteLine("Print Messages each: {0} messages", ModPrintMessages);
+
+
+        var config = new StreamSystemConfig() {Heartbeat = TimeSpan.Zero};
+        var system = await StreamSystem.Create(config);
+        await BatchSend(system, await RecreateStream(system, "StandardBatchSend"));
+        await StandardProducerSend(await RecreateStream(system, "StandardProducerSendNoBatch"), system);
+        await RProducerBatchSend(await RecreateStream(system, "ReliableProducerBatch"), system);
+        await RProducerSend(await RecreateStream(system, "ReliableProducerSendNoBatch"), system);
+    }
+
+    private static async Task RProducerSend(string stream, StreamSystem system)
+    {
+        Console.WriteLine("*****Reliable Producer Send No Batch*****");
+        var total = 0;
+        var confirmed = 0;
+        var error = 0;
+        var reliableProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
+        {
+            Stream = stream,
+            StreamSystem = system,
+            MaxInFlight = 1_000_000,
+            ConfirmationHandler = messagesConfirmed =>
+            {
+                if (messagesConfirmed.Status == ConfirmationStatus.Confirmed)
+                {
+                    confirmed += messagesConfirmed.Messages.Count;
+                }
+                else
+                {
+                    error += messagesConfirmed.Messages.Count;
+                }
+
+                if (++total % ModPrintMessages == 0)
+                {
+                    Console.WriteLine(
+                        $"*****Reliable Producer Send No Batch Confirmed: {confirmed} Error: {error}*****");
+                }
+
+                return Task.CompletedTask;
+            }
+        });
+
+        var start = DateTime.Now;
+        for (ulong i = 1; i <= TotalMessages; i++)
+        {
+            var array = new byte[MessageSize];
+            await reliableProducer.Send(new Message(array));
+
+            if (i % ModPrintMessages == 0)
+            {
+                Console.WriteLine($"*****Reliable Producer Send No Batch: {i}");
+            }
+        }
+
+        Console.WriteLine(
+            $"*****Reliable Producer Send No Batch***** send time: {DateTime.Now - start}, messages sent: {TotalMessages}");
+
+        Thread.Sleep(1000);
+        await reliableProducer.Close();
+    }
+
+
+    private static async Task RProducerBatchSend(string stream, StreamSystem system)
+    {
+        Console.WriteLine("*****Reliable Producer Batch Send*****");
+        var total = 0;
+        var confirmed = 0;
+        var error = 0;
+        var reliableProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
+        {
+            Stream = stream,
+            StreamSystem = system,
+            MaxInFlight = 1_000_000,
+            ConfirmationHandler = messagesConfirmed =>
+            {
+                if (messagesConfirmed.Status == ConfirmationStatus.Confirmed)
+                {
+                    confirmed += messagesConfirmed.Messages.Count;
+                }
+                else
+                {
+                    error += messagesConfirmed.Messages.Count;
+                }
+
+                if (++total % ModPrintMessages == 0)
+                {
+                    Console.WriteLine($"*****Reliable Producer Batch Confirmed: {confirmed}, Error: {error}*****");
+                }
+
+                return Task.CompletedTask;
+            }
+        });
+
+        var messages = new List<Message>();
+
+
+        var start = DateTime.Now;
+        for (ulong i = 1; i <= TotalMessages; i++)
+        {
+            var array = new byte[MessageSize];
+            messages.Add(new Message(array));
+            if (i % AggregateBatchSize == 0)
+            {
+                await reliableProducer.BatchSend(messages);
+                messages.Clear();
+            }
+
+            if (i % ModPrintMessages == 0)
+            {
+                Console.WriteLine($"*****Reliable Producer Batch Send: {i}");
+            }
+        }
+
+        await reliableProducer.BatchSend(messages);
+        messages.Clear();
+
+        Console.WriteLine(
+            $"*****Reliable Producer Batch Send***** time: {DateTime.Now - start}, messages sent: {TotalMessages}");
+        Thread.Sleep(1000);
+        await reliableProducer.Close();
+    }
+
+
+    private static async Task StandardProducerSend(string stream, StreamSystem system)
+    {
+        Console.WriteLine("*****Standard Producer Send*****");
+        var confirmed = 0;
+        var producer = await system.CreateProducer(new ProducerConfig()
+        {
+            Stream = stream,
+            MaxInFlight = 1_000_000,
+            ConfirmHandler = _ =>
+            {
+                if (++confirmed % ModPrintMessages == 0)
+                {
+                    Console.WriteLine($"*****Standard Producer Send Confirmed: {confirmed}");
+                }
+            }
+        });
+
+        var start = DateTime.Now;
+        for (ulong i = 1; i <= TotalMessages; i++)
+        {
+            var array = new byte[MessageSize];
+
+            await producer.Send(i, new Message(array));
+
+            if (i % ModPrintMessages == 0)
+            {
+                Console.WriteLine($"*****Standard Producer: {i}");
+            }
+        }
+
+        Console.WriteLine(
+            $"*****Standard Producer Send***** send time: {DateTime.Now - start}, messages sent: {TotalMessages}");
+        Thread.Sleep(1000);
+        await producer.Close();
+    }
+
+    private static async Task BatchSend(StreamSystem system, string stream)
+    {
+        Console.WriteLine("*****Standard Batch Send*****");
+        var confirmed = 0;
+        var producer = await system.CreateProducer(new ProducerConfig()
+        {
+            Stream = stream,
+            MaxInFlight = 1_000_000,
+            ConfirmHandler = _ =>
+            {
+                if (++confirmed % ModPrintMessages == 0)
+                {
+                    Console.WriteLine($"*****Standard Batch Confirmed: {confirmed}");
+                }
+            }
+        });
+        var messages = new List<(ulong, Message)>();
+        var start = DateTime.Now;
+        for (ulong i = 1; i <= TotalMessages; i++)
+        {
+            var array = new byte[MessageSize];
+            messages.Add((i, new Message(array)));
+            if (i % AggregateBatchSize == 0)
+            {
+                await producer.BatchSend(messages);
+                messages.Clear();
+            }
+
+            if (i % ModPrintMessages == 0)
+            {
+                Console.WriteLine($"*****Standard Batch Send: {i}");
+            }
+        }
+
+        await producer.BatchSend(messages);
+        messages.Clear();
+
+        Console.WriteLine(
+            $"*****Standard Batch Send***** send time: {DateTime.Now - start}, messages sent: {TotalMessages}");
+        Thread.Sleep(1000);
+        await producer.Close();
+    }
+
+    private static async Task<string> RecreateStream(StreamSystem system, string stream)
+    {
+        Console.WriteLine("==============================");
+        Console.WriteLine($"Recreate Stream: {stream}, just wait a bit..");
+        Thread.Sleep(5000);
+        try
+        {
+            await system.DeleteStream(stream);
+        }
+        catch (Exception e)
+        {
+            // Console.WriteLine(e);
+        }
+
+        Thread.Sleep(5000);
+
+        await system.CreateStream(new StreamSpec(stream) { });
+        Thread.Sleep(1000);
+        Console.WriteLine($"Stream: {stream} created");
+        return stream;
+    }
+}

--- a/Examples/Performances/Performances.csproj
+++ b/Examples/Performances/Performances.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\RabbitMQ.Stream.Client\RabbitMQ.Stream.Client.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Examples/Performances/Program.cs
+++ b/Examples/Performances/Program.cs
@@ -1,0 +1,3 @@
+﻿using Performances;
+
+new BatchVsBatchSend().Start().Wait();

--- a/README.md
+++ b/README.md
@@ -251,6 +251,21 @@ or more generic `system.QuerySequence("reference", "my_stream")`.
 
 `publishingId` must be incremented for each send.
 
+#### Standard Batch publish
+
+Batch send is a synchronous operation.
+It allows to pre-aggregate messages and send them in a single synchronous call.
+```csharp
+var messages = new List<(ulong, Message)>();
+for (ulong i = 0; i < 30; i++)
+{
+    messages.Add((i, new Message(Encoding.UTF8.GetBytes($"batch {i}"))));
+}
+await producer.BatchSend(messages);
+messages.Clear();
+```
+In most cases, the standard `Send` is easier and works in most of the cases.
+
 #### Sub Entries Batching
 A sub-entry is one "slot" in a publishing frame, meaning outbound messages are not only batched in publishing frames,
 but in sub-entries as well. Use this feature to increase throughput at the cost of increased latency.

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -116,6 +116,7 @@ namespace RabbitMQ.Stream.Client
         public int PublishCommandsSent => publishCommandsSent;
 
         public int MessagesSent => messagesSent;
+        public uint MaxFrameSize => tuneReceived.Task.Result.FrameMax;
 
         private int messagesSent;
         private int confirmFrames;
@@ -215,7 +216,7 @@ namespace RabbitMQ.Stream.Client
             ClientExceptions.MaybeThrowException(authResponse.ResponseCode, parameters.UserName);
 
             //tune
-            var tune = await client.tuneReceived.Task;
+            await client.tuneReceived.Task;
             await client.Publish(new TuneRequest(0,
                 (uint)client.Parameters.Heartbeat.TotalSeconds));
 
@@ -586,7 +587,7 @@ namespace RabbitMQ.Stream.Client
             }
             else
             {
-                return new ManualResetValueTaskSource<T>() { RunContinuationsAsynchronously = true };
+                return new ManualResetValueTaskSource<T>() {RunContinuationsAsynchronously = true};
             }
         }
 

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -587,7 +587,7 @@ namespace RabbitMQ.Stream.Client
             }
             else
             {
-                return new ManualResetValueTaskSource<T>() {RunContinuationsAsynchronously = true};
+                return new ManualResetValueTaskSource<T>() { RunContinuationsAsynchronously = true };
             }
         }
 

--- a/RabbitMQ.Stream.Client/Producer.cs
+++ b/RabbitMQ.Stream.Client/Producer.cs
@@ -93,7 +93,7 @@ namespace RabbitMQ.Stream.Client
                 {
                     foreach (var id in publishingIds.Span)
                     {
-                        config.ConfirmHandler(new Confirmation {PublishingId = id, Code = ResponseCode.Ok,});
+                        config.ConfirmHandler(new Confirmation { PublishingId = id, Code = ResponseCode.Ok, });
                     }
 
                     semaphore.Release(publishingIds.Length);
@@ -102,7 +102,7 @@ namespace RabbitMQ.Stream.Client
                 {
                     foreach (var (id, code) in errors)
                     {
-                        config.ConfirmHandler(new Confirmation {PublishingId = id, Code = code,});
+                        config.ConfirmHandler(new Confirmation { PublishingId = id, Code = code, });
                     }
 
                     semaphore.Release(errors.Length);
@@ -163,7 +163,7 @@ namespace RabbitMQ.Stream.Client
 
             if (messages.Count != 0 && !client.IsClosed)
             {
-                await SendMessages(messages).ConfigureAwait(false);
+                await SendMessages(messages, false).ConfigureAwait(false);
             }
         }
 
@@ -179,12 +179,17 @@ namespace RabbitMQ.Stream.Client
             }
         }
 
-        private async Task SendMessages(List<(ulong, Message)> messages)
+        private async Task SendMessages(List<(ulong, Message)> messages, bool clearMessagesList = true)
         {
             var publishTask = client.Publish(new Publish(publisherId, messages));
             if (!publishTask.IsCompletedSuccessfully)
             {
                 await publishTask.ConfigureAwait(false);
+            }
+
+            if (clearMessagesList)
+            {
+                messages.Clear();
             }
         }
 
@@ -232,8 +237,6 @@ namespace RabbitMQ.Stream.Client
                 {
                     await SendMessages(messages).ConfigureAwait(false);
                 }
-
-                messages.Clear();
             }
         }
 

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -193,6 +193,7 @@ RabbitMQ.Stream.Client.Client.DeletePublisher(byte publisherId) -> System.Thread
 RabbitMQ.Stream.Client.Client.DeleteStream(string stream) -> System.Threading.Tasks.ValueTask<RabbitMQ.Stream.Client.DeleteResponse>
 RabbitMQ.Stream.Client.Client.IncomingFrames.get -> int
 RabbitMQ.Stream.Client.Client.IsClosed.get -> bool
+RabbitMQ.Stream.Client.Client.MaxFrameSize.get -> uint
 RabbitMQ.Stream.Client.Client.MessagesSent.get -> int
 RabbitMQ.Stream.Client.Client.Parameters.get -> RabbitMQ.Stream.Client.ClientParameters
 RabbitMQ.Stream.Client.Client.Parameters.set -> void
@@ -531,6 +532,7 @@ RabbitMQ.Stream.Client.PeerPropertiesResponse.SizeNeeded.get -> int
 RabbitMQ.Stream.Client.PeerPropertiesResponse.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.PooledTaskSource<T>
 RabbitMQ.Stream.Client.Producer
+RabbitMQ.Stream.Client.Producer.BatchSend(System.Collections.Generic.List<(ulong, RabbitMQ.Stream.Client.Message)> messages) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Stream.Client.Producer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.Producer.ConfirmFrames.get -> int
 RabbitMQ.Stream.Client.Producer.Dispose() -> void

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -613,7 +613,7 @@ RabbitMQ.Stream.Client.QueryPublisherResponse.Write(System.Span<byte> span) -> i
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.AddUnConfirmedMessage(ulong publishingId, RabbitMQ.Stream.Client.Message message) -> void
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.AddUnConfirmedMessage(ulong publishingId, System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages) -> void
-RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.ConfirmationPipe(System.Func<RabbitMQ.Stream.Client.Reliable.MessagesConfirmation, System.Threading.Tasks.Task> confirmHandler, System.TimeSpan messageTimeout) -> void
+RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.ConfirmationPipe(System.Func<RabbitMQ.Stream.Client.Reliable.MessagesConfirmation, System.Threading.Tasks.Task> confirmHandler, System.TimeSpan messageTimeout, int maxInFlightMessages) -> void
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.RemoveUnConfirmedMessage(ulong publishingId, RabbitMQ.Stream.Client.Reliable.ConfirmationStatus confirmationStatus) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.Start() -> void
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.Stop() -> void

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -661,6 +661,7 @@ RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.Stream.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.StreamSystem.get -> RabbitMQ.Stream.Client.StreamSystem
 RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.StreamSystem.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableProducer
+RabbitMQ.Stream.Client.Reliable.ReliableProducer.BatchSend(System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Stream.Client.Reliable.ReliableProducer.Send(RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Stream.Client.Reliable.ReliableProducer.Send(System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages, RabbitMQ.Stream.Client.CompressionType compressionType) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig
@@ -668,6 +669,8 @@ RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ClientProvidedName.get ->
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ClientProvidedName.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ConfirmationHandler.get -> System.Func<RabbitMQ.Stream.Client.Reliable.MessagesConfirmation, System.Threading.Tasks.Task>
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ConfirmationHandler.init -> void
+RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.MaxInFlight.get -> int
+RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.MaxInFlight.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ReconnectStrategy.get -> RabbitMQ.Stream.Client.Reliable.IReconnectStrategy
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ReconnectStrategy.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.Reference.get -> string

--- a/RabbitMQ.Stream.Client/Reliable/ReliableProducer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableProducer.cs
@@ -61,8 +61,8 @@ public class ReliableProducer : ReliableBase
         _reliableProducerConfig = reliableProducerConfig;
         _confirmationPipe = new ConfirmationPipe(
             reliableProducerConfig.ConfirmationHandler,
-            reliableProducerConfig.TimeoutMessageAfter
-        );
+            reliableProducerConfig.TimeoutMessageAfter,
+            reliableProducerConfig.MaxInFlight);
     }
 
     public static async Task<ReliableProducer> CreateReliableProducer(ReliableProducerConfig reliableProducerConfig)
@@ -227,9 +227,9 @@ public class ReliableProducer : ReliableBase
         }
 
         _producer.PreValidateBatch(messagesToSend);
-        foreach (var valueTuple in messagesToSend)
+        foreach (var msg in messagesToSend)
         {
-            _confirmationPipe.AddUnConfirmedMessage(valueTuple.Item1, valueTuple.Item2);
+            _confirmationPipe.AddUnConfirmedMessage(msg.Item1, msg.Item2);
         }
 
         await SemaphoreSlim.WaitAsync();

--- a/RabbitMQ.Stream.Client/Reliable/ReliableProducer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableProducer.cs
@@ -21,6 +21,8 @@ public record ReliableProducerConfig
     public string ClientProvidedName { get; set; } = "dotnet-stream-rproducer";
     public IReconnectStrategy ReconnectStrategy { get; set; } = new BackOffReconnectStrategy();
 
+    public int MaxInFlight { get; set; } = 1000;
+
     public TimeSpan TimeoutMessageAfter
     {
         get => _timeoutMessageAfter;
@@ -81,6 +83,7 @@ public class ReliableProducer : ReliableBase
                 Stream = _reliableProducerConfig.Stream,
                 ClientProvidedName = _reliableProducerConfig.ClientProvidedName,
                 Reference = _reliableProducerConfig.Reference,
+                MaxInFlight = _reliableProducerConfig.MaxInFlight,
                 MetadataHandler = update =>
                 {
                     HandleMetaDataMaybeReconnect(update.Stream,
@@ -207,6 +210,45 @@ public class ReliableProducer : ReliableBase
         catch (Exception e)
         {
             LogEventSource.Log.LogError("Error sending messages: ", e);
+        }
+        finally
+        {
+            SemaphoreSlim.Release();
+        }
+    }
+
+    public async ValueTask BatchSend(List<Message> messages)
+    {
+        var messagesToSend = new List<(ulong, Message)>();
+        foreach (var message in messages)
+        {
+            Interlocked.Increment(ref _publishingId);
+            messagesToSend.Add((_publishingId, message));
+        }
+
+        _producer.PreValidateBatch(messagesToSend);
+        foreach (var valueTuple in messagesToSend)
+        {
+            _confirmationPipe.AddUnConfirmedMessage(valueTuple.Item1, valueTuple.Item2);
+        }
+
+        await SemaphoreSlim.WaitAsync();
+        try
+        {
+            // This flags avoid some race condition,
+            // since the reconnection can arrive from different threads. 
+            // In this case it skips the publish until
+            // the producer is connected. Messages are safe since are stored 
+            // on the _waitForConfirmation list. The user will get Timeout Error
+            if (!(_inReconnection))
+            {
+                await _producer.InternalBatchSend(messagesToSend);
+            }
+        }
+
+        catch (Exception e)
+        {
+            LogEventSource.Log.LogError("BatchSend error sending message: ", e);
         }
         finally
         {

--- a/Tests/ReliableTests.cs
+++ b/Tests/ReliableTests.cs
@@ -46,7 +46,7 @@ public class ReliableTests
 
                 return Task.CompletedTask;
             },
-            TimeSpan.FromSeconds(2)
+            TimeSpan.FromSeconds(2), 100
         );
         confirmationPipe.Start();
         var message = new Message(Encoding.UTF8.GetBytes($"hello"));
@@ -75,7 +75,7 @@ public class ReliableTests
 
                 return Task.CompletedTask;
             },
-            TimeSpan.FromSeconds(2)
+            TimeSpan.FromSeconds(2), 100
         );
         confirmationPipe.Start();
         var message = new Message(Encoding.UTF8.GetBytes($"hello"));

--- a/Tests/ReliableTests.cs
+++ b/Tests/ReliableTests.cs
@@ -102,7 +102,11 @@ public class ReliableTests
                 StreamSystem = system,
                 ConfirmationHandler = _ =>
                 {
-                    if (Interlocked.Increment(ref count) == 10)
+                    if (Interlocked.Increment(ref count) ==
+                        5 +  // first five messages iteration
+                        5 + // second five messages iteration with compression enabled
+                        2 // batch send iteration since the messages list contains two messages
+                        )
                     {
                         testPassed.SetResult(true);
                     }
@@ -116,12 +120,19 @@ public class ReliableTests
             await rProducer.Send(new Message(Encoding.UTF8.GetBytes($"hello {i}")));
         }
 
-        List<Message> messages = new() { new Message(Encoding.UTF8.GetBytes($"hello list")) };
+        List<Message> messages = new()
+        {
+            new Message(Encoding.UTF8.GetBytes($"hello Message1")),
+            new Message(Encoding.UTF8.GetBytes($"hello Message2"))
+        };
 
         for (var i = 0; i < 5; i++)
         {
             await rProducer.Send(messages, CompressionType.None);
         }
+
+        // batch send, it will produce (messages,count) confirmation
+        await rProducer.BatchSend(messages);
 
         new Utils<bool>(_testOutputHelper).WaitUntilTaskCompletes(testPassed);
         await rProducer.Close();


### PR DESCRIPTION
Closes #136

Using this gist: https://gist.github.com/Gsantomaggio/cd5b0734225d3fab9ed013d634eaf005 to test the performances 

cc @ricsiLT 


Test results `Producer` and `Reliable Producer` with and without `Batch Send` :
```
*****Standard Producer Batch Send***** send time: 00:00:24.3330340, messages sent: 20000000

*****Standard Producer Send***** send time: 00:00:24.6326600, messages sent: 20000000

*****Reliable Producer Batch Send***** time: 00:00:27.2689740, messages sent: 20000000

*****Reliable Producer Send No Batch***** send time: 00:00:31.4620940, messages sent: 20000000
```

These values are excepted the good news is `Reliable Producer Batch Send` time is not so far from standard producer with `batch send`
 
