### PR TITLE
replace seq.Slice(offset) with seq[offset..] 

### DIFF
--- a/RabbitMQ.Stream.Client.PerfTest/Program.fs
+++ b/RabbitMQ.Stream.Client.PerfTest/Program.fs
@@ -37,6 +37,7 @@ let main argv =
         let producerConfig = RawProducerConfig(streamName,
                                             Reference = null,
                                             MaxInFlight = 10000,
+                                            MessagesBufferSize = 10000,
                                             ConfirmHandler = fun c -> confirmed <- confirmed + 1)
         let! producer = system.CreateRawProducer producerConfig
         //make producer available to metrics async

--- a/RabbitMQ.Stream.Client/AMQP/AmqpWireFormattingRead.cs
+++ b/RabbitMQ.Stream.Client/AMQP/AmqpWireFormattingRead.cs
@@ -182,7 +182,7 @@ namespace RabbitMQ.Stream.Client.AMQP
                 case FormatCode.Sym32:
                 case FormatCode.Str32:
                     offset += WireFormatting.ReadInt32(ref reader, out var len);
-                    Span<byte> tempSpan32 = len <= 64 ? stackalloc byte[len] : new byte[len];
+                    var tempSpan32 = len <= 64 ? stackalloc byte[len] : new byte[len];
                     reader.TryCopyTo(tempSpan32);
                     reader.Advance(len);
                     value = Encoding.UTF8.GetString(tempSpan32);

--- a/RabbitMQ.Stream.Client/AMQP/AmqpWireFormattingWrite.cs
+++ b/RabbitMQ.Stream.Client/AMQP/AmqpWireFormattingWrite.cs
@@ -41,16 +41,16 @@ namespace RabbitMQ.Stream.Client.AMQP
             // Str8
             if (len <= byte.MaxValue)
             {
-                offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.Str8);
-                offset += WireFormatting.WriteByte(seq.Slice(offset), (byte)len);
-                offset += s_encoding.GetBytes(value, seq.Slice(offset));
+                offset += WireFormatting.WriteByte(seq[offset..], FormatCode.Str8);
+                offset += WireFormatting.WriteByte(seq[offset..], (byte)len);
+                offset += s_encoding.GetBytes(value, seq[offset..]);
                 return offset;
             }
 
             // Str32
-            offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.Str32);
-            offset += WireFormatting.WriteInt32(seq.Slice(offset), len);
-            offset += s_encoding.GetBytes(value, seq.Slice(offset));
+            offset += WireFormatting.WriteByte(seq[offset..], FormatCode.Str32);
+            offset += WireFormatting.WriteInt32(seq[offset..], len);
+            offset += s_encoding.GetBytes(value, seq[offset..]);
             return offset;
         }
 
@@ -64,13 +64,13 @@ namespace RabbitMQ.Stream.Client.AMQP
             var offset = 0;
             if (value < 256)
             {
-                offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.SmallUlong);
-                offset += WireFormatting.WriteByte(seq.Slice(offset), (byte)value);
+                offset += WireFormatting.WriteByte(seq[offset..], FormatCode.SmallUlong);
+                offset += WireFormatting.WriteByte(seq[offset..], (byte)value);
                 return offset;
             }
 
-            offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.Ulong);
-            offset += WireFormatting.WriteUInt64(seq.Slice(offset), value);
+            offset += WireFormatting.WriteByte(seq[offset..], FormatCode.Ulong);
+            offset += WireFormatting.WriteUInt64(seq[offset..], value);
             return offset;
         }
 
@@ -83,13 +83,13 @@ namespace RabbitMQ.Stream.Client.AMQP
                 case 0:
                     return WireFormatting.WriteByte(seq, FormatCode.Uint0);
                 case < 256:
-                    offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.SmallUint);
-                    offset += WireFormatting.WriteByte(seq.Slice(offset), (byte)value);
+                    offset += WireFormatting.WriteByte(seq[offset..], FormatCode.SmallUint);
+                    offset += WireFormatting.WriteByte(seq[offset..], (byte)value);
                     return offset;
             }
 
