### PR TITLE
Change definition of MaxLengthBytes stream specification - #165

### DIFF
--- a/RabbitMQ.Stream.Client/StreamSpec.cs
+++ b/RabbitMQ.Stream.Client/StreamSpec.cs
@@ -19,7 +19,7 @@ namespace RabbitMQ.Stream.Client
             set => Args["max-age"] = $"{value.TotalSeconds}s";
         }
 
-        public int MaxLengthBytes
+        public ulong MaxLengthBytes
         {
             set => Args["max-length-bytes"] = $"{value}";
         }

--- a/Tests/StreamSpecTests.cs
+++ b/Tests/StreamSpecTests.cs
@@ -25,10 +25,12 @@ namespace Tests
         [Fact]
         public void CanOverrideAnyStreamSpecAttributes()
         {
-            var spec = new StreamSpec("theStreamName");
-            spec.MaxAge = TimeSpan.FromHours(3);
-            spec.MaxLengthBytes = 10000;
-            spec.LeaderLocator = LeaderLocator.Random; // this is an override because the spec has already a default value
+            var spec = new StreamSpec("theStreamName")
+            {
+                MaxAge = TimeSpan.FromHours(3),
+                MaxLengthBytes = 10000,
+                LeaderLocator = LeaderLocator.Random // this is an override because the spec has already a default value
+            };
 
             // can override any settings being set
             spec.MaxAge = TimeSpan.FromHours(5);
@@ -41,6 +43,17 @@ namespace Tests
                 MaxAge = TimeSpan.FromHours(5)
             };
             Assert.Equal(expectedSpec.Args, spec.Args);
+        }
+
+        [Fact]
+        public void MaxLengthAttributeCanContainUInt64ValuesRange()
+        {
+            var spec = new StreamSpec("theStreamName")
+            {
+                MaxLengthBytes = ulong.MaxValue
+            };
+
+            Assert.Equal(ulong.MaxValue.ToString(), $"{spec.Args["max-length-bytes"]}");
         }
     }
 }

--- a/Tests/SystemTests.cs
+++ b/Tests/SystemTests.cs
@@ -97,6 +97,19 @@ namespace Tests
         }
 
         [Fact]
+        public async void Create_Stream_With_Max_Length_Maximum_Value()
+        {
+            var stream = Guid.NewGuid().ToString();
+            var config = new StreamSystemConfig();
+            var system = await StreamSystem.Create(config);
+            var spec = new StreamSpec(stream) { MaxLengthBytes = ulong.MaxValue };
+            await system.CreateStream(spec);
+            Assert.Equal(ulong.MaxValue.ToString(), spec.Args["max-length-bytes"]);
+            await system.DeleteStream(stream);
+            await system.Close();
+        }
+
+        [Fact]
         public async void CreateSystemThrowsWhenVirtualHostFailureAccess()
         {
             var config = new StreamSystemConfig { VirtualHost = "DOES_NOT_EXIST" };


### PR DESCRIPTION
Change definition of MaxLengthBytes stream specification from int to ulong. 
I used unsigned type because negative values don't make sense for this setting.

Fixes: #165