### PR TITLE
GetBytes(string).Length -> GetByteCount(string) + stackalloc in ReadString

### DIFF
--- a/RabbitMQ.Stream.Client/AMQP/AmqpWireFormattingRead.cs
+++ b/RabbitMQ.Stream.Client/AMQP/AmqpWireFormattingRead.cs
@@ -177,16 +177,16 @@ namespace RabbitMQ.Stream.Client.AMQP
                     reader.TryCopyTo(tempSpan);
                     reader.Advance(lenC);
                     value = Encoding.UTF8.GetString(tempSpan);
-                    return offset + s_encoding.GetBytes(value).Length;
+                    return offset + s_encoding.GetByteCount(value);
 
                 case FormatCode.Sym32:
                 case FormatCode.Str32:
                     offset += WireFormatting.ReadInt32(ref reader, out var len);
-                    Span<byte> tempSpan32 = new byte[len];
+                    Span<byte> tempSpan32 = len <= 64 ? stackalloc byte[len] : new byte[len];
                     reader.TryCopyTo(tempSpan32);
                     reader.Advance(len);
                     value = Encoding.UTF8.GetString(tempSpan32);
-                    return offset + s_encoding.GetBytes(value).Length;
+                    return offset + s_encoding.GetByteCount(value);
             }
 
             throw new AMQP.AmqpParseException($"ReadString invalid type {type}");

--- a/RabbitMQ.Stream.Client/AMQP/AmqpWireFormattingWrite.cs
+++ b/RabbitMQ.Stream.Client/AMQP/AmqpWireFormattingWrite.cs
@@ -36,7 +36,7 @@ namespace RabbitMQ.Stream.Client.AMQP
 
         private static int WriteString(Span<byte> seq, string value)
         {
-            var len = s_encoding.GetBytes(value).Length;
+            var len = s_encoding.GetByteCount(value);
             var offset = 0;
             // Str8
             if (len <= byte.MaxValue)


### PR DESCRIPTION
From MS sources:

```csharp
        public virtual byte[] Encoding.GetBytes(string s)
        {
            if (s == null)
                throw new ArgumentNullException(nameof(s),
                    SR.ArgumentNull_String);

            int byteCount = GetByteCount(s);
            byte[] bytes = new byte[byteCount];
            int bytesReceived = GetBytes(s, 0, s.Length, bytes, 0);
            Debug.Assert(byteCount == bytesReceived);
            return bytes;
        }
```

So `GetBytes(string).Length` call is pointless.