### PR TITLE
Implement SuperStream for ReliableProducer

### DIFF
--- a/RabbitMQ.Stream.Client/Producer.cs
+++ b/RabbitMQ.Stream.Client/Producer.cs
@@ -15,6 +15,8 @@ namespace RabbitMQ.Stream.Client
     {
         public ulong PublishingId { get; set; }
         public ResponseCode Code { get; set; }
+
+        public string Stream { get; set; }
     }
 
     public record ProducerConfig : IProducerConfig
@@ -24,7 +26,6 @@ namespace RabbitMQ.Stream.Client
         public Action<Confirmation> ConfirmHandler { get; set; } = _ => { };
 
         public Action<MetaDataUpdate> MetadataHandler { get; set; } = _ => { };
-
     }
 
     public class Producer : AbstractEntity, IProducer, IDisposable
@@ -79,7 +80,12 @@ namespace RabbitMQ.Stream.Client
                 {
                     foreach (var id in publishingIds.Span)
                     {
-                        config.ConfirmHandler(new Confirmation { PublishingId = id, Code = ResponseCode.Ok, });
+                        config.ConfirmHandler(new Confirmation
+                        {
+                            PublishingId = id,
+                            Code = ResponseCode.Ok,
+                            Stream = config.Stream
+                        });
                     }
 
                     semaphore.Release(publishingIds.Length);

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -267,6 +267,8 @@ RabbitMQ.Stream.Client.Confirmation.Code.set -> void
 RabbitMQ.Stream.Client.Confirmation.Confirmation() -> void
 RabbitMQ.Stream.Client.Confirmation.PublishingId.get -> ulong
 RabbitMQ.Stream.Client.Confirmation.PublishingId.set -> void
+RabbitMQ.Stream.Client.Confirmation.Stream.get -> string
+RabbitMQ.Stream.Client.Confirmation.Stream.set -> void
 RabbitMQ.Stream.Client.Connection
 RabbitMQ.Stream.Client.Connection.Dispose() -> void
 RabbitMQ.Stream.Client.Connection.IsClosed.get -> bool
@@ -688,7 +690,7 @@ RabbitMQ.Stream.Client.Reliable.ConfirmationPipe
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.AddUnConfirmedMessage(ulong publishingId, RabbitMQ.Stream.Client.Message message) -> void
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.AddUnConfirmedMessage(ulong publishingId, System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages) -> void
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.ConfirmationPipe(System.Func<RabbitMQ.Stream.Client.Reliable.MessagesConfirmation, System.Threading.Tasks.Task> confirmHandler, System.TimeSpan messageTimeout, int maxInFlightMessages) -> void
-RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.RemoveUnConfirmedMessage(ulong publishingId, RabbitMQ.Stream.Client.Reliable.ConfirmationStatus confirmationStatus) -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.RemoveUnConfirmedMessage(RabbitMQ.Stream.Client.Reliable.ConfirmationStatus confirmationStatus, ulong publishingId, string stream) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.Start() -> void
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.Stop() -> void
 RabbitMQ.Stream.Client.Reliable.ConfirmationStatus
@@ -711,6 +713,12 @@ RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.Messages.get -> System.Coll
 RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.MessagesConfirmation() -> void
 RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.PublishingId.get -> ulong
 RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.Status.get -> RabbitMQ.Stream.Client.Reliable.ConfirmationStatus
+RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.Stream.get -> string
+RabbitMQ.Stream.Client.Reliable.ProducerFactory
+RabbitMQ.Stream.Client.Reliable.ProducerFactory.CreateProducer() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
+RabbitMQ.Stream.Client.Reliable.ProducerFactory.ProducerFactory() -> void
+RabbitMQ.Stream.Client.Reliable.ProducerFactory._confirmationPipe -> RabbitMQ.Stream.Client.Reliable.ConfirmationPipe
+RabbitMQ.Stream.Client.Reliable.ProducerFactory._reliableProducerConfig -> RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig
 RabbitMQ.Stream.Client.Reliable.ReliableBase
 RabbitMQ.Stream.Client.Reliable.ReliableBase.IsOpen() -> bool
 RabbitMQ.Stream.Client.Reliable.ReliableBase.ReliableBase() -> void
@@ -751,8 +759,16 @@ RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.MaxInFlight.get -> int
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.MaxInFlight.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.Reference.get -> string
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.Reference.set -> void
+RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.SuperStreamConfig.get -> RabbitMQ.Stream.Client.Reliable.SuperStreamConfig
+RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.SuperStreamConfig.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.TimeoutMessageAfter.get -> System.TimeSpan
 RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.TimeoutMessageAfter.init -> void
+RabbitMQ.Stream.Client.Reliable.SuperStreamConfig
+RabbitMQ.Stream.Client.Reliable.SuperStreamConfig.Enabled.get -> bool
+RabbitMQ.Stream.Client.Reliable.SuperStreamConfig.Enabled.init -> void
+RabbitMQ.Stream.Client.Reliable.SuperStreamConfig.Routing.get -> System.Func<RabbitMQ.Stream.Client.Message, string>
+RabbitMQ.Stream.Client.Reliable.SuperStreamConfig.Routing.set -> void
+RabbitMQ.Stream.Client.Reliable.SuperStreamConfig.SuperStreamConfig() -> void
 RabbitMQ.Stream.Client.ResponseCode
 RabbitMQ.Stream.Client.ResponseCode.AccessRefused = 16 -> RabbitMQ.Stream.Client.ResponseCode
 RabbitMQ.Stream.Client.ResponseCode.AuthenticationFailure = 8 -> RabbitMQ.Stream.Client.ResponseCode

--- a/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
@@ -1,0 +1,90 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2007-2020 VMware, Inc.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RabbitMQ.Stream.Client.Reliable;
+
+public abstract class ProducerFactory : ReliableBase
+{
+    protected ReliableProducerConfig _reliableProducerConfig;
+    protected ConfirmationPipe _confirmationPipe;
+
+    protected async Task<IProducer> CreateProducer()
+    {
+        if (_reliableProducerConfig.SuperStreamConfig is { Enabled: true })
+        {
+            return await SuperStreamProducer();
+        }
+
+        return await StandardProducer();
+    }
+
+    private async Task<IProducer> SuperStreamProducer()
+    {
+        return await _reliableProducerConfig.StreamSystem.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+        {
+            SuperStream = _reliableProducerConfig.Stream,
+            ClientProvidedName = _reliableProducerConfig.ClientProvidedName,
+            Reference = _reliableProducerConfig.Reference,
+            MaxInFlight = _reliableProducerConfig.MaxInFlight,
+            Routing = _reliableProducerConfig.SuperStreamConfig.Routing,
+            ConfirmHandler = confirmation =>
+            {
+                var confirmationStatus = confirmation.Item2.Code switch
+                {
+                    ResponseCode.PublisherDoesNotExist => ConfirmationStatus.PublisherDoesNotExist,
+                    ResponseCode.AccessRefused => ConfirmationStatus.AccessRefused,
+                    ResponseCode.InternalError => ConfirmationStatus.InternalError,
+                    ResponseCode.PreconditionFailed => ConfirmationStatus.PreconditionFailed,
+                    ResponseCode.StreamNotAvailable => ConfirmationStatus.StreamNotAvailable,
+                    ResponseCode.Ok => ConfirmationStatus.Confirmed,
+                    _ => ConfirmationStatus.UndefinedError
+                };
+                _confirmationPipe.RemoveUnConfirmedMessage(confirmationStatus, confirmation.Item2.PublishingId,
+                    confirmation.Item1);
+            }
+        });
+    }
+
+    private async Task<IProducer> StandardProducer()
+    {
+        return await _reliableProducerConfig.StreamSystem.CreateProducer(new ProducerConfig()
+        {
+            Stream = _reliableProducerConfig.Stream,
+            ClientProvidedName = _reliableProducerConfig.ClientProvidedName,
+            Reference = _reliableProducerConfig.Reference,
+            MaxInFlight = _reliableProducerConfig.MaxInFlight,
+            MetadataHandler = update =>
+            {
+                // This is Async since the MetadataHandler is called from the Socket connection thread
+                // HandleMetaDataMaybeReconnect/2 could go in deadlock.
+
+                Task.Run(() =>
+                {
+                    // intentionally fire & forget
+                    HandleMetaDataMaybeReconnect(update.Stream,
+                        _reliableProducerConfig.StreamSystem).WaitAsync(CancellationToken.None);
+                });
+            },
+            ConnectionClosedHandler = async _ => { await TryToReconnect(_reliableProducerConfig.ReconnectStrategy); },
+            ConfirmHandler = confirmation =>
+            {
+                var confirmationStatus = confirmation.Code switch
+                {
+                    ResponseCode.PublisherDoesNotExist => ConfirmationStatus.PublisherDoesNotExist,
+                    ResponseCode.AccessRefused => ConfirmationStatus.AccessRefused,
+                    ResponseCode.InternalError => ConfirmationStatus.InternalError,
+                    ResponseCode.PreconditionFailed => ConfirmationStatus.PreconditionFailed,
+                    ResponseCode.StreamNotAvailable => ConfirmationStatus.StreamNotAvailable,
+                    ResponseCode.Ok => ConfirmationStatus.Confirmed,
+                    _ => ConfirmationStatus.UndefinedError
+                };
+                _confirmationPipe.RemoveUnConfirmedMessage(confirmationStatus, confirmation.PublishingId,
+                    confirmation.Stream);
+            }
+        });
+    }
+}