-            offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.Uint);
-            offset += WireFormatting.WriteUInt32(seq.Slice(offset), value);
+            offset += WireFormatting.WriteByte(seq[offset..], FormatCode.Uint);
+            offset += WireFormatting.WriteUInt32(seq[offset..], value);
             return offset;
         }
 
@@ -98,14 +98,14 @@ namespace RabbitMQ.Stream.Client.AMQP
             var offset = 0;
             if (value is < 128 and >= -128)
             {
-                offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.Smallint);
-                offset += WireFormatting.WriteByte(seq.Slice(offset), (byte)value);
+                offset += WireFormatting.WriteByte(seq[offset..], FormatCode.Smallint);
+                offset += WireFormatting.WriteByte(seq[offset..], (byte)value);
 
                 return offset;
             }
 
-            offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.Int);
-            offset += WireFormatting.WriteInt32(seq.Slice(offset), value);
+            offset += WireFormatting.WriteByte(seq[offset..], FormatCode.Int);
+            offset += WireFormatting.WriteInt32(seq[offset..], value);
             return offset;
         }
 
@@ -114,14 +114,14 @@ namespace RabbitMQ.Stream.Client.AMQP
             var offset = 0;
             if (value is < 128 and >= -128)
             {
-                offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.Smalllong);
-                offset += WireFormatting.WriteByte(seq.Slice(offset), (byte)value);
+                offset += WireFormatting.WriteByte(seq[offset..], FormatCode.Smalllong);
+                offset += WireFormatting.WriteByte(seq[offset..], (byte)value);
 
                 return offset;
             }
 
-            offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.Long);
-            offset += WireFormatting.WriteInt64(seq.Slice(offset), value);
+            offset += WireFormatting.WriteByte(seq[offset..], FormatCode.Long);
+            offset += WireFormatting.WriteInt64(seq[offset..], value);
             return offset;
         }
 
@@ -138,37 +138,37 @@ namespace RabbitMQ.Stream.Client.AMQP
             // List8
             if (len < 256)
             {
-                offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.Vbin8);
-                offset += WireFormatting.WriteByte(seq.Slice(offset), (byte)len);
-                offset += WireFormatting.Write(seq.Slice(offset), new ReadOnlySequence<byte>(value));
+                offset += WireFormatting.WriteByte(seq[offset..], FormatCode.Vbin8);
+                offset += WireFormatting.WriteByte(seq[offset..], (byte)len);
+                offset += WireFormatting.Write(seq[offset..], new ReadOnlySequence<byte>(value));
                 return offset;
             }
 
             // List32
-            offset += WireFormatting.WriteByte(seq.Slice(offset), FormatCode.Vbin32);
-            offset += WireFormatting.WriteUInt32(seq.Slice(offset), (uint)len);
-            offset += WireFormatting.Write(seq.Slice(offset), new ReadOnlySequence<byte>(value));
+            offset += WireFormatting.WriteByte(seq[offset..], FormatCode.Vbin32);
+            offset += WireFormatting.WriteUInt32(seq[offset..], (uint)len);
+            offset += WireFormatting.Write(seq[offset..], new ReadOnlySequence<byte>(value));
             return offset;
         }
 
         private static int WriteUInt16(Span<byte> seq, ushort value)
         {
             var offset = WireFormatting.WriteByte(seq, FormatCode.Ushort);
-            offset += WireFormatting.WriteUInt16(seq.Slice(offset), value);
+            offset += WireFormatting.WriteUInt16(seq[offset..], value);
             return offset;
         }
 
         private static int WriteByte(Span<byte> seq, byte value)
         {
             var offset = WireFormatting.WriteByte(seq, FormatCode.Ubyte);
-            offset += WireFormatting.WriteByte(seq.Slice(offset), value);
+            offset += WireFormatting.WriteByte(seq[offset..], value);
             return offset;
         }
 
         private static int WriteSByte(Span<byte> seq, sbyte value)
         {
             var offset = WireFormatting.WriteByte(seq, FormatCode.Byte);
-            offset += WireFormatting.WriteByte(seq.Slice(offset), (byte)value);
+            offset += WireFormatting.WriteByte(seq[offset..], (byte)value);
             return offset;
         }
 
