### PR TITLE
Add logging abstraction to use instead of ETW traces

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
+using Microsoft.Extensions.Logging;
 
 namespace RabbitMQ.Stream.Client
 {
@@ -141,6 +142,8 @@ namespace RabbitMQ.Stream.Client
             return result;
         }
 
+        private readonly ILogger _logger;
+
         public bool IsClosed
         {
             get
@@ -156,13 +159,15 @@ namespace RabbitMQ.Stream.Client
             private set => isClosed = value;
         }
 
-        private Client(ClientParameters parameters)
+        private Client(ClientParameters parameters, ILogger logger = null)
         {
             Parameters = parameters;
+            _logger = logger;
             _heartBeatHandler = new HeartBeatHandler(
                 SendHeartBeat,
                 Close,
-                (int)parameters.Heartbeat.TotalSeconds);
+                (int)parameters.Heartbeat.TotalSeconds
+            );
             IsClosed = false;
         }
 
@@ -183,9 +188,9 @@ namespace RabbitMQ.Stream.Client
             }
         }
 
-        public static async Task<Client> Create(ClientParameters parameters)
+        public static async Task<Client> Create(ClientParameters parameters, ILogger logger = null)
         {
-            var client = new Client(parameters);
+            var client = new Client(parameters, logger);
 
             client.connection = await Connection.Create(parameters.Endpoint,
                 client.HandleIncoming, client.HandleClosed, parameters.Ssl);
@@ -516,7 +521,7 @@ namespace RabbitMQ.Stream.Client
             }
             catch (Exception e)
             {
-                LogEventSource.Log.LogError($"An error occurred while calling {nameof(connection.Dispose)}.", e);
+                _logger?.LogError(e, "An error occurred while calling {FunctionName}", nameof(connection.Dispose));
             }
 
             return result;

--- a/RabbitMQ.Stream.Client/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Consumer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace RabbitMQ.Stream.Client
 {
@@ -38,11 +39,13 @@ namespace RabbitMQ.Stream.Client
         private bool _disposed;
         private readonly ConsumerConfig config;
         private byte subscriberId;
+        private readonly ILogger _logger;
 
-        private Consumer(Client client, ConsumerConfig config)
+        private Consumer(Client client, ConsumerConfig config, ILogger logger = null)
         {
             this.client = client;
             this.config = config;
+            _logger = logger;
         }
 
         // if a user specify a custom offset 
@@ -140,7 +143,7 @@ namespace RabbitMQ.Stream.Client
             }
             catch (Exception e)
             {
-                LogEventSource.Log.LogError($"Error removing the consumer id: {subscriberId} from the server. {e}");
+                _logger?.LogError(e, "Error removing the consumer id: {SubscriberId} from the server", subscriberId);
             }
 
             var closed = client.MaybeClose($"client-close-subscriber: {subscriberId}");
@@ -176,7 +179,7 @@ namespace RabbitMQ.Stream.Client
             }
             catch (Exception e)
             {
-                LogEventSource.Log.LogError($"Error during disposing Consumer: {subscriberId}.", e);
+                _logger?.LogError(e, "Error during disposing Consumer: {SubscriberId}", subscriberId);
             }
 
             GC.SuppressFinalize(this);

--- a/RabbitMQ.Stream.Client/Message.cs
+++ b/RabbitMQ.Stream.Client/Message.cs
@@ -126,7 +126,6 @@ namespace RabbitMQ.Stream.Client
                         offset += AmqpWireFormatting.ReadAny(amqpData.Slice(offset), out amqpValue);
                         break;
                     default:
-                        LogEventSource.Log.LogError($"dataCode: {dataCode} not handled. Please open an issue.");
                         throw new ArgumentOutOfRangeException($"dataCode: {dataCode} not handled");
                 }
             }

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -360,7 +360,7 @@ RabbitMQ.Stream.Client.GzipCompressionCodec.UnCompress(System.Buffers.ReadOnlySe
 RabbitMQ.Stream.Client.GzipCompressionCodec.UnCompressedSize.get -> int
 RabbitMQ.Stream.Client.GzipCompressionCodec.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.HeartBeatHandler
-RabbitMQ.Stream.Client.HeartBeatHandler.HeartBeatHandler(System.Func<System.Threading.Tasks.ValueTask<bool>> sendHeartbeatFunc, System.Func<string, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.CloseResponse>> close, int heartbeat) -> void
+RabbitMQ.Stream.Client.HeartBeatHandler.HeartBeatHandler(System.Func<System.Threading.Tasks.ValueTask<bool>> sendHeartbeatFunc, System.Func<string, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.CloseResponse>> close, int heartbeat, Microsoft.Extensions.Logging.ILogger logger = null) -> void
 RabbitMQ.Stream.Client.HeartBeatRequest
 RabbitMQ.Stream.Client.HeartBeatRequest.HeartBeatRequest() -> void
 RabbitMQ.Stream.Client.HeartBeatRequest.SizeNeeded.get -> int
@@ -391,7 +391,7 @@ RabbitMQ.Stream.Client.IOffsetType.OffsetType.get -> RabbitMQ.Stream.Client.Offs
 RabbitMQ.Stream.Client.IOffsetType.Size.get -> int
 RabbitMQ.Stream.Client.IOffsetType.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.IRouting
-RabbitMQ.Stream.Client.IRouting.CreateClient(RabbitMQ.Stream.Client.ClientParameters clientParameters) -> RabbitMQ.Stream.Client.IClient
+RabbitMQ.Stream.Client.IRouting.CreateClient(RabbitMQ.Stream.Client.ClientParameters clientParameters, Microsoft.Extensions.Logging.ILogger logger = null) -> RabbitMQ.Stream.Client.IClient
 RabbitMQ.Stream.Client.IRouting.ValidateDns.get -> bool
 RabbitMQ.Stream.Client.IRouting.ValidateDns.set -> void
 RabbitMQ.Stream.Client.Keywords
@@ -640,7 +640,7 @@ RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.Status.get -> RabbitMQ.Stre
 RabbitMQ.Stream.Client.Reliable.ReliableBase
 RabbitMQ.Stream.Client.Reliable.ReliableBase.Init() -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.Reliable.ReliableBase.IsOpen() -> bool
-RabbitMQ.Stream.Client.Reliable.ReliableBase.ReliableBase() -> void
+RabbitMQ.Stream.Client.Reliable.ReliableBase.ReliableBase(Microsoft.Extensions.Logging.ILogger logger = null) -> void
 RabbitMQ.Stream.Client.Reliable.ReliableBase.TryToReconnect(RabbitMQ.Stream.Client.Reliable.IReconnectStrategy reconnectStrategy) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.Reliable.ReliableBase._inReconnection -> bool
 RabbitMQ.Stream.Client.Reliable.ReliableBase._needReconnect -> bool
@@ -702,7 +702,7 @@ RabbitMQ.Stream.Client.ResponseCode.SubscriptionIdDoesNotExist = 4 -> RabbitMQ.S
 RabbitMQ.Stream.Client.ResponseCode.UnknownFrame = 13 -> RabbitMQ.Stream.Client.ResponseCode
 RabbitMQ.Stream.Client.ResponseCode.VirtualHostAccessFailure = 12 -> RabbitMQ.Stream.Client.ResponseCode
 RabbitMQ.Stream.Client.Routing
-RabbitMQ.Stream.Client.Routing.CreateClient(RabbitMQ.Stream.Client.ClientParameters clientParameters) -> RabbitMQ.Stream.Client.IClient
+RabbitMQ.Stream.Client.Routing.CreateClient(RabbitMQ.Stream.Client.ClientParameters clientParameters, Microsoft.Extensions.Logging.ILogger logger = null) -> RabbitMQ.Stream.Client.IClient
 RabbitMQ.Stream.Client.Routing.Routing() -> void
 RabbitMQ.Stream.Client.Routing.ValidateDns.get -> bool
 RabbitMQ.Stream.Client.Routing.ValidateDns.set -> void
@@ -785,7 +785,7 @@ RabbitMQ.Stream.Client.StreamSpec.StreamSpec(string Name) -> void
 RabbitMQ.Stream.Client.StreamSystem
 RabbitMQ.Stream.Client.StreamSystem.Close() -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.StreamSystem.CreateConsumer(RabbitMQ.Stream.Client.ConsumerConfig consumerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Consumer>
-RabbitMQ.Stream.Client.StreamSystem.CreateProducer(RabbitMQ.Stream.Client.ProducerConfig producerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Producer>
+RabbitMQ.Stream.Client.StreamSystem.CreateProducer(RabbitMQ.Stream.Client.ProducerConfig producerConfig, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Producer>
 RabbitMQ.Stream.Client.StreamSystem.CreateStream(RabbitMQ.Stream.Client.StreamSpec spec) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.StreamSystem.DeleteStream(string stream) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.StreamSystem.IsClosed.get -> bool
@@ -855,6 +855,7 @@ RabbitMQ.Stream.Client.UnsubscribeResponse.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.Version
 RabbitMQ.Stream.Client.VirtualHostAccessFailureException
 RabbitMQ.Stream.Client.VirtualHostAccessFailureException.VirtualHostAccessFailureException(string s) -> void
+readonly RabbitMQ.Stream.Client.Reliable.ReliableBase.Logger -> Microsoft.Extensions.Logging.ILogger
 readonly RabbitMQ.Stream.Client.Reliable.ReliableBase.SemaphoreSlim -> System.Threading.SemaphoreSlim
 static RabbitMQ.Stream.Client.AMQP.AmqpWireFormatting.GetAnySize(object value) -> int
 static RabbitMQ.Stream.Client.AMQP.AmqpWireFormatting.GetSequenceSize(System.Buffers.ReadOnlySequence<byte> data) -> int
@@ -865,7 +866,7 @@ static RabbitMQ.Stream.Client.AMQP.DescribedFormatCode.Write(System.Span<byte> s
 static RabbitMQ.Stream.Client.AMQP.Header.Parse(System.Buffers.ReadOnlySequence<byte> amqpData, ref int byteRead) -> RabbitMQ.Stream.Client.AMQP.Header
 static RabbitMQ.Stream.Client.AMQP.Map<TKey>.Parse<T>(System.Buffers.ReadOnlySequence<byte> amqpData, ref int byteRead) -> T
 static RabbitMQ.Stream.Client.AMQP.Properties.Parse(System.Buffers.ReadOnlySequence<byte> amqpData, ref int byteRead) -> RabbitMQ.Stream.Client.AMQP.Properties
-static RabbitMQ.Stream.Client.Client.Create(RabbitMQ.Stream.Client.ClientParameters parameters) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Client>
+static RabbitMQ.Stream.Client.Client.Create(RabbitMQ.Stream.Client.ClientParameters parameters, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Client>
 static RabbitMQ.Stream.Client.CompressionHelper.Compress(System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages, RabbitMQ.Stream.Client.CompressionType compressionType) -> RabbitMQ.Stream.Client.ICompressionCodec
 static RabbitMQ.Stream.Client.CompressionHelper.UnCompress(RabbitMQ.Stream.Client.CompressionType compressionType, System.Buffers.ReadOnlySequence<byte> source, uint dataLen, uint unCompressedDataSize) -> System.Buffers.ReadOnlySequence<byte>
 static RabbitMQ.Stream.Client.Connection.Create(System.Net.EndPoint endpoint, System.Func<System.Memory<byte>, System.Threading.Tasks.Task> commandCallback, System.Func<string, System.Threading.Tasks.Task> closedCallBack, RabbitMQ.Stream.Client.SslOption sslOption) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Connection>
@@ -876,10 +877,10 @@ static RabbitMQ.Stream.Client.LeaderLocator.Random.get -> RabbitMQ.Stream.Client
 static RabbitMQ.Stream.Client.Message.From(System.Buffers.ReadOnlySequence<byte> amqpData) -> RabbitMQ.Stream.Client.Message
 static RabbitMQ.Stream.Client.PooledTaskSource<T>.Rent() -> RabbitMQ.Stream.Client.ManualResetValueTaskSource<T>
 static RabbitMQ.Stream.Client.PooledTaskSource<T>.Return(RabbitMQ.Stream.Client.ManualResetValueTaskSource<T> task) -> void
-static RabbitMQ.Stream.Client.Producer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.ProducerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Producer>
+static RabbitMQ.Stream.Client.Producer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.ProducerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Producer>
 static RabbitMQ.Stream.Client.Publish.Version.get -> byte
-static RabbitMQ.Stream.Client.Reliable.ReliableConsumer.CreateReliableConsumer(RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig reliableConsumerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.ReliableConsumer>
-static RabbitMQ.Stream.Client.Reliable.ReliableProducer.CreateReliableProducer(RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig reliableProducerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.ReliableProducer>
+static RabbitMQ.Stream.Client.Reliable.ReliableConsumer.CreateReliableConsumer(RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig reliableConsumerConfig, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.ReliableConsumer>
+static RabbitMQ.Stream.Client.Reliable.ReliableProducer.CreateReliableProducer(RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig reliableProducerConfig, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.ReliableProducer>
 static RabbitMQ.Stream.Client.RoutingHelper<T>.LookupLeaderConnection(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.StreamInfo metaDataInfo) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IClient>
 static RabbitMQ.Stream.Client.RoutingHelper<T>.LookupRandomConnection(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.StreamInfo metaDataInfo) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IClient>
 static RabbitMQ.Stream.Client.StreamCompressionCodecs.GetCompressionCodec(RabbitMQ.Stream.Client.CompressionType compressionType) -> RabbitMQ.Stream.Client.ICompressionCodec

--- a/RabbitMQ.Stream.Client/RabbitMQ.Stream.Client.csproj
+++ b/RabbitMQ.Stream.Client/RabbitMQ.Stream.Client.csproj
@@ -51,6 +51,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/RabbitMQ.Stream.Client/Reliable/ReliableConsumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableConsumer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace RabbitMQ.Stream.Client.Reliable;
 
@@ -34,17 +35,17 @@ public class ReliableConsumer : ReliableBase
 {
     private Consumer _consumer;
     private readonly ReliableConsumerConfig _reliableConsumerConfig;
-    private ulong _lastConsumerOffset = 0;
-    private bool _consumedFirstTime = false;
+    private ulong _lastConsumerOffset;
+    private bool _consumedFirstTime;
 
-    private ReliableConsumer(ReliableConsumerConfig reliableConsumerConfig)
+    private ReliableConsumer(ReliableConsumerConfig reliableConsumerConfig, ILogger logger): base(logger)
     {
         _reliableConsumerConfig = reliableConsumerConfig;
     }
 
-    public static async Task<ReliableConsumer> CreateReliableConsumer(ReliableConsumerConfig reliableConsumerConfig)
+    public static async Task<ReliableConsumer> CreateReliableConsumer(ReliableConsumerConfig reliableConsumerConfig, ILogger logger = null)
     {
-        var rConsumer = new ReliableConsumer(reliableConsumerConfig);
+        var rConsumer = new ReliableConsumer(reliableConsumerConfig, logger);
         await rConsumer.Init();
         return rConsumer;
     }
@@ -93,7 +94,7 @@ public class ReliableConsumer : ReliableBase
 
         catch (Exception e)
         {
-            LogEventSource.Log.LogError("Error during consumer initialization: ", e);
+            Logger?.LogError(e, "Error during consumer initialization");
             throw;
         }
         finally

--- a/RabbitMQ.Stream.Client/Reliable/ReliableProducer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableProducer.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace RabbitMQ.Stream.Client.Reliable;
 
@@ -56,7 +57,7 @@ public class ReliableProducer : ReliableBase
     private readonly ReliableProducerConfig _reliableProducerConfig;
     private readonly ConfirmationPipe _confirmationPipe;
 
-    private ReliableProducer(ReliableProducerConfig reliableProducerConfig)
+    private ReliableProducer(ReliableProducerConfig reliableProducerConfig, ILogger logger = null) : base(logger)
     {
         _reliableProducerConfig = reliableProducerConfig;
         _confirmationPipe = new ConfirmationPipe(
@@ -65,9 +66,9 @@ public class ReliableProducer : ReliableBase
             reliableProducerConfig.MaxInFlight);
     }
 
-    public static async Task<ReliableProducer> CreateReliableProducer(ReliableProducerConfig reliableProducerConfig)
+    public static async Task<ReliableProducer> CreateReliableProducer(ReliableProducerConfig reliableProducerConfig, ILogger logger = null)
     {
-        var rProducer = new ReliableProducer(reliableProducerConfig);
+        var rProducer = new ReliableProducer(reliableProducerConfig, logger);
         await rProducer.Init();
         return rProducer;
     }
@@ -123,7 +124,7 @@ public class ReliableProducer : ReliableBase
         }
         catch (Exception e)
         {
-            LogEventSource.Log.LogError("Error during producer initialization: ", e);
+            Logger?.LogError(e, "Error during producer initialization");
             throw;
         }
         finally
@@ -186,7 +187,7 @@ public class ReliableProducer : ReliableBase
 
         catch (Exception e)
         {
-            LogEventSource.Log.LogError("Error sending message: ", e);
+            Logger?.LogError(e, "Error sending message");
         }
         finally
         {
@@ -209,7 +210,7 @@ public class ReliableProducer : ReliableBase
 
         catch (Exception e)
         {
-            LogEventSource.Log.LogError("Error sending messages: ", e);
+            Logger?.LogError(e, "Error sending messages");
         }
         finally
         {
@@ -248,7 +249,7 @@ public class ReliableProducer : ReliableBase
 
         catch (Exception e)
         {
-            LogEventSource.Log.LogError("BatchSend error sending message: ", e);
+            Logger?.LogError(e, "BatchSend error sending message");
         }
         finally
         {

--- a/RabbitMQ.Stream.Client/RoutingClient.cs
+++ b/RabbitMQ.Stream.Client/RoutingClient.cs
@@ -8,12 +8,13 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace RabbitMQ.Stream.Client
 {
     public interface IRouting
     {
-        IClient CreateClient(ClientParameters clientParameters);
+        IClient CreateClient(ClientParameters clientParameters, ILogger logger = null);
         bool ValidateDns { get; set; }
     }
 
@@ -21,9 +22,9 @@ namespace RabbitMQ.Stream.Client
     {
         public bool ValidateDns { get; set; } = true;
 
-        public IClient CreateClient(ClientParameters clientParameters)
+        public IClient CreateClient(ClientParameters clientParameters, ILogger logger = null)
         {
-            var taskClient = Client.Create(clientParameters);
+            var taskClient = Client.Create(clientParameters, logger);
             taskClient.Wait(TimeSpan.FromSeconds(1));
             return taskClient.Result;
         }

--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace RabbitMQ.Stream.Client
 {
@@ -106,7 +107,7 @@ namespace RabbitMQ.Stream.Client
             }
         }
 
-        public async Task<Producer> CreateProducer(ProducerConfig producerConfig)
+        public async Task<Producer> CreateProducer(ProducerConfig producerConfig, ILogger logger = null)
         {
             // Validate the ProducerConfig values
             if (producerConfig.Stream == "")
@@ -134,7 +135,10 @@ namespace RabbitMQ.Stream.Client
 
                 return await Producer.Create(
                     clientParameters with { ClientProvidedName = producerConfig.ClientProvidedName },
-                    producerConfig, metaStreamInfo);
+                    producerConfig,
+                    metaStreamInfo,
+                    logger
+                );
             }
             finally
             {

--- a/Tests/UnitTests.cs
+++ b/Tests/UnitTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using RabbitMQ.Stream.Client;
 using Xunit;
 
@@ -35,7 +36,7 @@ namespace Tests
 
         // Simulate a load-balancer access using random 
         // access to the advertisedHosts list
-        public IClient CreateClient(ClientParameters clientParameters)
+        public IClient CreateClient(ClientParameters clientParameters, ILogger logger = null)
         {
             var rnd = new Random();
             var advId = rnd.Next(0, advertisedHosts.Count);
@@ -56,7 +57,7 @@ namespace Tests
 
     public class MisconfiguredLoadBalancerRouting : IRouting
     {
-        public IClient CreateClient(ClientParameters clientParameters)
+        public IClient CreateClient(ClientParameters clientParameters, ILogger logger = null)
         {
             var fake = new FakeClient(clientParameters)
             {
@@ -75,7 +76,7 @@ namespace Tests
     //advertised_host is is missed
     public class MissingFieldsRouting : IRouting
     {
-        public IClient CreateClient(ClientParameters clientParameters)
+        public IClient CreateClient(ClientParameters clientParameters, ILogger logger = null)
         {
             var fake = new FakeClient(clientParameters)
             {
@@ -89,7 +90,7 @@ namespace Tests
 
     public class ReplicaRouting : IRouting
     {
-        public IClient CreateClient(ClientParameters clientParameters)
+        public IClient CreateClient(ClientParameters clientParameters, ILogger logger = null)
         {
             var fake = new FakeClient(clientParameters)
             {


### PR DESCRIPTION
Add an extra dependency to Microsoft Logging Abstractions so a logger can be passed into RMQ client.
I'd argue that using LogEventSource looks out of place in more modern dotnet applications when it comes to logging - mostly because it's aimed at file-based logging as opposed to structured logging.

By having ILogger attached like this you could still log into ETW by providing Logger that calls LogEventSource inside. The opposite is also true - you could create your own event listener that logs into a logger, but event is already flattened, so you can't extract additional info that could be present in an exception or scope (unless event source did that for you). Having it the other way around is more flexible.