--- a/RabbitMQ.Stream.Client/Reliable/ReliableProducer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableProducer.cs
@@ -20,8 +20,15 @@ public record ReliableProducerConfig : ReliableConfig
 {
     private readonly TimeSpan _timeoutMessageAfter = TimeSpan.FromSeconds(3);
 
+    // Reference is mostly used for deduplication. In most of the cases reference is not needed.
     public string Reference { get; set; }
+
+    // Confirmation is used to confirm that the message has been received by the server.
+    // After the timeout TimeoutMessageAfter/0 the message is considered not confirmed.
+    // See MessagesConfirmation.ConfirmationStatus for more details.
     public Func<MessagesConfirmation, Task> ConfirmationHandler { get; init; }
+    // The client name used to identify the producer. 
+    // You can see this value on the Management UI or in the connection detail
     public string ClientProvidedName { get; set; } = "dotnet-stream-rproducer";
 
     public int MaxInFlight { get; set; } = 1000;
@@ -29,6 +36,8 @@ public record ReliableProducerConfig : ReliableConfig
     // SuperStream configuration enables the SuperStream feature
     public SuperStreamConfig SuperStreamConfig { get; set; } = null;
 
+    // TimeoutMessageAfter is the time after which a message is considered as timed out
+    // If client does not receive a confirmation for a message after this time, the message is considered as timed out
     public TimeSpan TimeoutMessageAfter
     {
         get => _timeoutMessageAfter;
@@ -45,7 +54,7 @@ public record ReliableProducerConfig : ReliableConfig
 }
 
 /// <summary>
-/// ReliableProducer is a wrapper around the standard Producer.
+/// ReliableProducer is a wrapper around the standard Producer/SuperStream Consumer.
 /// Main features are:
 /// - Auto-reconnection if the connection is dropped
 /// - Trace sent and received messages. The event ReliableProducer:ConfirmationHandler/2

--- a/RabbitMQ.Stream.Client/SuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/SuperStreamProducer.cs
@@ -236,11 +236,11 @@ public class SuperStreamProducer : IProducer, IDisposable
         GC.SuppressFinalize(this);
     }
 