@@ -176,7 +176,7 @@ namespace RabbitMQ.Stream.Client.AMQP
         {
             var offset = WireFormatting.WriteByte(seq, FormatCode.Float);
             var intFloat = BitConverter.SingleToInt32Bits(value);
-            offset += WireFormatting.WriteInt32(seq.Slice(offset), intFloat);
+            offset += WireFormatting.WriteInt32(seq[offset..], intFloat);
             return offset;
         }
 
@@ -184,14 +184,14 @@ namespace RabbitMQ.Stream.Client.AMQP
         {
             var offset = WireFormatting.WriteByte(seq, FormatCode.Double);
             var intFloat = BitConverter.DoubleToInt64Bits(value);
-            offset += WireFormatting.WriteInt64(seq.Slice(offset), intFloat);
+            offset += WireFormatting.WriteInt64(seq[offset..], intFloat);
             return offset;
         }
 
         private static int WriteIn16(Span<byte> seq, short value)
         {
             var offset = WireFormatting.WriteByte(seq, FormatCode.Short);
-            offset += WireFormatting.WriteInt16(seq.Slice(offset), value);
+            offset += WireFormatting.WriteInt16(seq[offset..], value);
             return offset;
         }
 
@@ -204,7 +204,7 @@ namespace RabbitMQ.Stream.Client.AMQP
         {
             var offset = WireFormatting.WriteByte(seq, FormatCode.Timestamp);
             var unixTime = ((DateTimeOffset)value).ToUnixTimeMilliseconds();
-            offset += WireFormatting.WriteUInt64(seq.Slice(offset), (ulong)unixTime);
+            offset += WireFormatting.WriteUInt64(seq[offset..], (ulong)unixTime);
             return offset;
         }
 

--- a/RabbitMQ.Stream.Client/AMQP/Data.cs
+++ b/RabbitMQ.Stream.Client/AMQP/Data.cs
@@ -32,16 +32,16 @@ namespace RabbitMQ.Stream.Client.AMQP
             var offset = DescribedFormatCode.Write(span, DescribedFormatCode.ApplicationData);
             if (data.Length <= byte.MaxValue)
             {
-                offset += WireFormatting.WriteByte(span.Slice(offset), FormatCode.Vbin8); //binary marker
-                offset += WireFormatting.WriteByte(span.Slice(offset), (byte)data.Length); //length
+                offset += WireFormatting.WriteByte(span[offset..], FormatCode.Vbin8); //binary marker
+                offset += WireFormatting.WriteByte(span[offset..], (byte)data.Length); //length
             }
             else
             {
-                offset += WireFormatting.WriteByte(span.Slice(offset), FormatCode.Vbin32); //binary marker
-                offset += WireFormatting.WriteUInt32(span.Slice(offset), (uint)data.Length); //length
+                offset += WireFormatting.WriteByte(span[offset..], FormatCode.Vbin32); //binary marker
+                offset += WireFormatting.WriteUInt32(span[offset..], (uint)data.Length); //length
             }
 
-            offset += WireFormatting.Write(span.Slice(offset), data);
+            offset += WireFormatting.Write(span[offset..], data);
             return offset;
         }
 

