### PR TITLE
Fix Reconnect ReliableProducer/ ReliableConsumer in case leader is down

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -19,6 +19,12 @@ namespace RabbitMQ.Stream.Client
 {
     public record ClientParameters
     {
+        // internal list of endpoints where the client will try to connect
+        // the property Endpoint will use one of the endpoints in the list
+        // we keep it separate from the Endpoint property to avoid confusion
+        // only for internal user
+        internal IList<EndPoint> Endpoints { get; set; } = new List<EndPoint>();
+
         private string _clientProvidedName;
 
         public IDictionary<string, string> Properties { get; } =
@@ -39,6 +45,7 @@ namespace RabbitMQ.Stream.Client
         public string Password { get; set; } = "guest";
         public string VirtualHost { get; set; } = "/";
         public EndPoint Endpoint { get; set; } = new IPEndPoint(IPAddress.Loopback, 5552);
+
         public Action<MetaDataUpdate> MetadataHandler { get; set; } = _ => { };
         public Action<Exception> UnhandledExceptionHandler { get; set; } = _ => { };
         public TimeSpan Heartbeat { get; set; } = TimeSpan.FromMinutes(1);

--- a/RabbitMQ.Stream.Client/ClientExceptions.cs
+++ b/RabbitMQ.Stream.Client/ClientExceptions.cs
@@ -35,6 +35,14 @@ namespace RabbitMQ.Stream.Client
         }
     }
 