-    public int MessagesSent { get; }
-    public int ConfirmFrames { get; }
-    public int IncomingFrames { get; }
-    public int PublishCommandsSent { get; }
-    public int PendingCount { get; }
+    public int MessagesSent => _producers.Sum(x => x.Value.MessagesSent);
+    public int ConfirmFrames => _producers.Sum(x => x.Value.ConfirmFrames);
+    public int IncomingFrames => _producers.Sum(x => x.Value.IncomingFrames);
+    public int PublishCommandsSent => _producers.Sum(x => x.Value.PublishCommandsSent);
+    public int PendingCount => _producers.Sum(x => x.Value.PendingCount);
 
     public static IProducer Create(SuperStreamProducerConfig superStreamProducerConfig,
         IDictionary<string, StreamInfo> streamInfos, ClientParameters clientParameters)

--- a/RabbitMQ.Stream.Client/SuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/SuperStreamProducer.cs
@@ -104,7 +104,8 @@ public class SuperStreamProducer : IProducer, IDisposable
     {
         if (!_producers.ContainsKey(stream))
         {
-            _producers.TryAdd(stream, await InitProducer(stream));
+            var p = await InitProducer(stream);
+            _producers.TryAdd(stream, p);
         }
 
         return _producers[stream];
@@ -209,6 +210,11 @@ public class SuperStreamProducer : IProducer, IDisposable
     // </summary> 
     public Task<ulong> GetLastPublishingId()
     {
+        foreach (var stream in _streamInfos.Keys.ToList())
+        {
+            GetProducer(stream).Wait();
+        }
+
         var v = _producers.Values.Min(p => p.GetLastPublishingId().Result);
 
         return Task.FromResult(v);

--- a/Tests/ReliableTests.cs
+++ b/Tests/ReliableTests.cs
@@ -75,8 +75,8 @@ public class ReliableTests
         var message = new Message(Encoding.UTF8.GetBytes($"hello"));
         confirmationPipe.AddUnConfirmedMessage(1, message);
         confirmationPipe.AddUnConfirmedMessage(2, new List<Message>() { message });
-        confirmationPipe.RemoveUnConfirmedMessage(1, ConfirmationStatus.Confirmed);
-        confirmationPipe.RemoveUnConfirmedMessage(2, ConfirmationStatus.Confirmed);
+        confirmationPipe.RemoveUnConfirmedMessage(ConfirmationStatus.Confirmed, 1, null);
+        confirmationPipe.RemoveUnConfirmedMessage(ConfirmationStatus.Confirmed, 2, null);
         new Utils<List<MessagesConfirmation>>(_testOutputHelper).WaitUntilTaskCompletes(confirmationTask);
         Assert.Equal(ConfirmationStatus.Confirmed, confirmationTask.Task.Result[0].Status);
         Assert.Equal(ConfirmationStatus.Confirmed, confirmationTask.Task.Result[1].Status);

--- a/Tests/SuperStreamTests.cs
+++ b/Tests/SuperStreamTests.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Stream.Client;
 using RabbitMQ.Stream.Client.AMQP;
+using RabbitMQ.Stream.Client.Reliable;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -499,6 +500,7 @@ public class SuperStreamTests
 
             await streamProducer.Send(i, message);
         }
+
         // starting form here the number of the messages in the stream must be the same
         // the following send(s) will enable the deduplication
         await streamProducer.BatchSend(batchSendMessages);
@@ -508,6 +510,142 @@ public class SuperStreamTests
         // Total messages must be 20
         // according to the routing strategy hello{i} that must be the correct routing
         // Deduplication in action
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-0") == 9);
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-1") == 7);
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-2") == 4);
+        await system.Close();
+    }
+
+    // super stream reliable producer tests
+    [Fact]
+    public async void SuperStreamReliableProducerSendMessagesDifferentWays()
+    {
+        ResetSuperStreams();
+        var system = await StreamSystem.Create(new StreamSystemConfig());
+        var streamProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
+        {
+            StreamSystem = system,
+            Stream = "invoices",
+            SuperStreamConfig = new SuperStreamConfig()
+            {
+                Routing = message1 => message1.Properties.MessageId.ToString()
+            }
+        }
+        );
+
+        var batchSendMessages = new List<Message>();
+
+        for (ulong i = 0; i < 20; i++)
+        {
+            var message = new Message(Encoding.Default.GetBytes("hello"))
+            {
+                Properties = new Properties() { MessageId = $"hello{i}" }
+            };
+            await streamProducer.Send(message);
+            batchSendMessages.Add(message);
+        }
+
+        await streamProducer.BatchSend(batchSendMessages);
+        await streamProducer.Send(batchSendMessages, CompressionType.Gzip);
+
+        SystemUtils.Wait();
+        // Total messages must be 20 * 3 (standard send,batch send, subentry send)
+        // according to the routing strategy hello{i} that must be the correct routing
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-0") == 9 * 3);
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-1") == 7 * 3);
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-2") == 4 * 3);
+        await system.Close();
+    }
+
+    [Fact]
+    public async void HandleConfirmationToReliableSuperStream()
+    {
+        ResetSuperStreams();
+        // This test is for the confirmation mechanism
+        // We send 20 messages and we should have confirmation messages == stream messages count
+        // total count must be 20 divided by 3 streams (not in equals way..)
+        var testPassed = new TaskCompletionSource<bool>();
+        var confirmedList = new ConcurrentBag<(string, Message)>();
+        var system = await StreamSystem.Create(new StreamSystemConfig());
+        var streamProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
+        {
+            StreamSystem = system,
+            Stream = "invoices",
+            SuperStreamConfig =
+                new SuperStreamConfig() { Routing = message1 => message1.Properties.MessageId.ToString() },
+            ConfirmationHandler = confirmation =>
+            {
+                if (confirmation.Status == ConfirmationStatus.Confirmed)
+                {
+                    confirmedList.Add((confirmation.Stream, confirmation.Messages[0]));
+                }
+
+                if (confirmedList.Count == 20)
+                {
+                    testPassed.SetResult(true);
+                }
+
+                return Task.CompletedTask;
+            }
+        });
+
+        for (ulong i = 0; i < 20; i++)
+        {
+            var message = new Message(Encoding.Default.GetBytes("hello"))
+            {
+                Properties = new Properties() { MessageId = $"hello{i.ToString()}" }
+            };
+            await streamProducer.Send(message);
+        }
+
+        SystemUtils.Wait();
+        new Utils<bool>(_testOutputHelper).WaitUntilTaskCompletes(testPassed);
+        Assert.Equal(9, confirmedList.Count(x => x.Item1 == "invoices-0"));
+        Assert.Equal(7, confirmedList.Count(x => x.Item1 == "invoices-1"));
+        Assert.Equal(4, confirmedList.Count(x => x.Item1 == "invoices-2"));
+        await system.Close();
+    }
+
+    [Fact]
+    public async void SendMessageToReliableSuperStreamRecreateConnectionsIfKilled()
+    {
+        ResetSuperStreams();
+        // This test validates that the Reliable super stream producer is able to recreate the connection
+        // if the connection is killed
+        // It is NOT meant to test the availability of the super stream producer
+        // just the reconnect mechanism
+        var system = await StreamSystem.Create(new StreamSystemConfig());
+        var clientName = Guid.NewGuid().ToString();
+        var streamProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
+        {
+            StreamSystem = system,
+            Stream = "invoices",
+            SuperStreamConfig = new SuperStreamConfig()
+            {
+                Routing = message1 => message1.Properties.MessageId.ToString()
+            },
+            ClientProvidedName = clientName
+        });
+        for (ulong i = 0; i < 20; i++)
+        {
+            var message = new Message(Encoding.Default.GetBytes("hello"))
+            {
+                Properties = new Properties() { MessageId = $"hello{i}" }
+            };
+
+            if (i == 10)
+            {
+                SystemUtils.WaitUntil(() => SystemUtils.HttpKillConnections(clientName).Result == 3);
+                // We just decide to close the connections
+            }
+
+            // Here the connection _must_ be recreated  and the message sent
+            await streamProducer.Send(message);
+        }
+
+        SystemUtils.Wait();
+        // Total messages must be 20
+        // according to the routing strategy hello{i} that must be the correct routing
         SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-0") == 9);
         SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-1") == 7);
         SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-2") == 4);

