### PR TITLE
Add consumer name property

### DIFF
--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -215,9 +215,14 @@ namespace RabbitMQ.Stream.Client
             }
 
             var consumerProperties = new Dictionary<string, string>();
-            if (_config.IsSingleActiveConsumer)
+
+            if (!string.IsNullOrEmpty(_config.Reference))
             {
                 consumerProperties["name"] = _config.Reference;
+            }
+
+            if (_config.IsSingleActiveConsumer)
+            {
                 consumerProperties["single-active-consumer"] = "true";
                 if (!string.IsNullOrEmpty(_config.SuperStream))
                 {


### PR DESCRIPTION
- Add the consumer name property.
- Property is needed anyway no only in case of super stream

Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>