### PR TITLE
Refactor Classes names

### DIFF
--- a/.ci/versions.json
+++ b/.ci/versions.json
@@ -1,4 +1,4 @@
 {
-  "erlang": "25.0.4",
-  "rabbitmq": "3.11.0"
+  "erlang": "25.1.2",
+  "rabbitmq": "3.11.2"
 }

--- a/Examples/Performances/BatchVsBatchSend.cs
+++ b/Examples/Performances/BatchVsBatchSend.cs
@@ -35,10 +35,8 @@ public class BatchVsBatchSend
         var total = 0;
         var confirmed = 0;
         var error = 0;
-        var reliableProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
+        var reliableProducer = await Producer.Create(new ProducerConfig(system, stream)
         {
-            Stream = stream,
-            StreamSystem = system,
             MaxInFlight = 1_000_000,
             ConfirmationHandler = messagesConfirmed =>
             {
@@ -87,10 +85,8 @@ public class BatchVsBatchSend
         var total = 0;
         var confirmed = 0;
         var error = 0;
-        var reliableProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
+        var producer = await Producer.Create(new ProducerConfig(system,stream)
         {
-            Stream = stream,
-            StreamSystem = system,
             MaxInFlight = 1_000_000,
             ConfirmationHandler = messagesConfirmed =>
             {
@@ -122,7 +118,7 @@ public class BatchVsBatchSend
             messages.Add(new Message(array));
             if (i % AggregateBatchSize == 0)
             {
-                await reliableProducer.BatchSend(messages);
+                await producer.Send(messages);
                 messages.Clear();
             }
 
@@ -132,13 +128,13 @@ public class BatchVsBatchSend
             }
         }
 
-        await reliableProducer.BatchSend(messages);
+        await producer.Send(messages);
         messages.Clear();
 
         Console.WriteLine(
             $"*****Reliable Producer Batch Send***** time: {DateTime.Now - start}, messages sent: {TotalMessages}");
         Thread.Sleep(1000);
-        await reliableProducer.Close();
+        await producer.Close();
     }
 
 
@@ -146,9 +142,8 @@ public class BatchVsBatchSend
     {
         Console.WriteLine("*****Standard Producer Send*****");
         var confirmed = 0;
-        var producer = await system.CreateProducer(new ProducerConfig()
+        var producer = await system.CreateRawProducer(new RawProducerConfig(stream)
         {
-            Stream = stream,
             MaxInFlight = 1_000_000,
             ConfirmHandler = _ =>
             {
@@ -182,9 +177,8 @@ public class BatchVsBatchSend
     {
         Console.WriteLine("*****Standard Batch Send*****");
         var confirmed = 0;
-        var producer = await system.CreateProducer(new ProducerConfig()
+        var producer = await system.CreateRawProducer(new RawProducerConfig(stream)
         {
-            Stream = stream,
             MaxInFlight = 1_000_000,
             ConfirmHandler = _ =>
             {
@@ -202,7 +196,7 @@ public class BatchVsBatchSend
             messages.Add((i, new Message(array)));
             if (i % AggregateBatchSize == 0)
             {
-                await producer.BatchSend(messages);
+                await producer.Send(messages);
                 messages.Clear();
             }
 
@@ -212,7 +206,7 @@ public class BatchVsBatchSend
             }
         }
 
-        await producer.BatchSend(messages);
+        await producer.Send(messages);
         messages.Clear();
 
         Console.WriteLine(

--- a/RabbitMQ.Stream.Client.PerfTest/Program.fs
+++ b/RabbitMQ.Stream.Client.PerfTest/Program.fs
@@ -20,7 +20,7 @@ let main argv =
     let mutable confirmed = 0
     let mutable prod = null
     let streamName = "dotnet-perftest"
-    let consumerConfig = RawConsumerConfig(Stream = streamName,
+    let consumerConfig = RawConsumerConfig(streamName,
                                         Reference = Guid.NewGuid().ToString(),
                                         MessageHandler =
                                             fun c ctx m ->
@@ -34,7 +34,7 @@ let main argv =
         let! stream = system.CreateStream(StreamSpec(streamName))
         printfn $"Stream: {streamName}"
         let! consumer = system.CreateRawConsumer(consumerConfig)
-        let producerConfig = RawProducerConfig(Stream = streamName,
+        let producerConfig = RawProducerConfig(streamName,
                                             Reference = null,
                                             MaxInFlight = 10000,
                                             ConfirmHandler = fun c -> confirmed <- confirmed + 1)

--- a/RabbitMQ.Stream.Client.PerfTest/Program.fs
+++ b/RabbitMQ.Stream.Client.PerfTest/Program.fs
@@ -20,7 +20,7 @@ let main argv =
     let mutable confirmed = 0
     let mutable prod = null
     let streamName = "dotnet-perftest"
-    let consumerConfig = ConsumerConfig(Stream = streamName,
+    let consumerConfig = RawConsumerConfig(Stream = streamName,
                                         Reference = Guid.NewGuid().ToString(),
                                         MessageHandler =
                                             fun c ctx m ->
@@ -33,12 +33,12 @@ let main argv =
         let! system = StreamSystem.Create config
         let! stream = system.CreateStream(StreamSpec(streamName))
         printfn $"Stream: {streamName}"
-        let! consumer = system.CreateConsumer(consumerConfig)
-        let producerConfig = ProducerConfig(Stream = streamName,
+        let! consumer = system.CreateRawConsumer(consumerConfig)
+        let producerConfig = RawProducerConfig(Stream = streamName,
                                             Reference = null,
                                             MaxInFlight = 10000,
                                             ConfirmHandler = fun c -> confirmed <- confirmed + 1)
-        let! producer = system.CreateProducer producerConfig
+        let! producer = system.CreateRawProducer producerConfig
         //make producer available to metrics async
         prod <- producer
         let msg = Message "asdf"B

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -296,14 +296,14 @@ namespace RabbitMQ.Stream.Client
             Dictionary<string, string> properties, Func<Deliver, Task> deliverHandler,
             Func<bool, Task<IOffsetType>> consumerUpdateHandler = null)
         {
-            return await Subscribe(new ConsumerConfig() { Stream = stream, OffsetSpec = offsetType },
+            return await Subscribe(new RawConsumerConfig(stream) { OffsetSpec = offsetType },
                 initialCredit,
                 properties,
                 deliverHandler,
                 consumerUpdateHandler);
         }
 
-        public async Task<(byte, SubscribeResponse)> Subscribe(ConsumerConfig config,
+        public async Task<(byte, SubscribeResponse)> Subscribe(RawConsumerConfig config,
             ushort initialCredit,
             Dictionary<string, string> properties, Func<Deliver, Task> deliverHandler,
             Func<bool, Task<IOffsetType>> consumerUpdateHandler)
@@ -614,6 +614,7 @@ namespace RabbitMQ.Stream.Client
             return response.StreamInfos is { Count: >= 1 } &&
                    response.StreamInfos[stream].ResponseCode == ResponseCode.Ok;
         }
+
         public async ValueTask<QueryOffsetResponse> QueryOffset(string reference, string stream)
         {
             return await Request<QueryOffsetRequest, QueryOffsetResponse>(corr =>

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -24,7 +24,7 @@ public record IConsumerConfig : INamedEntity
     internal IOffsetType StoredOffsetSpec { get; set; }
 
     // ClientProvidedName is used to identify TCP connection name.
-    public string ClientProvidedName { get; set; } = "dotnet-stream-consumer";
+    public string ClientProvidedName { get; set; } = "dotnet-stream-raw-consumer";
 
     // SingleActiveConsumer is used to indicate that there is only one consumer active for the stream.
     // given a consumer reference. 

--- a/RabbitMQ.Stream.Client/IProducer.cs
+++ b/RabbitMQ.Stream.Client/IProducer.cs
@@ -16,13 +16,42 @@ namespace RabbitMQ.Stream.Client;
 
 public interface IProducer
 {
+    /// <summary>
+    /// Send the message to the stream in asynchronous mode.
+    /// The client will aggregate messages and send them in batches.
+    /// It works in most cases.
+    /// </summary>
+    /// <param name="publishingId">Publishing id</param>
+    /// <param name="message"> Message </param>
+    /// <returns></returns>
     public ValueTask Send(ulong publishingId, Message message);
-    public ValueTask BatchSend(List<(ulong, Message)> messages);
 
+    /// <summary>
+    /// Send the messages in batch to the stream in synchronous mode.
+    /// It is needed when you need to aggregate messages in your application.
+    /// </summary>
+    /// <param name="messages"></param>
+    /// <returns></returns>
+    public ValueTask Send(List<(ulong, Message)> messages);
+
+    /// <summary>
+    /// Enable sub-batch feature.
+    /// It is needed when you need to sub aggregate the messages and compress them.
+    /// For example you can aggregate 100 log messages and compress to reduce the space.
+    /// One single publishingId can have multiple sub-batches messages.
+    /// </summary>
+    /// <param name="publishingId"></param>
+    /// <param name="subEntryMessages">Messages to aggregate</param>
+    /// <param name="compressionType"> Type of compression. By default the client supports GZIP and none</param>
+    /// <returns></returns>
     public ValueTask Send(ulong publishingId, List<Message> subEntryMessages, CompressionType compressionType);
 
     public Task<ResponseCode> Close();
 
+    /// <summary>
+    /// Return the last publishing id.
+    /// </summary>
+    /// <returns></returns>
     public Task<ulong> GetLastPublishingId();
 
     public bool IsOpen();

--- a/RabbitMQ.Stream.Client/IProducer.cs
+++ b/RabbitMQ.Stream.Client/IProducer.cs
@@ -19,7 +19,7 @@ public interface IProducer
     /// <summary>
     /// Send the message to the stream in asynchronous mode.
     /// The client will aggregate messages and send them in batches.
-    /// It works in most cases.
+    /// The batch size is configurable. See IProducerConfig.BatchSize.
     /// </summary>
     /// <param name="publishingId">Publishing id</param>
     /// <param name="message"> Message </param>
@@ -28,9 +28,10 @@ public interface IProducer
 
     /// <summary>
     /// Send the messages in batch to the stream in synchronous mode.
-    /// It is needed when you need to aggregate messages in your application.
+    /// The aggregation is provided by the user.
+    /// The client will send the messages in the order they are provided.
     /// </summary>
-    /// <param name="messages"></param>
+    /// <param name="messages">Batch messages to send</param>
     /// <returns></returns>
     public ValueTask Send(List<(ulong, Message)> messages);
 
@@ -39,6 +40,7 @@ public interface IProducer
     /// It is needed when you need to sub aggregate the messages and compress them.
     /// For example you can aggregate 100 log messages and compress to reduce the space.
     /// One single publishingId can have multiple sub-batches messages.
+    /// See also: https://rabbitmq.github.io/rabbitmq-stream-java-client/stable/htmlsingle/#sub-entry-batching-and-compression
     /// </summary>
     /// <param name="publishingId"></param>
     /// <param name="subEntryMessages">Messages to aggregate</param>
@@ -70,7 +72,7 @@ public record IProducerConfig : INamedEntity
 {
     public string Reference { get; set; }
     public int MaxInFlight { get; set; } = 1000;
-    public string ClientProvidedName { get; set; } = "dotnet-stream-producer";
+    public string ClientProvidedName { get; set; } = "dotnet-stream-raw-producer";
 
     public int BatchSize { get; set; } = 100;
 

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -906,6 +906,7 @@ RabbitMQ.Stream.Client.StreamSystem
 RabbitMQ.Stream.Client.StreamSystem.Close() -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.StreamSystem.CreateRawConsumer(RabbitMQ.Stream.Client.RawConsumerConfig rawConsumerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
 RabbitMQ.Stream.Client.StreamSystem.CreateRawProducer(RabbitMQ.Stream.Client.RawProducerConfig rawProducerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
+RabbitMQ.Stream.Client.StreamSystem.CreateRawSuperStreamProducer(RabbitMQ.Stream.Client.RawSuperStreamProducerConfig rawSuperStreamProducerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 RabbitMQ.Stream.Client.StreamSystem.CreateStream(RabbitMQ.Stream.Client.StreamSpec spec) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.StreamSystem.CreateSuperStreamConsumer(RabbitMQ.Stream.Client.SuperStreamConsumerConfig superStreamConsumerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
 RabbitMQ.Stream.Client.StreamSystem.DeleteStream(string stream) -> System.Threading.Tasks.Task
@@ -913,7 +914,6 @@ RabbitMQ.Stream.Client.StreamSystem.IsClosed.get -> bool
 RabbitMQ.Stream.Client.StreamSystem.QueryOffset(string reference, string stream) -> System.Threading.Tasks.Task<ulong>
 RabbitMQ.Stream.Client.StreamSystem.QueryPartition(string superStream) -> System.Threading.Tasks.Task<string[]>
 RabbitMQ.Stream.Client.StreamSystem.QuerySequence(string reference, string stream) -> System.Threading.Tasks.Task<ulong>
-RabbitMQ.Stream.Client.StreamSystem.RawCreateSuperStreamProducer(RabbitMQ.Stream.Client.RawSuperStreamProducerConfig rawSuperStreamProducerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 RabbitMQ.Stream.Client.StreamSystem.StreamExists(string stream) -> System.Threading.Tasks.Task<bool>
 RabbitMQ.Stream.Client.StreamSystemConfig
 RabbitMQ.Stream.Client.StreamSystemConfig.AddressResolver.get -> RabbitMQ.Stream.Client.AddressResolver

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -94,10 +94,10 @@ override RabbitMQ.Stream.Client.Hash.Murmur3.HashSize.get -> int
 override RabbitMQ.Stream.Client.Hash.Murmur3.Initialize() -> void
 override RabbitMQ.Stream.Client.LeaderLocator.ToString() -> string
 override RabbitMQ.Stream.Client.LogEventListener.Dispose() -> void
-override RabbitMQ.Stream.Client.Reliable.ReliableConsumer.Close() -> System.Threading.Tasks.Task
-override RabbitMQ.Stream.Client.Reliable.ReliableConsumer.ToString() -> string
-override RabbitMQ.Stream.Client.Reliable.ReliableProducer.Close() -> System.Threading.Tasks.Task
-override RabbitMQ.Stream.Client.Reliable.ReliableProducer.ToString() -> string
+override RabbitMQ.Stream.Client.Reliable.Consumer.Close() -> System.Threading.Tasks.Task
+override RabbitMQ.Stream.Client.Reliable.Consumer.ToString() -> string
+override RabbitMQ.Stream.Client.Reliable.Producer.Close() -> System.Threading.Tasks.Task
+override RabbitMQ.Stream.Client.Reliable.Producer.ToString() -> string
 RabbitMQ.Stream.Client.AbstractEntity
 RabbitMQ.Stream.Client.AbstractEntity.AbstractEntity() -> void
 RabbitMQ.Stream.Client.AbstractEntity.client -> RabbitMQ.Stream.Client.Client
@@ -213,7 +213,7 @@ RabbitMQ.Stream.Client.Client.QueryPartition(string superStream) -> System.Threa
 RabbitMQ.Stream.Client.Client.QueryPublisherSequence(string publisherRef, string stream) -> System.Threading.Tasks.ValueTask<RabbitMQ.Stream.Client.QueryPublisherResponse>
 RabbitMQ.Stream.Client.Client.StoreOffset(string reference, string stream, ulong offsetValue) -> System.Threading.Tasks.ValueTask<bool>
 RabbitMQ.Stream.Client.Client.StreamExists(string stream) -> System.Threading.Tasks.Task<bool>
-RabbitMQ.Stream.Client.Client.Subscribe(RabbitMQ.Stream.Client.ConsumerConfig config, ushort initialCredit, System.Collections.Generic.Dictionary<string, string> properties, System.Func<RabbitMQ.Stream.Client.Deliver, System.Threading.Tasks.Task> deliverHandler, System.Func<bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>> consumerUpdateHandler) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.SubscribeResponse)>
+RabbitMQ.Stream.Client.Client.Subscribe(RabbitMQ.Stream.Client.RawConsumerConfig config, ushort initialCredit, System.Collections.Generic.Dictionary<string, string> properties, System.Func<RabbitMQ.Stream.Client.Deliver, System.Threading.Tasks.Task> deliverHandler, System.Func<bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>> consumerUpdateHandler) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.SubscribeResponse)>
 RabbitMQ.Stream.Client.Client.Subscribe(string stream, RabbitMQ.Stream.Client.IOffsetType offsetType, ushort initialCredit, System.Collections.Generic.Dictionary<string, string> properties, System.Func<RabbitMQ.Stream.Client.Deliver, System.Threading.Tasks.Task> deliverHandler, System.Func<bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>> consumerUpdateHandler = null) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.SubscribeResponse)>
 RabbitMQ.Stream.Client.Client.Unsubscribe(byte subscriptionId) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.UnsubscribeResponse>
 RabbitMQ.Stream.Client.ClientParameters
@@ -273,19 +273,6 @@ RabbitMQ.Stream.Client.Connection
 RabbitMQ.Stream.Client.Connection.Dispose() -> void
 RabbitMQ.Stream.Client.Connection.IsClosed.get -> bool
 RabbitMQ.Stream.Client.Connection.Write<T>(T command) -> System.Threading.Tasks.ValueTask<bool>
-RabbitMQ.Stream.Client.Consumer
-RabbitMQ.Stream.Client.Consumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
-RabbitMQ.Stream.Client.Consumer.Dispose() -> void
-RabbitMQ.Stream.Client.Consumer.StoreOffset(ulong offset) -> System.Threading.Tasks.Task
-RabbitMQ.Stream.Client.ConsumerConfig
-RabbitMQ.Stream.Client.ConsumerConfig.MessageHandler.get -> System.Func<RabbitMQ.Stream.Client.Consumer, RabbitMQ.Stream.Client.MessageContext, RabbitMQ.Stream.Client.Message, System.Threading.Tasks.Task>
-RabbitMQ.Stream.Client.ConsumerConfig.MessageHandler.set -> void
-RabbitMQ.Stream.Client.ConsumerConfig.MetadataHandler.get -> System.Action<RabbitMQ.Stream.Client.MetaDataUpdate>
-RabbitMQ.Stream.Client.ConsumerConfig.MetadataHandler.set -> void
-RabbitMQ.Stream.Client.ConsumerConfig.OffsetSpec.get -> RabbitMQ.Stream.Client.IOffsetType
-RabbitMQ.Stream.Client.ConsumerConfig.OffsetSpec.set -> void
-RabbitMQ.Stream.Client.ConsumerConfig.Stream.get -> string
-RabbitMQ.Stream.Client.ConsumerConfig.Stream.set -> void
 RabbitMQ.Stream.Client.ConsumerUpdateQueryResponse
 RabbitMQ.Stream.Client.ConsumerUpdateQueryResponse.ConsumerUpdateQueryResponse() -> void
 RabbitMQ.Stream.Client.ConsumerUpdateQueryResponse.CorrelationId.get -> uint
@@ -439,7 +426,6 @@ RabbitMQ.Stream.Client.IOffsetType.OffsetType.get -> RabbitMQ.Stream.Client.Offs
 RabbitMQ.Stream.Client.IOffsetType.Size.get -> int
 RabbitMQ.Stream.Client.IOffsetType.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.IProducer
-RabbitMQ.Stream.Client.IProducer.BatchSend(System.Collections.Generic.List<(ulong, RabbitMQ.Stream.Client.Message)> messages) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Stream.Client.IProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.IProducer.ConfirmFrames.get -> int
 RabbitMQ.Stream.Client.IProducer.Dispose() -> void
@@ -449,6 +435,7 @@ RabbitMQ.Stream.Client.IProducer.IsOpen() -> bool
 RabbitMQ.Stream.Client.IProducer.MessagesSent.get -> int
 RabbitMQ.Stream.Client.IProducer.PendingCount.get -> int
 RabbitMQ.Stream.Client.IProducer.PublishCommandsSent.get -> int
+RabbitMQ.Stream.Client.IProducer.Send(System.Collections.Generic.List<(ulong, RabbitMQ.Stream.Client.Message)> messages) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Stream.Client.IProducer.Send(ulong publishingId, RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Stream.Client.IProducer.Send(ulong publishingId, System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> subEntryMessages, RabbitMQ.Stream.Client.CompressionType compressionType) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Stream.Client.IProducerConfig
@@ -621,28 +608,6 @@ RabbitMQ.Stream.Client.PeerPropertiesResponse.ResponseCode.get -> ushort
 RabbitMQ.Stream.Client.PeerPropertiesResponse.SizeNeeded.get -> int
 RabbitMQ.Stream.Client.PeerPropertiesResponse.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.PooledTaskSource<T>
-RabbitMQ.Stream.Client.Producer
-RabbitMQ.Stream.Client.Producer.BatchSend(System.Collections.Generic.List<(ulong, RabbitMQ.Stream.Client.Message)> messages) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Stream.Client.Producer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
-RabbitMQ.Stream.Client.Producer.ConfirmFrames.get -> int
-RabbitMQ.Stream.Client.Producer.Dispose() -> void
-RabbitMQ.Stream.Client.Producer.GetLastPublishingId() -> System.Threading.Tasks.Task<ulong>
-RabbitMQ.Stream.Client.Producer.IncomingFrames.get -> int
-RabbitMQ.Stream.Client.Producer.IsOpen() -> bool
-RabbitMQ.Stream.Client.Producer.MessagesSent.get -> int
-RabbitMQ.Stream.Client.Producer.PendingCount.get -> int
-RabbitMQ.Stream.Client.Producer.PublishCommandsSent.get -> int
-RabbitMQ.Stream.Client.Producer.Send(ulong publishingId, RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Stream.Client.Producer.Send(ulong publishingId, System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> subEntryMessages, RabbitMQ.Stream.Client.CompressionType compressionType) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Stream.Client.ProducerConfig
-RabbitMQ.Stream.Client.ProducerConfig.ConfirmHandler.get -> System.Action<RabbitMQ.Stream.Client.Confirmation>
-RabbitMQ.Stream.Client.ProducerConfig.ConfirmHandler.set -> void
-RabbitMQ.Stream.Client.ProducerConfig.ConnectionClosedHandler.get -> System.Func<string, System.Threading.Tasks.Task>
-RabbitMQ.Stream.Client.ProducerConfig.ConnectionClosedHandler.set -> void
-RabbitMQ.Stream.Client.ProducerConfig.MetadataHandler.get -> System.Action<RabbitMQ.Stream.Client.MetaDataUpdate>
-RabbitMQ.Stream.Client.ProducerConfig.MetadataHandler.set -> void
-RabbitMQ.Stream.Client.ProducerConfig.Stream.get -> string
-RabbitMQ.Stream.Client.ProducerConfig.Stream.set -> void
 RabbitMQ.Stream.Client.ProtocolException
 RabbitMQ.Stream.Client.ProtocolException.ProtocolException(string s) -> void
 RabbitMQ.Stream.Client.Publish
@@ -691,6 +656,61 @@ RabbitMQ.Stream.Client.QueryPublisherResponse.ResponseCode.get -> RabbitMQ.Strea
 RabbitMQ.Stream.Client.QueryPublisherResponse.Sequence.get -> ulong
 RabbitMQ.Stream.Client.QueryPublisherResponse.SizeNeeded.get -> int
 RabbitMQ.Stream.Client.QueryPublisherResponse.Write(System.Span<byte> span) -> int
+RabbitMQ.Stream.Client.RawConsumer
+RabbitMQ.Stream.Client.RawConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+RabbitMQ.Stream.Client.RawConsumer.Dispose() -> void
+RabbitMQ.Stream.Client.RawConsumer.StoreOffset(ulong offset) -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.RawConsumerConfig
+RabbitMQ.Stream.Client.RawConsumerConfig.MessageHandler.get -> System.Func<RabbitMQ.Stream.Client.RawConsumer, RabbitMQ.Stream.Client.MessageContext, RabbitMQ.Stream.Client.Message, System.Threading.Tasks.Task>
+RabbitMQ.Stream.Client.RawConsumerConfig.MessageHandler.set -> void
+RabbitMQ.Stream.Client.RawConsumerConfig.MetadataHandler.get -> System.Action<RabbitMQ.Stream.Client.MetaDataUpdate>
+RabbitMQ.Stream.Client.RawConsumerConfig.MetadataHandler.set -> void
+RabbitMQ.Stream.Client.RawConsumerConfig.OffsetSpec.get -> RabbitMQ.Stream.Client.IOffsetType
+RabbitMQ.Stream.Client.RawConsumerConfig.OffsetSpec.set -> void
+RabbitMQ.Stream.Client.RawConsumerConfig.RawConsumerConfig(string stream) -> void
+RabbitMQ.Stream.Client.RawConsumerConfig.Stream.get -> string
+RabbitMQ.Stream.Client.RawProducer
+RabbitMQ.Stream.Client.RawProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+RabbitMQ.Stream.Client.RawProducer.ConfirmFrames.get -> int
+RabbitMQ.Stream.Client.RawProducer.Dispose() -> void
+RabbitMQ.Stream.Client.RawProducer.GetLastPublishingId() -> System.Threading.Tasks.Task<ulong>
+RabbitMQ.Stream.Client.RawProducer.IncomingFrames.get -> int
+RabbitMQ.Stream.Client.RawProducer.IsOpen() -> bool
+RabbitMQ.Stream.Client.RawProducer.MessagesSent.get -> int
+RabbitMQ.Stream.Client.RawProducer.PendingCount.get -> int
+RabbitMQ.Stream.Client.RawProducer.PublishCommandsSent.get -> int
+RabbitMQ.Stream.Client.RawProducer.Send(System.Collections.Generic.List<(ulong, RabbitMQ.Stream.Client.Message)> messages) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.RawProducer.Send(ulong publishingId, RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.RawProducer.Send(ulong publishingId, System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> subEntryMessages, RabbitMQ.Stream.Client.CompressionType compressionType) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.RawProducerConfig
+RabbitMQ.Stream.Client.RawProducerConfig.ConfirmHandler.get -> System.Action<RabbitMQ.Stream.Client.Confirmation>
+RabbitMQ.Stream.Client.RawProducerConfig.ConfirmHandler.set -> void
+RabbitMQ.Stream.Client.RawProducerConfig.ConnectionClosedHandler.get -> System.Func<string, System.Threading.Tasks.Task>
+RabbitMQ.Stream.Client.RawProducerConfig.ConnectionClosedHandler.set -> void
+RabbitMQ.Stream.Client.RawProducerConfig.MetadataHandler.get -> System.Action<RabbitMQ.Stream.Client.MetaDataUpdate>
+RabbitMQ.Stream.Client.RawProducerConfig.MetadataHandler.set -> void
+RabbitMQ.Stream.Client.RawProducerConfig.RawProducerConfig(string stream) -> void
+RabbitMQ.Stream.Client.RawProducerConfig.Stream.get -> string
+RabbitMQ.Stream.Client.RawSuperStreamProducer
+RabbitMQ.Stream.Client.RawSuperStreamProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+RabbitMQ.Stream.Client.RawSuperStreamProducer.ConfirmFrames.get -> int
+RabbitMQ.Stream.Client.RawSuperStreamProducer.Dispose() -> void
+RabbitMQ.Stream.Client.RawSuperStreamProducer.GetLastPublishingId() -> System.Threading.Tasks.Task<ulong>
+RabbitMQ.Stream.Client.RawSuperStreamProducer.IncomingFrames.get -> int
+RabbitMQ.Stream.Client.RawSuperStreamProducer.IsOpen() -> bool
+RabbitMQ.Stream.Client.RawSuperStreamProducer.MessagesSent.get -> int
+RabbitMQ.Stream.Client.RawSuperStreamProducer.PendingCount.get -> int
+RabbitMQ.Stream.Client.RawSuperStreamProducer.PublishCommandsSent.get -> int
+RabbitMQ.Stream.Client.RawSuperStreamProducer.Send(System.Collections.Generic.List<(ulong, RabbitMQ.Stream.Client.Message)> messages) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.RawSuperStreamProducer.Send(ulong publishingId, RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.RawSuperStreamProducer.Send(ulong publishingId, System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> subEntryMessages, RabbitMQ.Stream.Client.CompressionType compressionType) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.RawSuperStreamProducerConfig
+RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.ConfirmHandler.get -> System.Action<(string, RabbitMQ.Stream.Client.Confirmation)>
+RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.ConfirmHandler.set -> void
+RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RawSuperStreamProducerConfig(string superStream) -> void
+RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.Routing.get -> System.Func<RabbitMQ.Stream.Client.Message, string>
+RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.Routing.set -> void
+RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.SuperStream.get -> string
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.AddUnConfirmedMessage(ulong publishingId, RabbitMQ.Stream.Client.Message message) -> void
 RabbitMQ.Stream.Client.Reliable.ConfirmationPipe.AddUnConfirmedMessage(ulong publishingId, System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages) -> void
@@ -708,10 +728,27 @@ RabbitMQ.Stream.Client.Reliable.ConfirmationStatus.PublisherDoesNotExist = 18 ->
 RabbitMQ.Stream.Client.Reliable.ConfirmationStatus.StreamNotAvailable = 6 -> RabbitMQ.Stream.Client.Reliable.ConfirmationStatus
 RabbitMQ.Stream.Client.Reliable.ConfirmationStatus.UndefinedError = 200 -> RabbitMQ.Stream.Client.Reliable.ConfirmationStatus
 RabbitMQ.Stream.Client.Reliable.ConfirmationStatus.WaitForConfirmation = 0 -> RabbitMQ.Stream.Client.Reliable.ConfirmationStatus
+RabbitMQ.Stream.Client.Reliable.Consumer
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.ClientProvidedName.get -> string
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.ClientProvidedName.set -> void
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.ConsumerConfig(RabbitMQ.Stream.Client.StreamSystem streamSystem, string stream) -> void
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.ConsumerUpdateListener.get -> System.Func<string, string, bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>>
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.ConsumerUpdateListener.set -> void
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.IsSingleActiveConsumer.get -> bool
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.IsSingleActiveConsumer.set -> void
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.IsSuperStream.get -> bool
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.IsSuperStream.set -> void
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.MessageHandler.get -> System.Func<string, RabbitMQ.Stream.Client.RawConsumer, RabbitMQ.Stream.Client.MessageContext, RabbitMQ.Stream.Client.Message, System.Threading.Tasks.Task>
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.MessageHandler.set -> void
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.OffsetSpec.get -> RabbitMQ.Stream.Client.IOffsetType
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.OffsetSpec.set -> void
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.Reference.get -> string
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.Reference.set -> void
 RabbitMQ.Stream.Client.Reliable.ConsumerFactory
 RabbitMQ.Stream.Client.Reliable.ConsumerFactory.ConsumerFactory() -> void
 RabbitMQ.Stream.Client.Reliable.ConsumerFactory.CreateConsumer(bool boot) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
-RabbitMQ.Stream.Client.Reliable.ConsumerFactory._reliableConsumerConfig -> RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig
+RabbitMQ.Stream.Client.Reliable.ConsumerFactory._consumerConfig -> RabbitMQ.Stream.Client.Reliable.ConsumerConfig
 RabbitMQ.Stream.Client.Reliable.IReconnectStrategy
 RabbitMQ.Stream.Client.Reliable.IReconnectStrategy.WhenConnected(string connectionInfo) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Stream.Client.Reliable.IReconnectStrategy.WhenDisconnected(string connectionInfo) -> System.Threading.Tasks.ValueTask<bool>
@@ -723,11 +760,29 @@ RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.MessagesConfirmation() -> v
 RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.PublishingId.get -> ulong
 RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.Status.get -> RabbitMQ.Stream.Client.Reliable.ConfirmationStatus
 RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.Stream.get -> string
+RabbitMQ.Stream.Client.Reliable.Producer
+RabbitMQ.Stream.Client.Reliable.Producer.Send(RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.Reliable.Producer.Send(System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.Reliable.Producer.Send(System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages, RabbitMQ.Stream.Client.CompressionType compressionType) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.Reliable.ProducerConfig
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.ClientProvidedName.get -> string
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.ClientProvidedName.set -> void
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.ConfirmationHandler.get -> System.Func<RabbitMQ.Stream.Client.Reliable.MessagesConfirmation, System.Threading.Tasks.Task>
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.ConfirmationHandler.init -> void
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.MaxInFlight.get -> int
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.MaxInFlight.set -> void
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.ProducerConfig(RabbitMQ.Stream.Client.StreamSystem streamSystem, string stream) -> void
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.get -> string
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.set -> void
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.SuperStreamConfig.get -> RabbitMQ.Stream.Client.Reliable.SuperStreamConfig
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.SuperStreamConfig.set -> void
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.TimeoutMessageAfter.get -> System.TimeSpan
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.TimeoutMessageAfter.init -> void
 RabbitMQ.Stream.Client.Reliable.ProducerFactory
 RabbitMQ.Stream.Client.Reliable.ProducerFactory.CreateProducer() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 RabbitMQ.Stream.Client.Reliable.ProducerFactory.ProducerFactory() -> void
 RabbitMQ.Stream.Client.Reliable.ProducerFactory._confirmationPipe -> RabbitMQ.Stream.Client.Reliable.ConfirmationPipe
-RabbitMQ.Stream.Client.Reliable.ProducerFactory._reliableProducerConfig -> RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig
+RabbitMQ.Stream.Client.Reliable.ProducerFactory._producerConfig -> RabbitMQ.Stream.Client.Reliable.ProducerConfig
 RabbitMQ.Stream.Client.Reliable.ReliableBase
 RabbitMQ.Stream.Client.Reliable.ReliableBase.IsOpen() -> bool
 RabbitMQ.Stream.Client.Reliable.ReliableBase.ReliableBase() -> void
@@ -737,43 +792,9 @@ RabbitMQ.Stream.Client.Reliable.ReliableBase._isOpen -> bool
 RabbitMQ.Stream.Client.Reliable.ReliableConfig
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.ReconnectStrategy.get -> RabbitMQ.Stream.Client.Reliable.IReconnectStrategy
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.ReconnectStrategy.set -> void
+RabbitMQ.Stream.Client.Reliable.ReliableConfig.ReliableConfig(RabbitMQ.Stream.Client.StreamSystem streamSystem, string stream) -> void
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.Stream.get -> string
-RabbitMQ.Stream.Client.Reliable.ReliableConfig.Stream.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.StreamSystem.get -> RabbitMQ.Stream.Client.StreamSystem
-RabbitMQ.Stream.Client.Reliable.ReliableConfig.StreamSystem.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableConsumer
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.ClientProvidedName.get -> string
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.ClientProvidedName.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.ConsumerUpdateListener.get -> System.Func<string, string, bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>>
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.ConsumerUpdateListener.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.IsSingleActiveConsumer.get -> bool
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.IsSingleActiveConsumer.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.IsSuperStream.get -> bool
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.IsSuperStream.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.MessageHandler.get -> System.Func<string, RabbitMQ.Stream.Client.Consumer, RabbitMQ.Stream.Client.MessageContext, RabbitMQ.Stream.Client.Message, System.Threading.Tasks.Task>
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.MessageHandler.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.OffsetSpec.get -> RabbitMQ.Stream.Client.IOffsetType
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.OffsetSpec.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.Reference.get -> string
-RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig.Reference.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableProducer
-RabbitMQ.Stream.Client.Reliable.ReliableProducer.BatchSend(System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Stream.Client.Reliable.ReliableProducer.Send(RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Stream.Client.Reliable.ReliableProducer.Send(System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages, RabbitMQ.Stream.Client.CompressionType compressionType) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ClientProvidedName.get -> string
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ClientProvidedName.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ConfirmationHandler.get -> System.Func<RabbitMQ.Stream.Client.Reliable.MessagesConfirmation, System.Threading.Tasks.Task>
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.ConfirmationHandler.init -> void
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.MaxInFlight.get -> int
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.MaxInFlight.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.Reference.get -> string
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.Reference.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.SuperStreamConfig.get -> RabbitMQ.Stream.Client.Reliable.SuperStreamConfig
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.SuperStreamConfig.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.TimeoutMessageAfter.get -> System.TimeSpan
-RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig.TimeoutMessageAfter.init -> void
 RabbitMQ.Stream.Client.Reliable.SuperStreamConfig
 RabbitMQ.Stream.Client.Reliable.SuperStreamConfig.Enabled.get -> bool
 RabbitMQ.Stream.Client.Reliable.SuperStreamConfig.Enabled.init -> void
@@ -883,16 +904,16 @@ RabbitMQ.Stream.Client.StreamSpec.Name.init -> void
 RabbitMQ.Stream.Client.StreamSpec.StreamSpec(string Name) -> void
 RabbitMQ.Stream.Client.StreamSystem
 RabbitMQ.Stream.Client.StreamSystem.Close() -> System.Threading.Tasks.Task
-RabbitMQ.Stream.Client.StreamSystem.CreateConsumer(RabbitMQ.Stream.Client.ConsumerConfig consumerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
-RabbitMQ.Stream.Client.StreamSystem.CreateProducer(RabbitMQ.Stream.Client.ProducerConfig producerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
+RabbitMQ.Stream.Client.StreamSystem.CreateRawConsumer(RabbitMQ.Stream.Client.RawConsumerConfig rawConsumerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
+RabbitMQ.Stream.Client.StreamSystem.CreateRawProducer(RabbitMQ.Stream.Client.RawProducerConfig rawProducerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 RabbitMQ.Stream.Client.StreamSystem.CreateStream(RabbitMQ.Stream.Client.StreamSpec spec) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.StreamSystem.CreateSuperStreamConsumer(RabbitMQ.Stream.Client.SuperStreamConsumerConfig superStreamConsumerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
-RabbitMQ.Stream.Client.StreamSystem.CreateSuperStreamProducer(RabbitMQ.Stream.Client.SuperStreamProducerConfig superStreamProducerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 RabbitMQ.Stream.Client.StreamSystem.DeleteStream(string stream) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.StreamSystem.IsClosed.get -> bool
 RabbitMQ.Stream.Client.StreamSystem.QueryOffset(string reference, string stream) -> System.Threading.Tasks.Task<ulong>
 RabbitMQ.Stream.Client.StreamSystem.QueryPartition(string superStream) -> System.Threading.Tasks.Task<string[]>
 RabbitMQ.Stream.Client.StreamSystem.QuerySequence(string reference, string stream) -> System.Threading.Tasks.Task<ulong>
+RabbitMQ.Stream.Client.StreamSystem.RawCreateSuperStreamProducer(RabbitMQ.Stream.Client.RawSuperStreamProducerConfig rawSuperStreamProducerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 RabbitMQ.Stream.Client.StreamSystem.StreamExists(string stream) -> System.Threading.Tasks.Task<bool>
 RabbitMQ.Stream.Client.StreamSystemConfig
 RabbitMQ.Stream.Client.StreamSystemConfig.AddressResolver.get -> RabbitMQ.Stream.Client.AddressResolver
@@ -934,32 +955,12 @@ RabbitMQ.Stream.Client.SuperStreamConsumer.Close() -> System.Threading.Tasks.Tas
 RabbitMQ.Stream.Client.SuperStreamConsumer.Dispose() -> void
 RabbitMQ.Stream.Client.SuperStreamConsumer.StoreOffset(ulong offset) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.SuperStreamConsumerConfig
-RabbitMQ.Stream.Client.SuperStreamConsumerConfig.MessageHandler.get -> System.Func<string, RabbitMQ.Stream.Client.Consumer, RabbitMQ.Stream.Client.MessageContext, RabbitMQ.Stream.Client.Message, System.Threading.Tasks.Task>
+RabbitMQ.Stream.Client.SuperStreamConsumerConfig.MessageHandler.get -> System.Func<string, RabbitMQ.Stream.Client.RawConsumer, RabbitMQ.Stream.Client.MessageContext, RabbitMQ.Stream.Client.Message, System.Threading.Tasks.Task>
 RabbitMQ.Stream.Client.SuperStreamConsumerConfig.MessageHandler.set -> void
 RabbitMQ.Stream.Client.SuperStreamConsumerConfig.OffsetSpec.get -> System.Collections.Concurrent.ConcurrentDictionary<string, RabbitMQ.Stream.Client.IOffsetType>
 RabbitMQ.Stream.Client.SuperStreamConsumerConfig.OffsetSpec.set -> void
 RabbitMQ.Stream.Client.SuperStreamConsumerConfig.SuperStream.get -> string
 RabbitMQ.Stream.Client.SuperStreamConsumerConfig.SuperStream.set -> void
-RabbitMQ.Stream.Client.SuperStreamProducer
-RabbitMQ.Stream.Client.SuperStreamProducer.BatchSend(System.Collections.Generic.List<(ulong, RabbitMQ.Stream.Client.Message)> messages) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Stream.Client.SuperStreamProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
-RabbitMQ.Stream.Client.SuperStreamProducer.ConfirmFrames.get -> int
-RabbitMQ.Stream.Client.SuperStreamProducer.Dispose() -> void
-RabbitMQ.Stream.Client.SuperStreamProducer.GetLastPublishingId() -> System.Threading.Tasks.Task<ulong>
-RabbitMQ.Stream.Client.SuperStreamProducer.IncomingFrames.get -> int
-RabbitMQ.Stream.Client.SuperStreamProducer.IsOpen() -> bool
-RabbitMQ.Stream.Client.SuperStreamProducer.MessagesSent.get -> int
-RabbitMQ.Stream.Client.SuperStreamProducer.PendingCount.get -> int
-RabbitMQ.Stream.Client.SuperStreamProducer.PublishCommandsSent.get -> int
-RabbitMQ.Stream.Client.SuperStreamProducer.Send(ulong publishingId, RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Stream.Client.SuperStreamProducer.Send(ulong publishingId, System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> subEntryMessages, RabbitMQ.Stream.Client.CompressionType compressionType) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Stream.Client.SuperStreamProducerConfig
-RabbitMQ.Stream.Client.SuperStreamProducerConfig.ConfirmHandler.get -> System.Action<(string, RabbitMQ.Stream.Client.Confirmation)>
-RabbitMQ.Stream.Client.SuperStreamProducerConfig.ConfirmHandler.set -> void
-RabbitMQ.Stream.Client.SuperStreamProducerConfig.Routing.get -> System.Func<RabbitMQ.Stream.Client.Message, string>
-RabbitMQ.Stream.Client.SuperStreamProducerConfig.Routing.set -> void
-RabbitMQ.Stream.Client.SuperStreamProducerConfig.SuperStream.get -> string
-RabbitMQ.Stream.Client.SuperStreamProducerConfig.SuperStream.set -> void
 RabbitMQ.Stream.Client.TuneRequest
 RabbitMQ.Stream.Client.TuneRequest.FrameMax.get -> uint
 RabbitMQ.Stream.Client.TuneRequest.Heartbeat.get -> uint
@@ -1002,17 +1003,18 @@ static RabbitMQ.Stream.Client.Client.Create(RabbitMQ.Stream.Client.ClientParamet
 static RabbitMQ.Stream.Client.CompressionHelper.Compress(System.Collections.Generic.List<RabbitMQ.Stream.Client.Message> messages, RabbitMQ.Stream.Client.CompressionType compressionType) -> RabbitMQ.Stream.Client.ICompressionCodec
 static RabbitMQ.Stream.Client.CompressionHelper.UnCompress(RabbitMQ.Stream.Client.CompressionType compressionType, System.Buffers.ReadOnlySequence<byte> source, uint dataLen, uint unCompressedDataSize) -> System.Buffers.ReadOnlySequence<byte>
 static RabbitMQ.Stream.Client.Connection.Create(System.Net.EndPoint endpoint, System.Func<System.Memory<byte>, System.Threading.Tasks.Task> commandCallback, System.Func<string, System.Threading.Tasks.Task> closedCallBack, RabbitMQ.Stream.Client.SslOption sslOption) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Connection>
-static RabbitMQ.Stream.Client.Consumer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.ConsumerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
 static RabbitMQ.Stream.Client.LeaderLocator.ClientLocal.get -> RabbitMQ.Stream.Client.LeaderLocator
 static RabbitMQ.Stream.Client.LeaderLocator.LeastLeaders.get -> RabbitMQ.Stream.Client.LeaderLocator
 static RabbitMQ.Stream.Client.LeaderLocator.Random.get -> RabbitMQ.Stream.Client.LeaderLocator
 static RabbitMQ.Stream.Client.Message.From(System.Buffers.ReadOnlySequence<byte> amqpData) -> RabbitMQ.Stream.Client.Message
 static RabbitMQ.Stream.Client.PooledTaskSource<T>.Rent() -> RabbitMQ.Stream.Client.ManualResetValueTaskSource<T>
 static RabbitMQ.Stream.Client.PooledTaskSource<T>.Return(RabbitMQ.Stream.Client.ManualResetValueTaskSource<T> task) -> void
-static RabbitMQ.Stream.Client.Producer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.ProducerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 static RabbitMQ.Stream.Client.Publish.Version.get -> byte
-static RabbitMQ.Stream.Client.Reliable.ReliableConsumer.CreateReliableConsumer(RabbitMQ.Stream.Client.Reliable.ReliableConsumerConfig reliableConsumerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.ReliableConsumer>
-static RabbitMQ.Stream.Client.Reliable.ReliableProducer.CreateReliableProducer(RabbitMQ.Stream.Client.Reliable.ReliableProducerConfig reliableProducerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.ReliableProducer>
+static RabbitMQ.Stream.Client.RawConsumer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.RawConsumerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
+static RabbitMQ.Stream.Client.RawProducer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.RawProducerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
+static RabbitMQ.Stream.Client.RawSuperStreamProducer.Create(RabbitMQ.Stream.Client.RawSuperStreamProducerConfig rawSuperStreamProducerConfig, System.Collections.Generic.IDictionary<string, RabbitMQ.Stream.Client.StreamInfo> streamInfos, RabbitMQ.Stream.Client.ClientParameters clientParameters) -> RabbitMQ.Stream.Client.IProducer
+static RabbitMQ.Stream.Client.Reliable.Consumer.Create(RabbitMQ.Stream.Client.Reliable.ConsumerConfig consumerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.Consumer>
+static RabbitMQ.Stream.Client.Reliable.Producer.Create(RabbitMQ.Stream.Client.Reliable.ProducerConfig producerConfig) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.Producer>
 static RabbitMQ.Stream.Client.RoutingHelper<T>.LookupLeaderConnection(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.StreamInfo metaDataInfo) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IClient>
 static RabbitMQ.Stream.Client.RoutingHelper<T>.LookupRandomConnection(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.StreamInfo metaDataInfo) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IClient>
 static RabbitMQ.Stream.Client.StreamCompressionCodecs.GetCompressionCodec(RabbitMQ.Stream.Client.CompressionType compressionType) -> RabbitMQ.Stream.Client.ICompressionCodec
@@ -1021,5 +1023,4 @@ static RabbitMQ.Stream.Client.StreamCompressionCodecs.UnRegisterCodec(RabbitMQ.S
 static RabbitMQ.Stream.Client.StreamSystem.Create(RabbitMQ.Stream.Client.StreamSystemConfig config) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.StreamSystem>
 static RabbitMQ.Stream.Client.SubEntryPublish.Version.get -> byte
 static RabbitMQ.Stream.Client.SuperStreamConsumer.Create(RabbitMQ.Stream.Client.SuperStreamConsumerConfig superStreamConsumerConfig, System.Collections.Generic.IDictionary<string, RabbitMQ.Stream.Client.StreamInfo> streamInfos, RabbitMQ.Stream.Client.ClientParameters clientParameters) -> RabbitMQ.Stream.Client.IConsumer
-static RabbitMQ.Stream.Client.SuperStreamProducer.Create(RabbitMQ.Stream.Client.SuperStreamProducerConfig superStreamProducerConfig, System.Collections.Generic.IDictionary<string, RabbitMQ.Stream.Client.StreamInfo> streamInfos, RabbitMQ.Stream.Client.ClientParameters clientParameters) -> RabbitMQ.Stream.Client.IProducer
 static RabbitMQ.Stream.Client.Version.VersionString.get -> string

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -34,8 +34,18 @@ namespace RabbitMQ.Stream.Client
         public Func<bool, Task<IOffsetType>> ConsumerUpdateHandler { get; }
     }
 
-    public record ConsumerConfig : IConsumerConfig
+    public record RawConsumerConfig : IConsumerConfig
     {
+        public RawConsumerConfig(string stream)
+        {
+            if (string.IsNullOrWhiteSpace(stream))
+            {
+                throw new ArgumentException("Stream cannot be null or whitespace.", nameof(stream));
+            }
+
+            Stream = stream;
+        }
+
         internal void Validate()
         {
             if (IsSingleActiveConsumer && (Reference == null || Reference.Trim() == string.Empty))
@@ -48,19 +58,19 @@ namespace RabbitMQ.Stream.Client
 
         // stream name where the consumer will consume the messages.
         // stream must exist before the consumer is created.
-        public string Stream { get; set; }
-        public Func<Consumer, MessageContext, Message, Task> MessageHandler { get; set; }
+        public string Stream { get; }
+        public Func<RawConsumer, MessageContext, Message, Task> MessageHandler { get; set; }
 
         public Action<MetaDataUpdate> MetadataHandler { get; set; } = _ => { };
     }
 
-    public class Consumer : AbstractEntity, IConsumer, IDisposable
+    public class RawConsumer : AbstractEntity, IConsumer, IDisposable
     {
         private bool _disposed;
-        private readonly ConsumerConfig config;
+        private readonly RawConsumerConfig config;
         private byte subscriberId;
 
-        private Consumer(Client client, ConsumerConfig config)
+        private RawConsumer(Client client, RawConsumerConfig config)
         {
             this.client = client;
             this.config = config;
@@ -86,11 +96,11 @@ namespace RabbitMQ.Stream.Client
         }
 
         public static async Task<IConsumer> Create(ClientParameters clientParameters,
-            ConsumerConfig config,
+            RawConsumerConfig config,
             StreamInfo metaStreamInfo)
         {
             var client = await RoutingHelper<Routing>.LookupRandomConnection(clientParameters, metaStreamInfo);
-            var consumer = new Consumer((Client)client, config);
+            var consumer = new RawConsumer((Client)client, config);
             await consumer.Init();
             return consumer;
         }

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -59,6 +59,7 @@ namespace RabbitMQ.Stream.Client
         // stream name where the consumer will consume the messages.
         // stream must exist before the consumer is created.
         public string Stream { get; }
+
         public Func<RawConsumer, MessageContext, Message, Task> MessageHandler { get; set; }
 
         public Action<MetaDataUpdate> MetadataHandler { get; set; } = _ => { };

--- a/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
@@ -16,9 +16,8 @@ namespace RabbitMQ.Stream.Client;
 /// <summary>
 /// RawSuperStreamProducer is a producer that can send messages to multiple streams.
 /// Super Stream is available in RabbitMQ 3.11.0 and later.
-/// SuperStreamProducer is actually an abstraction over multiple Producers.
-/// It does not contain any connection or state, it is just a way to send messages 
-/// to multiple streams using multi producers.
+/// See https://rabbitmq.com/streams.html#super-streams for more information.
+///
 /// When a message is sent to a stream, the producer will be selected based on the stream name and the partition key.
 /// SuperStreamProducer uses lazy initialization for the producers, when it starts there are no producers until the first message is sent.
 /// </summary>
@@ -208,7 +207,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
     }
 
     //<summary>
-    /// Returns MAX from the LastPublishingId for all the producers
+    /// Returns lower from the LastPublishingId for all the producers
     // </summary> 
     public Task<ulong> GetLastPublishingId()
     {

--- a/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
@@ -14,7 +14,7 @@ using RabbitMQ.Stream.Client.Hash;
 namespace RabbitMQ.Stream.Client;
 
 /// <summary>
-/// SuperStreamProducer is a producer that can send messages to multiple streams.
+/// RawSuperStreamProducer is a producer that can send messages to multiple streams.
 /// Super Stream is available in RabbitMQ 3.11.0 and later.
 /// SuperStreamProducer is actually an abstraction over multiple Producers.
 /// It does not contain any connection or state, it is just a way to send messages 
@@ -22,14 +22,14 @@ namespace RabbitMQ.Stream.Client;
 /// When a message is sent to a stream, the producer will be selected based on the stream name and the partition key.
 /// SuperStreamProducer uses lazy initialization for the producers, when it starts there are no producers until the first message is sent.
 /// </summary>
-public class SuperStreamProducer : IProducer, IDisposable
+public class RawSuperStreamProducer : IProducer, IDisposable
 {
     private bool _disposed;
 
     // ConcurrentDictionary because the producer can be closed from another thread
     // The send operations will check if the producer exists and if not it will be created
     private readonly ConcurrentDictionary<string, IProducer> _producers = new();
-    private readonly SuperStreamProducerConfig _config;
+    private readonly RawSuperStreamProducerConfig _config;
 
     private readonly DefaultRoutingConfiguration _defaultRoutingConfiguration = new();
 
@@ -42,11 +42,10 @@ public class SuperStreamProducer : IProducer, IDisposable
     private readonly ClientParameters _clientParameters;
 
     // We need to copy the config from the super producer to the standard producer
-    private ProducerConfig FromStreamConfig(string stream)
+    private RawProducerConfig FromStreamConfig(string stream)
     {
-        return new ProducerConfig()
+        return new RawProducerConfig(stream)
         {
-            Stream = stream,
             ConfirmHandler = confirmation =>
             {
                 // The confirmation handler is routed to the super stream confirmation handler
@@ -97,7 +96,7 @@ public class SuperStreamProducer : IProducer, IDisposable
     // The producer is created on demand when a message is sent to a stream
     private async Task<IProducer> InitProducer(string stream)
     {
-        var p = await Producer.Create(_clientParameters,
+        var p = await RawProducer.Create(_clientParameters,
             FromStreamConfig(stream), _streamInfos[stream]);
         LogEventSource.Log.LogInformation($"SuperStream Producer. Producer {_config.Reference} created for Stream {stream}");
         return p;
@@ -119,7 +118,7 @@ public class SuperStreamProducer : IProducer, IDisposable
     {
         if (_disposed)
         {
-            throw new ObjectDisposedException(nameof(SuperStreamProducer));
+            throw new ObjectDisposedException(nameof(RawSuperStreamProducer));
         }
 
         var routes = _defaultRoutingConfiguration.RoutingStrategy.Route(message,
@@ -127,7 +126,7 @@ public class SuperStreamProducer : IProducer, IDisposable
         return await GetProducer(routes[0]);
     }
 
-    private SuperStreamProducer(SuperStreamProducerConfig config,
+    private RawSuperStreamProducer(RawSuperStreamProducerConfig config,
         IDictionary<string, StreamInfo> streamInfos, ClientParameters clientParameters)
     {
         _config = config;
@@ -142,7 +141,7 @@ public class SuperStreamProducer : IProducer, IDisposable
         await producer.Send(publishingId, message);
     }
 
-    public async ValueTask BatchSend(List<(ulong, Message)> messages)
+    public async ValueTask Send(List<(ulong, Message)> messages)
     {
         var aggregate = new List<(IProducer, List<(ulong, Message)>)>();
 
@@ -165,7 +164,7 @@ public class SuperStreamProducer : IProducer, IDisposable
 
         foreach (var (producer, list) in aggregate)
         {
-            await producer.BatchSend(list);
+            await producer.Send(list);
         }
     }
 
@@ -245,18 +244,28 @@ public class SuperStreamProducer : IProducer, IDisposable
     public int PublishCommandsSent => _producers.Sum(x => x.Value.PublishCommandsSent);
     public int PendingCount => _producers.Sum(x => x.Value.PendingCount);
 
-    public static IProducer Create(SuperStreamProducerConfig superStreamProducerConfig,
+    public static IProducer Create(RawSuperStreamProducerConfig rawSuperStreamProducerConfig,
         IDictionary<string, StreamInfo> streamInfos, ClientParameters clientParameters)
     {
-        return new SuperStreamProducer(superStreamProducerConfig, streamInfos, clientParameters);
+        return new RawSuperStreamProducer(rawSuperStreamProducerConfig, streamInfos, clientParameters);
     }
 }
 
-public record SuperStreamProducerConfig : IProducerConfig
+public record RawSuperStreamProducerConfig : IProducerConfig
 {
+    public RawSuperStreamProducerConfig(string superStream)
+    {
+        if (string.IsNullOrWhiteSpace(superStream))
+        {
+            throw new ArgumentException("SuperStream name cannot be null or empty", nameof(superStream));
+        }
+
+        SuperStream = superStream;
+    }
+
     // SuperStreamName. The user interacts with this it
     // In AMQP this is the exchange name
-    public string SuperStream { get; set; }
+    public string SuperStream { get; }
 
     // The routing key extractor is used to extract the routing key from the message
     // The routing key is used to route the message to a stream

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -10,8 +10,18 @@ namespace RabbitMQ.Stream.Client.Reliable;
 
 public record ConsumerConfig : ReliableConfig
 {
+    /// <summary>
+    /// Consumer reference name.
+    /// Used to identify the consumer server side when store the messages offset.
+    /// see also <see cref="StreamSystem.QueryOffset"/> to retrieve the last offset.
+    /// </summary>
     public string Reference { get; set; }
-    public string ClientProvidedName { get; set; } = "dotnet-stream-rconusmer";
+
+    // <summary>
+    // The client name used to identify the Consumer. 
+    // You can see this value on the Management UI or in the connection detail
+    // </summary>
+    public string ClientProvidedName { get; set; } = "dotnet-stream-conusmer";
 
     public Func<string, RawConsumer, MessageContext, Message, Task> MessageHandler { get; set; }
 

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -8,48 +8,52 @@ using System.Threading.Tasks;
 
 namespace RabbitMQ.Stream.Client.Reliable;
 
-public record ReliableConsumerConfig : ReliableConfig
+public record ConsumerConfig : ReliableConfig
 {
     public string Reference { get; set; }
     public string ClientProvidedName { get; set; } = "dotnet-stream-rconusmer";
 
-    public Func<string, Consumer, MessageContext, Message, Task> MessageHandler { get; set; }
+    public Func<string, RawConsumer, MessageContext, Message, Task> MessageHandler { get; set; }
 
     public bool IsSuperStream { get; set; }
     public IOffsetType OffsetSpec { get; set; } = new OffsetTypeNext();
 
     public bool IsSingleActiveConsumer { get; set; } = false;
     public Func<string, string, bool, Task<IOffsetType>> ConsumerUpdateListener { get; set; } = null;
+
+    public ConsumerConfig(StreamSystem streamSystem, string stream) : base(streamSystem, stream)
+    {
+    }
 }
 
 /// <summary>
-/// ReliableConsumer is a wrapper around the standard Consumer.
+/// Consumer is a wrapper around the standard RawConsumer.
 /// Main features are:
 /// - Auto-reconnection if the connection is dropped
 ///   Automatically restart consuming from the last offset 
-/// - Handle the Metadata Update. In case the stream is deleted ReliableProducer closes Producer/Connection.
+/// - Handle the Metadata Update. In case the stream is deleted Producer closes Producer/Connection.
 ///   Reconnect the Consumer if the stream still exists.
 /// </summary>
-public class ReliableConsumer : ConsumerFactory
+public class Consumer : ConsumerFactory
 {
     private IConsumer _consumer;
 
-    internal ReliableConsumer(ReliableConsumerConfig reliableConsumerConfig)
+    internal Consumer(ConsumerConfig consumerConfig)
     {
-        _reliableConsumerConfig = reliableConsumerConfig;
+        _consumerConfig = consumerConfig;
     }
 
-    public static async Task<ReliableConsumer> CreateReliableConsumer(ReliableConsumerConfig reliableConsumerConfig)
+    public static async Task<Consumer> Create(ConsumerConfig consumerConfig)
     {
-        var rConsumer = new ReliableConsumer(reliableConsumerConfig);
-        await rConsumer.Init(reliableConsumerConfig.ReconnectStrategy);
+        var rConsumer = new Consumer(consumerConfig);
+        await rConsumer.Init(consumerConfig.ReconnectStrategy);
         return rConsumer;
     }
 
     internal override async Task CreateNewEntity(bool boot)
     {
         _consumer = await CreateConsumer(boot);
-        await _reliableConsumerConfig.ReconnectStrategy.WhenConnected(ToString());
+        await _consumerConfig.ReconnectStrategy.WhenConnected(ToString());
     }
 
     // just close the consumer. See base/metadataupdate
@@ -77,7 +81,7 @@ public class ReliableConsumer : ConsumerFactory
 
     public override string ToString()
     {
-        return $"Consumer reference: {_reliableConsumerConfig.Reference},  " +
-               $"stream: {_reliableConsumerConfig.Stream} ";
+        return $"Consumer reference: {_consumerConfig.Reference},  " +
+               $"stream: {_consumerConfig.Stream} ";
     }
 }

--- a/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
@@ -16,12 +16,12 @@ namespace RabbitMQ.Stream.Client.Reliable;
 
 public abstract class ProducerFactory : ReliableBase
 {
-    protected ReliableProducerConfig _reliableProducerConfig;
+    protected ProducerConfig _producerConfig;
     protected ConfirmationPipe _confirmationPipe;
 
     protected async Task<IProducer> CreateProducer()
     {
-        if (_reliableProducerConfig.SuperStreamConfig is { Enabled: true })
+        if (_producerConfig.SuperStreamConfig is { Enabled: true })
         {
             return await SuperStreamProducer();
         }
@@ -31,13 +31,12 @@ public abstract class ProducerFactory : ReliableBase
 
     private async Task<IProducer> SuperStreamProducer()
     {
-        return await _reliableProducerConfig.StreamSystem.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+        return await _producerConfig.StreamSystem.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(_producerConfig.Stream)
         {
-            SuperStream = _reliableProducerConfig.Stream,
-            ClientProvidedName = _reliableProducerConfig.ClientProvidedName,
-            Reference = _reliableProducerConfig.Reference,
-            MaxInFlight = _reliableProducerConfig.MaxInFlight,
-            Routing = _reliableProducerConfig.SuperStreamConfig.Routing,
+            ClientProvidedName = _producerConfig.ClientProvidedName,
+            Reference = _producerConfig.Reference,
+            MaxInFlight = _producerConfig.MaxInFlight,
+            Routing = _producerConfig.SuperStreamConfig.Routing,
             ConfirmHandler = confirmationHandler =>
             {
                 var (stream, confirmation) = confirmationHandler;
@@ -59,12 +58,11 @@ public abstract class ProducerFactory : ReliableBase
 
     private async Task<IProducer> StandardProducer()
     {
-        return await _reliableProducerConfig.StreamSystem.CreateProducer(new ProducerConfig()
+        return await _producerConfig.StreamSystem.CreateRawProducer(new RawProducerConfig(_producerConfig.Stream)
         {
-            Stream = _reliableProducerConfig.Stream,
-            ClientProvidedName = _reliableProducerConfig.ClientProvidedName,
-            Reference = _reliableProducerConfig.Reference,
-            MaxInFlight = _reliableProducerConfig.MaxInFlight,
+            ClientProvidedName = _producerConfig.ClientProvidedName,
+            Reference = _producerConfig.Reference,
+            MaxInFlight = _producerConfig.MaxInFlight,
             MetadataHandler = update =>
             {
                 // This is Async since the MetadataHandler is called from the Socket connection thread
@@ -74,10 +72,10 @@ public abstract class ProducerFactory : ReliableBase
                 {
                     // intentionally fire & forget
                     HandleMetaDataMaybeReconnect(update.Stream,
-                        _reliableProducerConfig.StreamSystem).WaitAsync(CancellationToken.None);
+                        _producerConfig.StreamSystem).WaitAsync(CancellationToken.None);
                 });
             },
-            ConnectionClosedHandler = async _ => { await TryToReconnect(_reliableProducerConfig.ReconnectStrategy); },
+            ConnectionClosedHandler = async _ => { await TryToReconnect(_producerConfig.ReconnectStrategy); },
             ConfirmHandler = confirmation =>
             {
                 var confirmationStatus = confirmation.Code switch

--- a/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
@@ -31,7 +31,7 @@ public abstract class ProducerFactory : ReliableBase
 
     private async Task<IProducer> SuperStreamProducer()
     {
-        return await _producerConfig.StreamSystem.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(_producerConfig.Stream)
+        return await _producerConfig.StreamSystem.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(_producerConfig.Stream)
         {
             ClientProvidedName = _producerConfig.ClientProvidedName,
             Reference = _producerConfig.Reference,

--- a/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
@@ -12,8 +12,19 @@ namespace RabbitMQ.Stream.Client.Reliable;
 public record ReliableConfig
 {
     public IReconnectStrategy ReconnectStrategy { get; set; } = new BackOffReconnectStrategy();
-    public StreamSystem StreamSystem { get; set; }
-    public string Stream { get; set; }
+    public StreamSystem StreamSystem { get; }
+    public string Stream { get; }
+
+    protected ReliableConfig(StreamSystem streamSystem, string stream)
+    {
+        if (string.IsNullOrWhiteSpace(stream))
+        {
+            throw new ArgumentException("Stream cannot be null or whitespace.", nameof(stream));
+        }
+
+        Stream = stream;
+        StreamSystem = streamSystem ?? throw new ArgumentNullException(nameof(streamSystem));
+    }
 }
 
 /// <summary>

--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -120,29 +120,29 @@ namespace RabbitMQ.Stream.Client
             }
         }
 
-        public async Task<IProducer> CreateSuperStreamProducer(SuperStreamProducerConfig superStreamProducerConfig)
+        public async Task<IProducer> RawCreateSuperStreamProducer(RawSuperStreamProducerConfig rawSuperStreamProducerConfig)
         {
             await MayBeReconnectLocator();
-            if (superStreamProducerConfig.SuperStream == "")
+            if (rawSuperStreamProducerConfig.SuperStream == "")
             {
                 throw new CreateProducerException($"Super Stream name can't be empty");
             }
 
-            if (superStreamProducerConfig.MessagesBufferSize < Consts.MinBatchSize)
+            if (rawSuperStreamProducerConfig.MessagesBufferSize < Consts.MinBatchSize)
             {
                 throw new CreateProducerException(
                     $"Batch Size must be bigger than 0");
             }
 
-            if (superStreamProducerConfig.Routing == null)
+            if (rawSuperStreamProducerConfig.Routing == null)
             {
                 throw new CreateProducerException(
                     $"Routing Key Extractor must be provided");
             }
 
-            superStreamProducerConfig.Client = client;
+            rawSuperStreamProducerConfig.Client = client;
 
-            var partitions = await client.QueryPartition(superStreamProducerConfig.SuperStream);
+            var partitions = await client.QueryPartition(rawSuperStreamProducerConfig.SuperStream);
             if (partitions.ResponseCode != ResponseCode.Ok)
             {
                 throw new CreateProducerException($"producer could not be created code: {partitions.ResponseCode}");
@@ -155,9 +155,9 @@ namespace RabbitMQ.Stream.Client
                 streamInfos[partitionsStream] = metaDataResponse.StreamInfos[partitionsStream];
             }
 
-            return SuperStreamProducer.Create(superStreamProducerConfig,
+            return RawSuperStreamProducer.Create(rawSuperStreamProducerConfig,
                 streamInfos,
-                clientParameters with { ClientProvidedName = superStreamProducerConfig.ClientProvidedName });
+                clientParameters with { ClientProvidedName = rawSuperStreamProducerConfig.ClientProvidedName });
         }
 
         public async Task<string[]> QueryPartition(string superStream)
@@ -200,24 +200,19 @@ namespace RabbitMQ.Stream.Client
                 clientParameters with { ClientProvidedName = superStreamConsumerConfig.ClientProvidedName });
         }
 
-        public async Task<IProducer> CreateProducer(ProducerConfig producerConfig)
+        public async Task<IProducer> CreateRawProducer(RawProducerConfig rawProducerConfig)
         {
-            // Validate the ProducerConfig values
-            if (producerConfig.Stream == "")
-            {
-                throw new CreateProducerException($"Stream name can't be empty");
-            }
 
-            if (producerConfig.MessagesBufferSize < Consts.MinBatchSize)
+            if (rawProducerConfig.MessagesBufferSize < Consts.MinBatchSize)
             {
                 throw new CreateProducerException(
                     $"Batch Size must be bigger than 0");
             }
 
             await MayBeReconnectLocator();
-            var meta = await client.QueryMetadata(new[] { producerConfig.Stream });
+            var meta = await client.QueryMetadata(new[] { rawProducerConfig.Stream });
 
-            var metaStreamInfo = meta.StreamInfos[producerConfig.Stream];
+            var metaStreamInfo = meta.StreamInfos[rawProducerConfig.Stream];
             if (metaStreamInfo.ResponseCode != ResponseCode.Ok)
             {
                 throw new CreateProducerException($"producer could not be created code: {metaStreamInfo.ResponseCode}");
@@ -229,9 +224,9 @@ namespace RabbitMQ.Stream.Client
             {
                 await _semClientProvidedName.WaitAsync();
 
-                return await Producer.Create(
-                    clientParameters with { ClientProvidedName = producerConfig.ClientProvidedName },
-                    producerConfig, metaStreamInfo);
+                return await RawProducer.Create(
+                    clientParameters with { ClientProvidedName = rawProducerConfig.ClientProvidedName },
+                    rawProducerConfig, metaStreamInfo);
             }
             finally
             {
@@ -257,9 +252,9 @@ namespace RabbitMQ.Stream.Client
 
         private static void MaybeThrowQueryException(string reference, string stream)
         {
-            if (string.IsNullOrEmpty(reference) || string.IsNullOrEmpty(stream))
+            if (string.IsNullOrWhiteSpace(reference) || string.IsNullOrWhiteSpace(stream))
             {
-                throw new QueryException("Stream name and reference can't be empty or null");
+                throw new ArgumentException("Stream name and reference can't be empty or null");
             }
         }
 
@@ -309,11 +304,11 @@ namespace RabbitMQ.Stream.Client
             throw new DeleteStreamException($"Failed to delete stream, error code: {response.ResponseCode.ToString()}");
         }
 
-        public async Task<IConsumer> CreateConsumer(ConsumerConfig consumerConfig)
+        public async Task<IConsumer> CreateRawConsumer(RawConsumerConfig rawConsumerConfig)
         {
             await MayBeReconnectLocator();
-            var meta = await client.QueryMetadata(new[] { consumerConfig.Stream });
-            var metaStreamInfo = meta.StreamInfos[consumerConfig.Stream];
+            var meta = await client.QueryMetadata(new[] { rawConsumerConfig.Stream });
+            var metaStreamInfo = meta.StreamInfos[rawConsumerConfig.Stream];
             if (metaStreamInfo.ResponseCode != ResponseCode.Ok)
             {
                 throw new CreateConsumerException($"consumer could not be created code: {metaStreamInfo.ResponseCode}");
@@ -324,9 +319,9 @@ namespace RabbitMQ.Stream.Client
             try
             {
                 await _semClientProvidedName.WaitAsync();
-                var s = clientParameters with { ClientProvidedName = consumerConfig.ClientProvidedName };
-                return await Consumer.Create(s,
-                    consumerConfig, metaStreamInfo);
+                var s = clientParameters with { ClientProvidedName = rawConsumerConfig.ClientProvidedName };
+                return await RawConsumer.Create(s,
+                    rawConsumerConfig, metaStreamInfo);
             }
             finally
             {

--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -120,7 +120,8 @@ namespace RabbitMQ.Stream.Client
             }
         }
 
-        public async Task<IProducer> RawCreateSuperStreamProducer(RawSuperStreamProducerConfig rawSuperStreamProducerConfig)
+        public async Task<IProducer> CreateRawSuperStreamProducer(
+            RawSuperStreamProducerConfig rawSuperStreamProducerConfig)
         {
             await MayBeReconnectLocator();
             if (rawSuperStreamProducerConfig.SuperStream == "")
@@ -202,7 +203,6 @@ namespace RabbitMQ.Stream.Client
 
         public async Task<IProducer> CreateRawProducer(RawProducerConfig rawProducerConfig)
         {
-
             if (rawProducerConfig.MessagesBufferSize < Consts.MinBatchSize)
             {
                 throw new CreateProducerException(

--- a/RabbitMQ.Stream.Client/SuperStreamConsumer.cs
+++ b/RabbitMQ.Stream.Client/SuperStreamConsumer.cs
@@ -25,11 +25,10 @@ public class SuperStreamConsumer : IConsumer, IDisposable
 
     // We need to copy the config from the super consumer to the standard consumer
 
-    private ConsumerConfig FromStreamConfig(string stream)
+    private RawConsumerConfig FromStreamConfig(string stream)
     {
-        return new ConsumerConfig()
+        return new RawConsumerConfig(stream)
         {
-            Stream = stream,
             Reference = _config.Reference,
             IsSingleActiveConsumer = _config.IsSingleActiveConsumer,
             ConsumerUpdateListener = _config.ConsumerUpdateListener,
@@ -112,7 +111,7 @@ public class SuperStreamConsumer : IConsumer, IDisposable
 
     private async Task<IConsumer> InitConsumer(string stream)
     {
-        var c = await Consumer.Create(
+        var c = await RawConsumer.Create(
             _clientParameters with { ClientProvidedName = _clientParameters.ClientProvidedName },
             FromStreamConfig(stream), _streamInfos[stream]);
         LogEventSource.Log.LogInformation(
@@ -210,7 +209,7 @@ public record SuperStreamConsumerConfig : IConsumerConfig
     /// MessageHandler is called when a message is received
     /// The first parameter is the stream name from which the message is coming from
     /// </summary>
-    public Func<string, Consumer, MessageContext, Message, Task> MessageHandler { get; set; }
+    public Func<string, RawConsumer, MessageContext, Message, Task> MessageHandler { get; set; }
 
     public string SuperStream { get; set; }
 

--- a/Tests/PermissionTests.cs
+++ b/Tests/PermissionTests.cs
@@ -6,6 +6,7 @@ using System;
 using RabbitMQ.Stream.Client;
 using RabbitMQ.Stream.Client.Reliable;
 using Xunit;
+using ConsumerConfig = RabbitMQ.Stream.Client.Reliable.ConsumerConfig;
 
 namespace Tests
 {
@@ -26,53 +27,54 @@ namespace Tests
             await Assert.ThrowsAsync<CreateProducerException>(
                 async () =>
                 {
-                    await system.CreateProducer(
-                        new ProducerConfig { Reference = "producer", Stream = stream, });
+                    await system.CreateRawProducer(
+                        new RawProducerConfig(stream) { Reference = "producer" });
                 }
             );
 
             await Assert.ThrowsAsync<CreateProducerException>(
                 async () =>
                 {
-                    await ReliableProducer.CreateReliableProducer(
-                        new ReliableProducerConfig() { Stream = stream, StreamSystem = system });
+                    await Producer.Create(
+                        new ProducerConfig(system, stream));
                 }
             );
 
-            ReliableProducer reliableProducer = null;
+            Producer producer = null;
             try
             {
-                reliableProducer = await ReliableProducer.CreateReliableProducer(
-                    new ReliableProducerConfig() { Stream = stream, StreamSystem = system });
+                producer = await Producer.Create(
+                    new ProducerConfig(system, stream));
             }
             catch (Exception)
             {
                 // we already tested the Exception (CreateProducerException)
             }
+
             // here the reliableProducer must be closed due of the CreateProducerException
-            Assert.False(reliableProducer != null && reliableProducer.IsOpen());
+            Assert.False(producer != null && producer.IsOpen());
 
             await Assert.ThrowsAsync<CreateConsumerException>(
                 async () =>
                 {
-                    await system.CreateConsumer(
-                        new ConsumerConfig() { Reference = "consumer", Stream = stream, });
+                    await system.CreateRawConsumer(
+                        new RawConsumerConfig(stream) { Reference = "consumer" });
                 }
             );
 
             await Assert.ThrowsAsync<CreateConsumerException>(
                 async () =>
                 {
-                    await ReliableConsumer.CreateReliableConsumer(
-                        new ReliableConsumerConfig() { Stream = stream, StreamSystem = system });
+                    await Consumer.Create(
+                        new ConsumerConfig(system, stream));
                 }
             );
 
-            ReliableConsumer reliableConsumer = null;
+            Consumer consumer = null;
             try
             {
-                reliableConsumer = await ReliableConsumer.CreateReliableConsumer(
-                    new ReliableConsumerConfig() { Stream = stream, StreamSystem = system });
+                consumer = await Consumer.Create(
+                    new ConsumerConfig(system, stream));
             }
             catch (Exception)
             {
@@ -80,7 +82,7 @@ namespace Tests
             }
 
             // here the reliableConsumer must be closed due of the CreateConsumerException
-            Assert.False(reliableConsumer != null && reliableConsumer.IsOpen());
+            Assert.False(consumer != null && consumer.IsOpen());
 
             await system.Close();
         }

--- a/Tests/SacTests.cs
+++ b/Tests/SacTests.cs
@@ -28,14 +28,12 @@ public class SacTests
     {
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
 
-        await Assert.ThrowsAsync<ArgumentException>(() => system.CreateConsumer(new ConsumerConfig()
-        {
-            Stream = stream,
-            IsSingleActiveConsumer = true,
-        }));
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            system.CreateRawConsumer(
+                new RawConsumerConfig(stream) { IsSingleActiveConsumer = true, }));
 
-        await Assert.ThrowsAsync<ArgumentException>(() => ReliableConsumer.CreateReliableConsumer(
-            new ReliableConsumerConfig() { StreamSystem = system, Stream = stream, IsSingleActiveConsumer = true, }));
+        await Assert.ThrowsAsync<ArgumentException>(() => Consumer.Create(
+            new ConsumerConfig(system, stream) { IsSingleActiveConsumer = true, }));
 
         await system.DeleteStream(stream);
         await system.Close();
@@ -126,9 +124,8 @@ public class SacTests
 
         await SystemUtils.PublishMessages(system, stream, TotalMessages, _testOutputHelper);
         var testPassedConsumer1 = new TaskCompletionSource<int>();
-        var consumer1 = await system.CreateConsumer(new ConsumerConfig()
+        var consumer1 = await system.CreateRawConsumer(new RawConsumerConfig(stream)
         {
-            Stream = stream,
             Reference = AppName,
             OffsetSpec = offsetSpecFirstConsumer,
             IsSingleActiveConsumer = true,
@@ -147,9 +144,8 @@ public class SacTests
 
         var testPassedConsumer2 = new TaskCompletionSource<int>();
         var messagesConsumed = 0;
-        var consumer2 = await system.CreateConsumer(new ConsumerConfig()
+        var consumer2 = await system.CreateRawConsumer(new RawConsumerConfig(stream)
         {
-            Stream = stream,
             Reference = AppName,
             OffsetSpec = offsetSpecSecondConsumer,
             ConsumerUpdateListener = offsetTypeFunc,

--- a/Tests/SuperStreamConsumerTests.cs
+++ b/Tests/SuperStreamConsumerTests.cs
@@ -13,6 +13,7 @@ using RabbitMQ.Stream.Client;
 using RabbitMQ.Stream.Client.Reliable;
 using Xunit;
 using Xunit.Abstractions;
+using ConsumerConfig = RabbitMQ.Stream.Client.Reliable.ConsumerConfig;
 
 namespace Tests;
 
@@ -263,10 +264,8 @@ public class SuperStreamConsumerTests
         var system = await StreamSystem.Create(new StreamSystemConfig());
         await SystemUtils.PublishMessagesSuperStream(system, SystemUtils.InvoicesExchange, 20, "", _testOutputHelper);
         var listConsumed = new ConcurrentBag<string>();
-        var consumer = await ReliableConsumer.CreateReliableConsumer(new ReliableConsumerConfig()
+        var consumer = await Consumer.Create(new ConsumerConfig(system, SystemUtils.InvoicesExchange)
         {
-            StreamSystem = system,
-            Stream = SystemUtils.InvoicesExchange,
             OffsetSpec = new OffsetTypeFirst(),
             IsSuperStream = true,
             MessageHandler = (stream, consumer1, context, message) =>
@@ -304,16 +303,14 @@ public class SuperStreamConsumerTests
         await SystemUtils.PublishMessagesSuperStream(system, SystemUtils.InvoicesExchange, 20, "", _testOutputHelper);
         var listConsumed = new ConcurrentBag<string>();
         var reference = Guid.NewGuid().ToString();
-        var consumers = new List<ReliableConsumer>();
+        var consumers = new List<Consumer>();
 
-        async Task<ReliableConsumer> NewReliableConsumer(string refConsumer, string clientProvidedName,
+        async Task<Consumer> NewReliableConsumer(string refConsumer, string clientProvidedName,
             Func<string, string, bool, Task<IOffsetType>> consumerUpdateListener
         )
         {
-            return await ReliableConsumer.CreateReliableConsumer(new ReliableConsumerConfig()
+            return await Consumer.Create(new ConsumerConfig(system, SystemUtils.InvoicesExchange)
             {
-                StreamSystem = system,
-                Stream = SystemUtils.InvoicesExchange,
                 OffsetSpec = new OffsetTypeFirst(),
                 Reference = refConsumer,
                 ClientProvidedName = clientProvidedName,

--- a/Tests/SuperStreamProducerTests.cs
+++ b/Tests/SuperStreamProducerTests.cs
@@ -40,10 +40,10 @@ public class SuperStreamProducerTests
         var system = await StreamSystem.Create(new StreamSystemConfig());
 
         await Assert.ThrowsAsync<CreateProducerException>(() =>
-            system.CreateSuperStreamProducer(new SuperStreamProducerConfig() { SuperStream = "does-not-exist" }));
+            system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig("does-not-exist") { }));
 
-        await Assert.ThrowsAsync<CreateProducerException>(() =>
-            system.CreateSuperStreamProducer(new SuperStreamProducerConfig() { SuperStream = "" }));
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig("")));
         await system.Close();
     }
 
@@ -54,9 +54,8 @@ public class SuperStreamProducerTests
         // RoutingKeyExtractor must be set else the traffic won't be routed
         var system = await StreamSystem.Create(new StreamSystemConfig());
         await Assert.ThrowsAsync<CreateProducerException>(() =>
-            system.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+            system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
-                SuperStream = SystemUtils.InvoicesExchange,
                 Routing = null
             }));
         await system.Close();
@@ -111,9 +110,8 @@ public class SuperStreamProducerTests
         // the message should be routed to the correct stream
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
-                SuperStream = SystemUtils.InvoicesExchange,
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 Reference = "reference"
             });
@@ -154,9 +152,8 @@ public class SuperStreamProducerTests
         // The number of the messages per queue _must_ be the same as SendMessageToSuperStream test
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
-                SuperStream = SystemUtils.InvoicesExchange,
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 Reference = "reference"
             });
@@ -170,7 +167,7 @@ public class SuperStreamProducerTests
             messages.Add((i, message));
         }
 
-        await streamProducer.BatchSend(messages);
+        await streamProducer.Send(messages);
 
         SystemUtils.Wait();
         // Total messages must be 20
@@ -193,9 +190,8 @@ public class SuperStreamProducerTests
         // The number of the messages per queue _must_ be the same as SendMessageToSuperStream test
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
-                SuperStream = SystemUtils.InvoicesExchange,
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 Reference = "ref1"
             });
@@ -234,9 +230,8 @@ public class SuperStreamProducerTests
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var clientName = Guid.NewGuid().ToString();
         var streamProducer =
-            await system.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
-                SuperStream = SystemUtils.InvoicesExchange,
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 ClientProvidedName = clientName
             });
@@ -276,9 +271,8 @@ public class SuperStreamProducerTests
         // When the producer is closed it should raise ObjectDisposedException
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
-                SuperStream = SystemUtils.InvoicesExchange,
                 Routing = message1 => message1.Properties.MessageId.ToString()
             });
         Assert.True(streamProducer.IsOpen());
@@ -298,9 +292,8 @@ public class SuperStreamProducerTests
         // This test is for using and Dispose  
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
-                SuperStream = SystemUtils.InvoicesExchange,
                 Routing = message1 => message1.Properties.MessageId.ToString()
             });
         Assert.True(streamProducer.IsOpen());
@@ -324,9 +317,8 @@ public class SuperStreamProducerTests
         var confirmedList = new ConcurrentBag<(string, Confirmation)>();
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
-                SuperStream = SystemUtils.InvoicesExchange,
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 ConfirmHandler = conf =>
                 {
@@ -370,9 +362,8 @@ public class SuperStreamProducerTests
         var testPassed = new TaskCompletionSource<bool>();
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
-                SuperStream = SystemUtils.InvoicesExchange,
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 ConfirmHandler = conf =>
                 {
@@ -427,9 +418,8 @@ public class SuperStreamProducerTests
         // same scenario but with deduplication
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
-                SuperStream = SystemUtils.InvoicesExchange,
                 Routing = message1 => message1.Properties.MessageId.ToString(),
             });
         // List for the batch send 
@@ -450,7 +440,7 @@ public class SuperStreamProducerTests
             await streamProducer.Send(i, message);
         }
 
-        await streamProducer.BatchSend(batchSendMessages);
+        await streamProducer.Send(batchSendMessages);
         await streamProducer.Send(1, messagesForSubEntry, CompressionType.Gzip);
 
         SystemUtils.Wait();
@@ -473,9 +463,8 @@ public class SuperStreamProducerTests
 
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.CreateSuperStreamProducer(new SuperStreamProducerConfig()
+            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
-                SuperStream = SystemUtils.InvoicesExchange,
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 Reference = "reference"
             });
@@ -499,7 +488,7 @@ public class SuperStreamProducerTests
 
         // starting form here the number of the messages in the stream must be the same
         // the following send(s) will enable the deduplication
-        await streamProducer.BatchSend(batchSendMessages);
+        await streamProducer.Send(batchSendMessages);
         await streamProducer.Send(1, messagesForSubEntry, CompressionType.Gzip);
 
         SystemUtils.Wait();
@@ -518,10 +507,8 @@ public class SuperStreamProducerTests
     {
         SystemUtils.ResetSuperStreams();
         var system = await StreamSystem.Create(new StreamSystemConfig());
-        var streamProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
+        var streamProducer = await Producer.Create(new ProducerConfig(system, SystemUtils.InvoicesExchange)
         {
-            StreamSystem = system,
-            Stream = SystemUtils.InvoicesExchange,
             SuperStreamConfig = new SuperStreamConfig()
             {
                 Routing = message1 => message1.Properties.MessageId.ToString()
@@ -541,7 +528,7 @@ public class SuperStreamProducerTests
             batchSendMessages.Add(message);
         }
 
-        await streamProducer.BatchSend(batchSendMessages);
+        await streamProducer.Send(batchSendMessages);
         await streamProducer.Send(batchSendMessages, CompressionType.Gzip);
 
         SystemUtils.Wait();
@@ -563,10 +550,8 @@ public class SuperStreamProducerTests
         var testPassed = new TaskCompletionSource<bool>();
         var confirmedList = new ConcurrentBag<(string, Message)>();
         var system = await StreamSystem.Create(new StreamSystemConfig());
-        var streamProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
+        var streamProducer = await Producer.Create(new ProducerConfig(system, SystemUtils.InvoicesExchange)
         {
-            StreamSystem = system,
-            Stream = SystemUtils.InvoicesExchange,
             SuperStreamConfig =
                 new SuperStreamConfig() { Routing = message1 => message1.Properties.MessageId.ToString() },
             ConfirmationHandler = confirmation =>
@@ -612,10 +597,8 @@ public class SuperStreamProducerTests
         // just the reconnect mechanism
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var clientName = Guid.NewGuid().ToString();
-        var streamProducer = await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig()
+        var streamProducer = await Producer.Create(new ProducerConfig(system, SystemUtils.InvoicesExchange)
         {
-            StreamSystem = system,
-            Stream = SystemUtils.InvoicesExchange,
             SuperStreamConfig = new SuperStreamConfig()
             {
                 Routing = message1 => message1.Properties.MessageId.ToString()

--- a/Tests/SuperStreamProducerTests.cs
+++ b/Tests/SuperStreamProducerTests.cs
@@ -40,10 +40,10 @@ public class SuperStreamProducerTests
         var system = await StreamSystem.Create(new StreamSystemConfig());
 
         await Assert.ThrowsAsync<CreateProducerException>(() =>
-            system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig("does-not-exist") { }));
+            system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig("does-not-exist") { }));
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
-            system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig("")));
+            system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig("")));
         await system.Close();
     }
 
@@ -54,7 +54,7 @@ public class SuperStreamProducerTests
         // RoutingKeyExtractor must be set else the traffic won't be routed
         var system = await StreamSystem.Create(new StreamSystemConfig());
         await Assert.ThrowsAsync<CreateProducerException>(() =>
-            system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+            system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
                 Routing = null
             }));
@@ -110,7 +110,7 @@ public class SuperStreamProducerTests
         // the message should be routed to the correct stream
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 Reference = "reference"
@@ -152,7 +152,7 @@ public class SuperStreamProducerTests
         // The number of the messages per queue _must_ be the same as SendMessageToSuperStream test
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 Reference = "reference"
@@ -190,7 +190,7 @@ public class SuperStreamProducerTests
         // The number of the messages per queue _must_ be the same as SendMessageToSuperStream test
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 Reference = "ref1"
@@ -230,7 +230,7 @@ public class SuperStreamProducerTests
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var clientName = Guid.NewGuid().ToString();
         var streamProducer =
-            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 ClientProvidedName = clientName
@@ -271,7 +271,7 @@ public class SuperStreamProducerTests
         // When the producer is closed it should raise ObjectDisposedException
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
                 Routing = message1 => message1.Properties.MessageId.ToString()
             });
@@ -292,7 +292,7 @@ public class SuperStreamProducerTests
         // This test is for using and Dispose  
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
                 Routing = message1 => message1.Properties.MessageId.ToString()
             });
@@ -317,7 +317,7 @@ public class SuperStreamProducerTests
         var confirmedList = new ConcurrentBag<(string, Confirmation)>();
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 ConfirmHandler = conf =>
@@ -362,7 +362,7 @@ public class SuperStreamProducerTests
         var testPassed = new TaskCompletionSource<bool>();
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 ConfirmHandler = conf =>
@@ -418,7 +418,7 @@ public class SuperStreamProducerTests
         // same scenario but with deduplication
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
                 Routing = message1 => message1.Properties.MessageId.ToString(),
             });
@@ -463,7 +463,7 @@ public class SuperStreamProducerTests
 
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var streamProducer =
-            await system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
             {
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 Reference = "reference"

--- a/Tests/SystemTests.cs
+++ b/Tests/SystemTests.cs
@@ -250,14 +250,10 @@ namespace Tests
             var system = await StreamSystem.Create(config);
             await system.CreateStream(new StreamSpec(stream));
             var producer =
-                await system.CreateProducer(new ProducerConfig
-                {
-                    Stream = stream,
-                    ClientProvidedName = clientProvidedName
-                });
+                await system.CreateRawProducer(new RawProducerConfig(stream) { ClientProvidedName = clientProvidedName });
             SystemUtils.Wait();
-            var consumer = await system.CreateConsumer(
-                new ConsumerConfig { Stream = stream, ClientProvidedName = clientProvidedName });
+            var consumer = await system.CreateRawConsumer(
+                new RawConsumerConfig(stream) { ClientProvidedName = clientProvidedName });
             SystemUtils.Wait();
 
             // Here we have to wait the management stats refresh time before killing the connections.
@@ -286,7 +282,7 @@ namespace Tests
             var stream = Guid.NewGuid().ToString();
             await system.CreateStream(new StreamSpec(stream));
             var producer =
-                await system.CreateProducer(new ProducerConfig { Stream = stream });
+                await system.CreateRawProducer(new RawProducerConfig(stream));
             SystemUtils.Wait();
             Assert.Equal(ResponseCode.Ok, await producer.Close());
             await system.DeleteStream(stream);

--- a/Tests/SystemTests.cs
+++ b/Tests/SystemTests.cs
@@ -175,21 +175,21 @@ namespace Tests
             var config = new StreamSystemConfig();
             var system = await StreamSystem.Create(config);
 
-            await Assert.ThrowsAsync<QueryException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () =>
                 {
                     await system.QueryOffset(string.Empty, "stream_we_don_t_care");
                 }
             );
 
-            await Assert.ThrowsAsync<QueryException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () =>
                 {
                     await system.QueryOffset("reference_we_don_care", string.Empty);
                 }
             );
 
-            await Assert.ThrowsAsync<QueryException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () =>
                 {
                     await system.QueryOffset(string.Empty, string.Empty);
@@ -214,21 +214,21 @@ namespace Tests
             var config = new StreamSystemConfig();
             var system = await StreamSystem.Create(config);
 
-            await Assert.ThrowsAsync<QueryException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () =>
                 {
                     await system.QuerySequence(string.Empty, "stream_we_don_t_care");
                 }
             );
 
-            await Assert.ThrowsAsync<QueryException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () =>
                 {
                     await system.QuerySequence("reference_we_don_care", string.Empty);
                 }
             );
 
-            await Assert.ThrowsAsync<QueryException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () =>
                 {
                     await system.QuerySequence(string.Empty, string.Empty);

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -178,7 +178,7 @@ namespace Tests
 
             var testPassed = new TaskCompletionSource<int>();
             var count = 0;
-            var producer = await system.RawCreateSuperStreamProducer(
+            var producer = await system.CreateRawSuperStreamProducer(
                 new RawSuperStreamProducerConfig(stream)
                 {
                     Reference = producerName,

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -126,11 +126,10 @@ namespace Tests
 
             var testPassed = new TaskCompletionSource<int>();
             var count = 0;
-            var producer = await system.CreateProducer(
-                new ProducerConfig
+            var producer = await system.CreateRawProducer(
+                new RawProducerConfig(stream)
                 {
                     Reference = producerName,
-                    Stream = stream,
                     ConfirmHandler = _ =>
                     {
                         count++;
@@ -179,11 +178,10 @@ namespace Tests
 
             var testPassed = new TaskCompletionSource<int>();
             var count = 0;
-            var producer = await system.CreateSuperStreamProducer(
-                new SuperStreamProducerConfig()
+            var producer = await system.RawCreateSuperStreamProducer(
+                new RawSuperStreamProducerConfig(stream)
                 {
                     Reference = producerName,
-                    SuperStream = stream,
                     Routing = message1 => message1.Properties.MessageId.ToString(),
                     ConfirmHandler = _ =>
                     {


### PR DESCRIPTION
Closes: https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/173 Closes: https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/171

Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>


Refactor class names. 
---

Why?
--
The idea is to give a similar [JavaStream client](https://github.com/rabbitmq/rabbitmq-stream-java-client) user experience.

Main concepts:
---
| Class  | Description  | How to get  | Note | 
|---|---|---|---|
|  RawProducer | Low-Level producer   |  `system.CreateRawProducer(new RawProducerConfig("stream")` | |
|  RawSuperStreamProducer | Low Level Super Stream Producer   |  `system.RawCreateSuperStreamProducer(new RawSuperStreamProducerConfig("superStream")` | |
|  Producer    | Hight Level producer. | `Producer.Create(new ProducerConfig(system, stream))`  | -Handle `RawProducer` and  `RawSuperStreamProducer` <br> - Auto reconnect <br> - Auto publishing id <br> - Confirm Messages with errors (timeout..etc)|  
|  RawConsumer | Low Level consumer   |  `system.CreateRawConsumer(newRawConsumerConfig("stream")` | |
|  RawSuperStreamConsumer | Low Level Super Stream Consumer   |  `system.RawCreateSuperStreamConsumer(new RawSuperStreamConsumerConfig("superStream")` | |
|  Consumer    | Hight Level Consumer. | `Consumer.Create(new ConsumerConfig(system, stream))`  | -Handle RawConsumer and  RawCreateSuperStreamConsumer <br> - Auto reconnect <br>|  

Class mapping from version: `v1.0.0-rc.5` to `v1.0.0-rc.6` 
---

|  <=`v1.0.0-rc.5` | >= `v1.0.0-rc.6`   |  
|---|---
| `Producer`  | `RawProducer`   |   
| `Consumer`  | `RawConsumer`   |   
|  `ReliableProducer` |  `Producer` |    
|  `ReliableConsumer` |  `Consumer` |  

for example:
|  <=`v1.0.0-rc.5` from | >= `v1.0.0-rc.6` to   |  
|---|---
|`await system.CreateProducer(new ProducerConfig() {stream = "mystream"})`| `await system.CreateRawProducer(new RawProducerConfig(streamName))`|
|`await system.CreateConsumer(new ConsumerConfig() {stream = "mystream"})`| `await system.CreateRawConsumer(new RawConsumerConfig(streamName))`|
|`await ReliableProducer.CreateReliableProducer(new ReliableProducerConfig() {..}`| `await Producer.Create(new ProducerConfig(system,stream)`|
|`await ReliableConsumer.CreateReliableConsumer(new ReliableConsumerConfig() {..}`| `await Consumer.Create(new ConsumerConfig(system,stream)`|

Configuration changes:
---

All the `*Config` classes contain a constructor with the mandatory fields. So it is easier for the user understand how to use the class.

For example:
`new RawProducerConfig(stream)` <-- the stream is mandatory

Exceptions
---

All the validations are now under the `ArgumentException` Exception
For example:
`new RawProducerConfig("")` <-- raises `ArgumentException`



Questions:
----
Q: Why the `Producer`/`Consumer` classes are not provided directly by `system`?
A: We'd like to leave the low-level classes easy as possible. A user can implement a similar `Producer` starting from  `RawProducer` and `RawSuperStreamProducer` as we did.

Q: Which classes should I use?
A: We suggest using `Producer`/`Consumer` classes

Q: When to use `RawProducer` ?
A: When you want a low-level producer and handle the reconnections/confirmation in a different way. `RawProducer` could be faster than the `Producer` under certain situations since it doesn't have to handle the sent/received messages.