--- a/Tests/SuperStreamTests.cs
+++ b/Tests/SuperStreamTests.cs
@@ -129,6 +129,10 @@ public class SuperStreamTests
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 Reference = "reference"
             });
+        Assert.True(streamProducer.MessagesSent == 0);
+        Assert.True(streamProducer.ConfirmFrames == 0);
+        Assert.True(streamProducer.PublishCommandsSent == 0);
+        Assert.True(streamProducer.PendingCount == 0);
         for (ulong i = 0; i < 20; i++)
         {
             var message = new Message(Encoding.Default.GetBytes("hello"))
@@ -145,6 +149,10 @@ public class SuperStreamTests
         SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-1") == 7);
         SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-2") == 4);
         Assert.Equal(await streamProducer.GetLastPublishingId(), (ulong)10);
+
+        Assert.True(streamProducer.MessagesSent == 20);
+        SystemUtils.WaitUntil(() => streamProducer.ConfirmFrames > 0);
+        SystemUtils.WaitUntil(() => streamProducer.PublishCommandsSent > 0);
 
         Assert.True(await streamProducer.Close() == ResponseCode.Ok);
         await system.Close();


### PR DESCRIPTION
Add SuperStreamConfig to enable super stream 

Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>

ReliableProducer can handle standard producers and super stream producers.  From the user's perspective, the behaviour is hidden.

Standard producer
---
```csharp
  var reliableProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
   {
   StreamSystem = system,
   Stream = stream,
   Reference = "my-reliable-producer",
   ClientProvidedName = "my-reliable-producer",
   ConfirmationHandler = confirmation =>
```

Super stream:
---
```csharp
  var reliableProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
  {
  StreamSystem = system,
  Stream = stream,
  Reference = "my-reliable-producer",
  ClientProvidedName = "my-reliable-producer",
  SuperStreamConfig = new SuperStreamConfig()
    {
         Routing = message => message.Properties.MessageId.ToString()
     },
  ConfirmationHandler = confirmation =>
```

Recap:
---
We have two different low-level classes:
`StandardProducer`  : IProducer 
`SuperStreamProducer`  : IProducer 

One Smart layer class:
`ReliableProducer` that handles:
- `StandardProducer` and `SuperStreamProducer`
- Confirmation messages with timeouts and errors
- Auto reconnect 