--- a/RabbitMQ.Stream.Client/AMQP/DescribedFormatCode.cs
+++ b/RabbitMQ.Stream.Client/AMQP/DescribedFormatCode.cs
@@ -15,6 +15,9 @@ namespace RabbitMQ.Stream.Client.AMQP
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte Read(ref SequenceReader<byte> reader)
         {
+            // DescribedFormatCode in this case we need to read 
+            // only the last byte form the header to get the format code
+            // the first can be ignored but it is necessary to read them
             reader.TryRead(out _);
             reader.TryRead(out _);
             reader.TryRead(out var formatCode);

--- a/RabbitMQ.Stream.Client/AMQP/Map.cs
+++ b/RabbitMQ.Stream.Client/AMQP/Map.cs
@@ -72,15 +72,15 @@ namespace RabbitMQ.Stream.Client.AMQP
         public int Write(Span<byte> span)
         {
             var offset = DescribedFormatCode.Write(span, MapDataCode);
-            offset += WireFormatting.WriteByte(span.Slice(offset), FormatCode.Map32);
-            offset += WireFormatting.WriteUInt32(span.Slice(offset), (uint)MapSize()); // MapSize 
-            offset += WireFormatting.WriteUInt32(span.Slice(offset), (uint)Count * 2); // pair values
+            offset += WireFormatting.WriteByte(span[offset..], FormatCode.Map32);
+            offset += WireFormatting.WriteUInt32(span[offset..], (uint)MapSize()); // MapSize 
+            offset += WireFormatting.WriteUInt32(span[offset..], (uint)Count * 2); // pair values
             foreach (var (key, value) in this)
             {
                 if (!IsNullOrEmptyString(key))
                 {
-                    offset += AmqpWireFormatting.WriteAny(span.Slice(offset), key);
-                    offset += AmqpWireFormatting.WriteAny(span.Slice(offset), value);
+                    offset += AmqpWireFormatting.WriteAny(span[offset..], key);
+                    offset += AmqpWireFormatting.WriteAny(span[offset..], value);
                 }
             }
 

--- a/RabbitMQ.Stream.Client/AMQP/Properties.cs
+++ b/RabbitMQ.Stream.Client/AMQP/Properties.cs
@@ -132,22 +132,22 @@ namespace RabbitMQ.Stream.Client.AMQP
         public int Write(Span<byte> span)
         {
             var offset = DescribedFormatCode.Write(span, DescribedFormatCode.MessageProperties);
-            offset += WireFormatting.WriteByte(span.Slice(offset), FormatCode.List32);
-            offset += WireFormatting.WriteUInt32(span.Slice(offset), (uint)PropertySize()); // PropertySize 
-            offset += WireFormatting.WriteUInt32(span.Slice(offset), 13); // field numbers
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), MessageId);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), UserId);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), To);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), Subject);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), ReplyTo);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), CorrelationId);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), ContentType);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), ContentEncoding);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), AbsoluteExpiryTime);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), CreationTime);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), GroupId);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), GroupSequence);
-            offset += AmqpWireFormatting.WriteAny(span.Slice(offset), ReplyToGroupId);
+            offset += WireFormatting.WriteByte(span[offset..], FormatCode.List32);
+            offset += WireFormatting.WriteUInt32(span[offset..], (uint)PropertySize()); // PropertySize 
+            offset += WireFormatting.WriteUInt32(span[offset..], 13); // field numbers
+            offset += AmqpWireFormatting.WriteAny(span[offset..], MessageId);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], UserId);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], To);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], Subject);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], ReplyTo);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], CorrelationId);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], ContentType);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], ContentEncoding);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], AbsoluteExpiryTime);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], CreationTime);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], GroupId);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], GroupSequence);
+            offset += AmqpWireFormatting.WriteAny(span[offset..], ReplyToGroupId);
             return offset;
         }
     }

--- a/RabbitMQ.Stream.Client/Message.cs
+++ b/RabbitMQ.Stream.Client/Message.cs
@@ -46,20 +46,20 @@ namespace RabbitMQ.Stream.Client
             var offset = 0;
             if (Properties != null)
             {
-                offset += Properties.Write(span.Slice(offset));
+                offset += Properties.Write(span[offset..]);
             }
 
             if (ApplicationProperties != null)
             {
-                offset += ApplicationProperties.Write(span.Slice(offset));
+                offset += ApplicationProperties.Write(span[offset..]);
             }
 
             if (Annotations != null)
             {
-                offset += Annotations.Write(span.Slice(offset));
+                offset += Annotations.Write(span[offset..]);
             }
 
-            offset += Data.Write(span.Slice(offset));
+            offset += Data.Write(span[offset..]);
             return offset;
         }
 

