### PR TITLE
Add cancellation token during subscribe

### DIFF
--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -152,8 +152,7 @@ namespace RabbitMQ.Stream.Client
                     message.MessageOffset = chunk.ChunkId + i;
                     if (MaybeDispatch(message.MessageOffset))
                     {
-                        _logger.LogInformation("doing.. {MessageMessageOffset}", message.MessageOffset);
-                        if (_cancelTokenSource.IsCancellationRequested)
+                        if (_token.IsCancellationRequested)
                         {
                             _logger.LogInformation("cancelling..");
                             return;
@@ -334,6 +333,7 @@ namespace RabbitMQ.Stream.Client
             closeConsumer.Wait(TimeSpan.FromSeconds(1));
             ClientExceptions.MaybeThrowException(closeConsumer.Result,
                 $"Error during remove producer. Subscriber: {_subscriberId}");
+            _cancelTokenSource.Dispose();
         }
 
         public void Dispose()

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -154,7 +154,6 @@ namespace RabbitMQ.Stream.Client
                     {
                         if (_token.IsCancellationRequested)
                         {
-                            _logger.LogInformation("cancelling..");
                             return;
                         }
 
@@ -168,6 +167,12 @@ namespace RabbitMQ.Stream.Client
                     _logger.LogError(e, "Unexpected error while parsing message. Message will be skipped. " +
                                         "Please report this issue to the RabbitMQ team on GitHub {Repo}",
                         Consts.RabbitMQClientRepo);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogWarning(
+                        "OperationCanceledException. The consumer id: {SubscriberId} reference: {Reference} has been closed while consuming messages",
+                        _subscriberId, _config.Reference);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/205

In this way, the thread is not locked, and the:
```csharp
new MessageContext(message.MessageOffset, TimeSpan.FromMilliseconds(chunk.Timestamp)),
                            message).Wait(_token);
```

is in wait(...), so there is not the thread pool exhaustion.

@ricardSiliuk @ricsiLT it should not change anything. Please feel free to add any comments.

@jonnepmyra  do you have a chance to test it? 
 
Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>