### PR TITLE
Make the AddressResolver more generic

### DIFF
--- a/RabbitMQ.Stream.Client/AddressResolver.cs
+++ b/RabbitMQ.Stream.Client/AddressResolver.cs
@@ -8,13 +8,13 @@ namespace RabbitMQ.Stream.Client
 {
     public class AddressResolver
     {
-        public AddressResolver(IPEndPoint endPoint)
+        public AddressResolver(EndPoint endPoint)
         {
             EndPoint = endPoint;
             Enabled = true;
         }
 
-        public IPEndPoint EndPoint { get; set; }
+        public EndPoint EndPoint { get; set; }
         public bool Enabled { get; set; }
     }
 }

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -102,10 +102,10 @@ RabbitMQ.Stream.Client.AbstractEntity
 RabbitMQ.Stream.Client.AbstractEntity.AbstractEntity() -> void
 RabbitMQ.Stream.Client.AbstractEntity._client -> RabbitMQ.Stream.Client.Client
 RabbitMQ.Stream.Client.AddressResolver
-RabbitMQ.Stream.Client.AddressResolver.AddressResolver(System.Net.IPEndPoint endPoint) -> void
+RabbitMQ.Stream.Client.AddressResolver.AddressResolver(System.Net.EndPoint endPoint) -> void
 RabbitMQ.Stream.Client.AddressResolver.Enabled.get -> bool
 RabbitMQ.Stream.Client.AddressResolver.Enabled.set -> void
-RabbitMQ.Stream.Client.AddressResolver.EndPoint.get -> System.Net.IPEndPoint
+RabbitMQ.Stream.Client.AddressResolver.EndPoint.get -> System.Net.EndPoint
 RabbitMQ.Stream.Client.AddressResolver.EndPoint.set -> void
 RabbitMQ.Stream.Client.AMQP.AmqpParseException
 RabbitMQ.Stream.Client.AMQP.AmqpParseException.AmqpParseException(string s) -> void

--- a/Tests/UnitTests.cs
+++ b/Tests/UnitTests.cs
@@ -156,6 +156,22 @@ namespace Tests
         }
 
         [Fact]
+        public void DnsAddressResolverLoadBalancerSimulate()
+        {
+            var addressResolver = new AddressResolver(new DnsEndPoint("MyDnsEntryPoint", 5552));
+            var clientParameters = new ClientParameters() { AddressResolver = addressResolver, };
+            var metaDataInfo = new StreamInfo("stream", ResponseCode.Ok, new Broker("node2", 5552),
+                new List<Broker>() { new Broker("node1", 5552), new Broker("node3", 5552) });
+            // run more than one time just to be sure to use all the IP with random
+            for (var i = 0; i < 4; i++)
+            {
+                var client = RoutingHelper<LoadBalancerRouting>.LookupLeaderConnection(clientParameters, metaDataInfo);
+                Assert.Equal("node2", client.Result.ConnectionProperties["advertised_host"]);
+                Assert.Equal("5552", client.Result.ConnectionProperties["advertised_port"]);
+            }
+        }
+
+        [Fact]
         public async Task RoutingHelperShouldThrowIfLoadBalancerIsMisconfigured()
         {
             var addressResolver = new AddressResolver(new IPEndPoint(IPAddress.Parse("192.168.10.99"), 5552));


### PR DESCRIPTION
Add AddressResolver(EndPoint endPoint) in this way can accept DNS and IP endpoints

See also https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/discussions/188

you can now use:
```csharp
var addressResolver = new AddressResolver(new IPEndPoint(IPAddress.Parse("192.168.10.99"), 5552));
```          

and

```csharp
var addressResolver = new AddressResolver(new DnsEndPoint("MyDnsEntryPoint", 5552));
```    



Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>