--- a/RabbitMQ.Stream.Client/MetaData.cs
+++ b/RabbitMQ.Stream.Client/MetaData.cs
@@ -39,13 +39,13 @@ namespace RabbitMQ.Stream.Client
         {
             var command = (ICommand)this;
             var offset = WireFormatting.WriteUInt16(span, Key);
-            offset += WireFormatting.WriteUInt16(span.Slice(offset), command.Version);
-            offset += WireFormatting.WriteUInt32(span.Slice(offset), correlationId);
+            offset += WireFormatting.WriteUInt16(span[offset..], command.Version);
+            offset += WireFormatting.WriteUInt32(span[offset..], correlationId);
             // map
-            offset += WireFormatting.WriteInt32(span.Slice(offset), streams.Count());
+            offset += WireFormatting.WriteInt32(span[offset..], streams.Count());
             foreach (var s in streams)
             {
-                offset += WireFormatting.WriteString(span.Slice(offset), s);
+                offset += WireFormatting.WriteString(span[offset..], s);
             }
 
             return offset;

--- a/RabbitMQ.Stream.Client/Publish.cs
+++ b/RabbitMQ.Stream.Client/Publish.cs
@@ -40,17 +40,17 @@ namespace RabbitMQ.Stream.Client
         public int Write(Span<byte> span)
         {
             var offset = WireFormatting.WriteUInt16(span, Key);
-            offset += WireFormatting.WriteUInt16(span.Slice(offset), Version);
-            offset += WireFormatting.WriteByte(span.Slice(offset), publisherId);
+            offset += WireFormatting.WriteUInt16(span[offset..], Version);
+            offset += WireFormatting.WriteByte(span[offset..], publisherId);
             // this assumes we never write an empty publish frame
-            offset += WireFormatting.WriteInt32(span.Slice(offset), MessageCount);
+            offset += WireFormatting.WriteInt32(span[offset..], MessageCount);
             foreach (var (publishingId, msg) in messages)
             {
-                offset += WireFormatting.WriteUInt64(span.Slice(offset), publishingId);
+                offset += WireFormatting.WriteUInt64(span[offset..], publishingId);
                 // this only write "simple" messages, we assume msg is just the binary body
                 // not stream encoded data
-                offset += WireFormatting.WriteUInt32(span.Slice(offset), (uint)msg.Size);
-                offset += msg.Write(span.Slice(offset));
+                offset += WireFormatting.WriteUInt32(span[offset..], (uint)msg.Size);
+                offset += msg.Write(span[offset..]);
             }
 
             return offset;

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -221,6 +222,7 @@ namespace RabbitMQ.Stream.Client
             return !_disposed && !_client.IsClosed;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public async ValueTask Send(ulong publishingId, Message message)
         {
             await SemaphoreWait();
@@ -235,9 +237,11 @@ namespace RabbitMQ.Stream.Client
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private async Task ProcessBuffer()
         {
             var messages = new List<(ulong, Message)>(_config.MessagesBufferSize);
+
             while (await _messageBuffer.Reader.WaitToReadAsync().ConfigureAwait(false))
             {
                 while (_messageBuffer.Reader.TryRead(out var msg))

--- a/RabbitMQ.Stream.Client/Subscribe.cs
+++ b/RabbitMQ.Stream.Client/Subscribe.cs
@@ -78,7 +78,7 @@ namespace RabbitMQ.Stream.Client
         public int Write(Span<byte> span)
         {
             var offset = WireFormatting.WriteUInt16(span, (ushort)OffsetType);
-            offset += WireFormatting.WriteUInt64(span.Slice(offset), OffsetValue);
+            offset += WireFormatting.WriteUInt64(span[offset..], OffsetValue);
             return offset;
         }
     }
@@ -99,7 +99,7 @@ namespace RabbitMQ.Stream.Client
         public int Write(Span<byte> span)
         {
             var offset = WireFormatting.WriteUInt16(span, (ushort)OffsetType);
-            offset += WireFormatting.WriteInt64(span.Slice(offset), timestamp);
+            offset += WireFormatting.WriteInt64(span[offset..], timestamp);
             return offset;
         }
     }

--- a/RabbitMQ.Stream.Client/WireFormatting.cs
+++ b/RabbitMQ.Stream.Client/WireFormatting.cs
@@ -19,62 +19,62 @@ namespace RabbitMQ.Stream.Client
         {
             return string.IsNullOrEmpty(@string) ? 2 : 2 + s_encoding.GetByteCount(@string);
         }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int WriteByte(Span<byte> span, byte value)
         {
             span[0] = value;
             return 1;
         }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int WriteInt32(Span<byte> span, int value)
         {
             BinaryPrimitives.WriteInt32BigEndian(span, value);
             return 4;
         }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int WriteUInt16(Span<byte> p, ushort value)
         {
             BinaryPrimitives.WriteUInt16BigEndian(p, value);
             return 2;
         }
-
-        internal static int WriteInt16(Span<byte> p, short value)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int WriteInt16(Span<byte> span, short value)
         {
-            BinaryPrimitives.WriteInt16BigEndian(p, value);
+            BinaryPrimitives.WriteInt16BigEndian(span, value);
             return 2;
         }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int WriteUInt64(Span<byte> span, ulong value)
         {
             BinaryPrimitives.WriteUInt64BigEndian(span, value);
             return 8;
         }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int WriteInt64(Span<byte> span, long value)
         {
             BinaryPrimitives.WriteInt64BigEndian(span, value);
             return 8;
         }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int WriteUInt32(Span<byte> span, uint value)
         {
             BinaryPrimitives.WriteUInt32BigEndian(span, value);
             return 4;
         }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int Write(Span<byte> span, ReadOnlySequence<byte> msg)
         {
             msg.CopyTo(span);
             return (int)msg.Length;
         }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int WriteBytes(Span<byte> span, ReadOnlySequence<byte> msg)
         {
             WriteUInt32(span, (uint)msg.Length);
             Write(span.Slice(4), msg);
             return 4 + (int)msg.Length;
         }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int WriteString(Span<byte> span, string s)
         {
             if (string.IsNullOrEmpty(s))


### PR DESCRIPTION
Improve the publish

- replace `seq.Slice(offset)` with `seq[offset..]`
- Add AggressiveInlining to the main send functions
- Add AggressiveInlining to write functions
- Tune the performance test increasing the messages buffer ( important to increase the throughout) 


With the 1.0.0-rc.6 version: 

Run the `RabbitMQ.Stream.Client.PerfTest`:
```
published 782590 msg/s in 8393 publish frames, confirmed 782590 msg/s, consumed: 782590 msg/sec total confirm frames 4140 4146 pending commands: 10000
published 845984 msg/s in 9077 publish frames, confirmed 845984 msg/s, consumed: 850080 msg/sec total confirm frames 4437 4443 pending commands: 10000
published 850967 msg/s in 9103 publish frames, confirmed 850967 msg/s, consumed: 848497 msg/sec total confirm frames 4726 4732 pending commands: 10000
published 795881 msg/s in 8593 publish frames, confirmed 795881 msg/s, consumed: 795881 msg/sec total confirm frames 5001 5007 pending commands: 10000
```

This commit Run the `RabbitMQ.Stream.Client.PerfTest`:
```
published 997693 msg/s in 7906 publish frames, confirmed 997516 msg/s, consumed: 997951 msg/sec total confirm frames 4623 4629 pending commands: 10000
published 1023137 msg/s in 7734 publish frames, confirmed 1027097 msg/s, consumed: 1025227 msg/sec total confirm frames 4967 4973 pending commands: 6257
published 1062742 msg/s in 9024 publish frames, confirmed 1058782 msg/s, consumed: 1061619 msg/sec total confirm frames 5355 5361 pending commands: 10000
published 1069740 msg/s in 8703 publish frames, confirmed 1069740 msg/s, consumed: 1069740 msg/sec total confirm frames 5715 5721 pending commands: 10000
```






Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>