### PR TITLE
Add GetAwaiter().GetResult(); on MessageHandler

### DIFF
--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -6,7 +6,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace RabbitMQ.Stream.Client

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -138,7 +138,7 @@ namespace RabbitMQ.Stream.Client
                     {
                         _config.MessageHandler(this,
                             new MessageContext(message.MessageOffset, TimeSpan.FromMilliseconds(chunk.Timestamp)),
-                            message).WaitAsync(CancellationToken.None);
+                            message).GetAwaiter().GetResult();
                     }
                 }
                 catch (Exception e)

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -6,6 +6,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace RabbitMQ.Stream.Client
@@ -137,7 +138,7 @@ namespace RabbitMQ.Stream.Client
                     {
                         _config.MessageHandler(this,
                             new MessageContext(message.MessageOffset, TimeSpan.FromMilliseconds(chunk.Timestamp)),
-                            message);
+                            message).WaitAsync(CancellationToken.None);
                     }
                 }
                 catch (Exception e)

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -37,7 +37,7 @@ public record ConsumerConfig : ReliableConfig
     // See also: https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-super-streams
     // Parameters:
     public bool IsSuperStream { get; set; }
-    
+
     // <summary>
     // The offset is the place in the stream where the consumer starts consuming from. The possible values for the offset parameter are the following:
     // - OffsetTypeFirst: starting from the first available offset. If the stream has not been truncated, this means the beginning of the stream (offset 0).
@@ -53,7 +53,7 @@ public record ConsumerConfig : ReliableConfig
     // The other instances will be idle.
     // </summary>
     public bool IsSingleActiveConsumer { get; set; } = false;
-    
+
     // <summary>
     // The broker notifies a consumer that becomes active before dispatching messages to it. 
     // With ConsumerUpdateListener the consumer can decide where to start consuming from.

--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -226,6 +226,11 @@ public class Producer : ProducerFactory
         }
     }
 
+    public override string ToString()
+    {
+        return $"Producer reference: {_producerConfig.Reference}, stream: {_producerConfig.Stream} ";
+    }
+
     /// <summary>
     /// Send the messages in batch to the stream in synchronous mode.
     /// The aggregation is provided by the user.
@@ -269,10 +274,5 @@ public class Producer : ProducerFactory
         {
             SemaphoreSlim.Release();
         }
-    }
-
-    public override string ToString()
-    {
-        return $"Producer reference: {_producerConfig.Reference}, stream: {_producerConfig.Stream} ";
     }
 }


### PR DESCRIPTION
Small improvement, the `GetAwaiter().GetResult();` will wait for the complete task. it takes the memory under control.

Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>

cc @ricardSiliuk @ricsiLT 