+    public class LeaderNotFoundException : ProtocolException
+    {
+        public LeaderNotFoundException(string s)
+            : base(s)
+        {
+        }
+    }
+
     public class GenericProtocolException : ProtocolException
     {
         public GenericProtocolException(ResponseCode responseCode, string s)

--- a/RabbitMQ.Stream.Client/MetaData.cs
+++ b/RabbitMQ.Stream.Client/MetaData.cs
@@ -117,10 +117,10 @@ namespace RabbitMQ.Stream.Client
             offset += WireFormatting.ReadUInt32(frame.Slice(offset), out var correlation);
             //offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var responseCode);
             offset += WireFormatting.ReadUInt32(frame.Slice(offset), out var numBrokers);
-            var brokers = new Dictionary<ushort, Broker>();
+            var brokers = new Dictionary<short, Broker>();
             for (var i = 0; i < numBrokers; i++)
             {
-                offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var brokerRef);
+                offset += WireFormatting.ReadInt16(frame.Slice(offset), out var brokerRef);
                 offset += WireFormatting.ReadString(frame.Slice(offset), out var host);
                 offset += WireFormatting.ReadUInt32(frame.Slice(offset), out var port);
                 brokers.Add(brokerRef, new Broker(host, port));
@@ -132,18 +132,19 @@ namespace RabbitMQ.Stream.Client
             {
                 offset += WireFormatting.ReadString(frame.Slice(offset), out var stream);
                 offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var code);
-                offset += WireFormatting.ReadUInt16(frame.Slice(offset), out var leaderRef);
+
+                offset += WireFormatting.ReadInt16(frame.Slice(offset), out var leaderRef);
                 offset += WireFormatting.ReadUInt32(frame.Slice(offset), out var numReplicas);
-                var replicaRefs = new ushort[numReplicas];
+                var replicaRefs = new short[numReplicas];
                 for (var j = 0; j < numReplicas; j++)
                 {
-                    offset += WireFormatting.ReadUInt16(frame.Slice(offset), out replicaRefs[j]);
+                    offset += WireFormatting.ReadInt16(frame.Slice(offset), out replicaRefs[j]);
                 }
 
                 if (brokers.Count > 0)
                 {
                     var replicas = replicaRefs.Select(r => brokers[r]).ToList();
-                    var leader = brokers[leaderRef];
+                    var leader = brokers.ContainsKey(leaderRef) ? brokers[leaderRef] : default;
                     streamInfos.Add(stream, new StreamInfo(stream, (ResponseCode)code, leader, replicas));
                 }
                 else

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 abstract RabbitMQ.Stream.Client.Reliable.ReliableBase.Close() -> System.Threading.Tasks.Task
-abstract RabbitMQ.Stream.Client.Reliable.ReliableBase.CloseReliable() -> System.Threading.Tasks.Task
-abstract RabbitMQ.Stream.Client.Reliable.ReliableBase.GetNewReliable(bool boot) -> System.Threading.Tasks.Task
+abstract RabbitMQ.Stream.Client.Reliable.ReliableBase.CloseEntity() -> System.Threading.Tasks.Task
 const RabbitMQ.Stream.Client.AMQP.DescribedFormatCode.AmqpValue = 119 -> byte
 const RabbitMQ.Stream.Client.AMQP.DescribedFormatCode.ApplicationData = 117 -> byte
 const RabbitMQ.Stream.Client.AMQP.DescribedFormatCode.ApplicationProperties = 116 -> byte
@@ -402,6 +401,8 @@ RabbitMQ.Stream.Client.IRouting.ValidateDns.set -> void
 RabbitMQ.Stream.Client.Keywords
 RabbitMQ.Stream.Client.LeaderLocator
 RabbitMQ.Stream.Client.LeaderLocator.LeaderLocator() -> void
+RabbitMQ.Stream.Client.LeaderNotFoundException
+RabbitMQ.Stream.Client.LeaderNotFoundException.LeaderNotFoundException(string s) -> void
 RabbitMQ.Stream.Client.LogEventListener
 RabbitMQ.Stream.Client.LogEventListener.LogEventListener() -> void
 RabbitMQ.Stream.Client.ManualResetValueTaskSource<T>
@@ -643,12 +644,19 @@ RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.MessagesConfirmation() -> v
 RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.PublishingId.get -> ulong
 RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.Status.get -> RabbitMQ.Stream.Client.Reliable.ConfirmationStatus
 RabbitMQ.Stream.Client.Reliable.ReliableBase
-RabbitMQ.Stream.Client.Reliable.ReliableBase.Init() -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.Reliable.ReliableBase.Init(RabbitMQ.Stream.Client.Reliable.IReconnectStrategy reconnectStrategy) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.Reliable.ReliableBase.IsOpen() -> bool
 RabbitMQ.Stream.Client.Reliable.ReliableBase.ReliableBase() -> void
 RabbitMQ.Stream.Client.Reliable.ReliableBase.TryToReconnect(RabbitMQ.Stream.Client.Reliable.IReconnectStrategy reconnectStrategy) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.Reliable.ReliableBase._inReconnection -> bool
-RabbitMQ.Stream.Client.Reliable.ReliableBase._needReconnect -> bool
+RabbitMQ.Stream.Client.Reliable.ReliableBase._isOpen -> bool
+RabbitMQ.Stream.Client.Reliable.ReliableConfig
+RabbitMQ.Stream.Client.Reliable.ReliableConfig.ReconnectStrategy.get -> RabbitMQ.Stream.Client.Reliable.IReconnectStrategy
+RabbitMQ.Stream.Client.Reliable.ReliableConfig.ReconnectStrategy.set -> void
+RabbitMQ.Stream.Client.Reliable.ReliableConfig.Stream.get -> string
+RabbitMQ.Stream.Client.Reliable.ReliableConfig.Stream.set -> void
+RabbitMQ.Stream.Client.Reliable.ReliableConfig.StreamSystem.get -> RabbitMQ.Stream.Client.StreamSystem
+RabbitMQ.Stream.Client.Reliable.ReliableConfig.StreamSystem.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableConsumer
 RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig
 RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.ClientProvidedName.get -> string
@@ -657,14 +665,8 @@ RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.MessageHandler.get -> Sys
 RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.MessageHandler.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.OffsetSpec.get -> RabbitMQ.Stream.Client.IOffsetType
 RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.OffsetSpec.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.ReconnectStrategy.get -> RabbitMQ.Stream.Client.Reliable.IReconnectStrategy
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.ReconnectStrategy.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.Reference.get -> string
 RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.Reference.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.Stream.get -> string
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.Stream.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.StreamSystem.get -> RabbitMQ.Stream.Client.StreamSystem
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.StreamSystem.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableProducer
 RabbitMQ.Stream.Client.Reliable.ReliableProducer.BatchSend(System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Stream.Client.Reliable.ReliableProducer.Send(RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
@@ -676,14 +678,8 @@ RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ConfirmationHandler.get -
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ConfirmationHandler.init -> void
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.MaxInFlight.get -> int
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.MaxInFlight.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ReconnectStrategy.get -> RabbitMQ.Stream.Client.Reliable.IReconnectStrategy
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ReconnectStrategy.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.Reference.get -> string
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.Reference.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.Stream.get -> string
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.Stream.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.StreamSystem.get -> RabbitMQ.Stream.Client.StreamSystem
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.StreamSystem.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.TimeoutMessageAfter.get -> System.TimeSpan
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.TimeoutMessageAfter.init -> void
 RabbitMQ.Stream.Client.ResponseCode

--- a/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
+++ b/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
@@ -35,6 +35,15 @@ public interface IReconnectStrategy
 internal class BackOffReconnectStrategy : IReconnectStrategy
 {
     private int Tentatives { get; set; } = 1;
+    // reset the tentatives after a while 
+    // else the backoff will be too long
+    private void MaybeResetTentatives()
+    {
+        if (Tentatives > 1000)
+        {
+            Tentatives = 1;
+        }
+    }
 
     public async ValueTask<bool> WhenDisconnected(string connectionInfo)
     {
@@ -42,6 +51,7 @@ internal class BackOffReconnectStrategy : IReconnectStrategy
         LogEventSource.Log.LogInformation(
             $"{connectionInfo} disconnected, check if reconnection needed in {Tentatives * 100} ms.");
         await Task.Delay(TimeSpan.FromMilliseconds(Tentatives * 100));
+        MaybeResetTentatives();
         return true;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/150
Reconnect `ReliableProducer` and/or `ReliableConsumer` in case the leader is down and if the Stream changes the topology.

Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>


Refactor The  Reliable part

How to test:
---

using a cluster with 3 nodes and:
```csharp
 using System.Net;
using System.Text;
using RabbitMQ.Stream.Client;
using RabbitMQ.Stream.Client.Reliable;

namespace example;

public static class MultiEndPoints
{
    public static async Task Start()
    {

        var config = new StreamSystemConfig()
        {
            UserName = "test",
            Password = "test",
            Endpoints = new EndPoint[]
            {
                new DnsEndPoint("node0", 5552),
                new DnsEndPoint("node1", 5552),
                new DnsEndPoint("node2", 5552),
            }
        };

        var system = await StreamSystem.Create(config);
        var streamName = Guid.NewGuid().ToString();
        await system.CreateStream(new StreamSpec(streamName));

        var producer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
        {
            Stream = streamName,
            StreamSystem = system,
            ConfirmationHandler = confirmation =>
            {
                Console.WriteLine($"Confirmation: {confirmation.Status} {confirmation.PublishingId}");
                return Task.CompletedTask;
            },
        });

        var t= Task.Run(async () =>
        {
            for (int i = 0; i < 1000; i++)
            {
                if (!producer.IsOpen())
                {
                    Console.WriteLine("Producer is not connected");
                    return;
                }
                await producer.Send(new Message(Encoding.UTF8.GetBytes($"hello {i}")));
                Console.WriteLine($"Sent message {i}");
                Thread.Sleep(1 * 1000);
            }
        });

        var consumer = await ReliableConsumer.CreateReliableConsumer(new ReliableConsumerConfig()
        {
            Stream = streamName,
            StreamSystem = system,
            MessageHandler = (_, _, message) =>
            {
                Console.WriteLine($"Consumed message {Encoding.UTF8.GetString(message.Data.Contents)}");
                return Task.CompletedTask;
            },
        });
        Console.WriteLine("Press enter to stop");
        Console.ReadKey();
        t.Dispose();
        await producer.Close();
        await consumer.Close();
        await system.DeleteStream(streamName);
        await system.Close();
        Console.WriteLine("Closed");
    }
}
```

Then Identify the leader node for the queue:
![Screen Shot 2022-09-07 at 19 20 11](https://user-images.githubusercontent.com/386987/188940350-a0261c8e-d696-458a-b0bd-a831e80873f5.png)

And stop the node; in this case, it is the `node0`.  The producer should reconnect to another node.

Note:
---

Locator connection can be in the same leader stream node. The locator connection should be able to reconnect to another node too.  



