### PR TITLE
Handle System.InvalidOperationException in case of big body buffer send

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -239,15 +239,11 @@ namespace RabbitMQ.Stream.Client
 
         public async ValueTask<bool> Publish(Publish publishMsg)
         {
-            var publishTask = Publish<Publish>(publishMsg);
-            if (!publishTask.IsCompletedSuccessfully)
-            {
-                await publishTask.ConfigureAwait(false);
-            }
+            var publishTask = await Publish<Publish>(publishMsg);
 
             publishCommandsSent += 1;
             messagesSent += publishMsg.MessageCount;
-            return publishTask.Result;
+            return publishTask;
         }
 
         public ValueTask<bool> Publish<T>(T msg) where T : struct, ICommand

--- a/RabbitMQ.Stream.Client/Connection.cs
+++ b/RabbitMQ.Stream.Client/Connection.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace RabbitMQ.Stream.Client
@@ -20,7 +21,7 @@ namespace RabbitMQ.Stream.Client
         private Func<Memory<byte>, Task> commandCallback;
         private readonly Func<string, Task> closedCallback;
         private int numFrames;
-        private readonly object writeLock = new();
+        private readonly SemaphoreSlim writeLock = new SemaphoreSlim(1, 1);
         internal int NumFrames => numFrames;
         private bool isClosed = false;
 
@@ -87,8 +88,7 @@ namespace RabbitMQ.Stream.Client
 
         public async ValueTask<bool> Write<T>(T command) where T : struct, ICommand
         {
-
-            var flushTask = await WriteCommand(command);
+            await WriteCommand(command);
 
             // Let's check if this is completed synchronously before invoking the async state machine
             // if (!flushTask.IsCompletedSuccessfully)
@@ -96,22 +96,27 @@ namespace RabbitMQ.Stream.Client
             //     await flushTask.ConfigureAwait(false);
             // }
 
-            return flushTask.IsCompleted;
+            return true;
         }
 
-        private ValueTask<FlushResult> WriteCommand<T>(T command) where T : struct, ICommand
+        private async Task WriteCommand<T>(T command) where T : struct, ICommand
         {
             // Only one thread should be able to write to the output pipeline at a time.
-            lock (writeLock)
+            // lock (writeLock)
+            await writeLock.WaitAsync();
             {
                 var size = command.SizeNeeded;
-                var mem = writer.GetSpan(4 + size); // + 4 to write the size
+                var mem = new byte[4 + size]; // + 4 to write the size
                 WireFormatting.WriteUInt32(mem, (uint)size);
-                var written = command.Write(mem.Slice(4));
+                var written = command.Write(mem.AsSpan()[4..]);
+
+                await writer.WriteAsync(new ReadOnlyMemory<byte>(mem));
                 Debug.Assert(size == written);
-                writer.Advance(4 + written);
-                return writer.FlushAsync();
+                // writer.Advance(4 + written);
+                await writer.FlushAsync();
             }
+
+            writeLock.Release();
         }
 
         private async Task ProcessIncomingFrames()

--- a/RabbitMQ.Stream.Client/Connection.cs
+++ b/RabbitMQ.Stream.Client/Connection.cs
@@ -90,6 +90,9 @@ namespace RabbitMQ.Stream.Client
         {
             await WriteCommand(command);
             // we return true to indicate that the command was written
+            // In this PR https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/pull/220
+            // we made all WriteCommand async so await is enough to indicate that the command was written
+            // We decided to keep the return value to avoid a breaking change
             return true;
         }
 

--- a/RabbitMQ.Stream.Client/IProducer.cs
+++ b/RabbitMQ.Stream.Client/IProducer.cs
@@ -71,7 +71,7 @@ public interface IProducer
 public record IProducerConfig : INamedEntity
 {
     public string Reference { get; set; }
-    public int MaxInFlight { get; set; } = 5_000;
+    public int MaxInFlight { get; set; } = 1_000;
     public string ClientProvidedName { get; set; } = "dotnet-stream-raw-producer";
 
     public int BatchSize { get; set; } = 100;

--- a/RabbitMQ.Stream.Client/IProducer.cs
+++ b/RabbitMQ.Stream.Client/IProducer.cs
@@ -71,7 +71,7 @@ public interface IProducer
 public record IProducerConfig : INamedEntity
 {
     public string Reference { get; set; }
-    public int MaxInFlight { get; set; } = 1000;
+    public int MaxInFlight { get; set; } = 100_000;
     public string ClientProvidedName { get; set; } = "dotnet-stream-raw-producer";
 
     public int BatchSize { get; set; } = 100;

--- a/RabbitMQ.Stream.Client/IProducer.cs
+++ b/RabbitMQ.Stream.Client/IProducer.cs
@@ -71,7 +71,7 @@ public interface IProducer
 public record IProducerConfig : INamedEntity
 {
     public string Reference { get; set; }
-    public int MaxInFlight { get; set; } = 100_000;
+    public int MaxInFlight { get; set; } = 5_000;
     public string ClientProvidedName { get; set; } = "dotnet-stream-raw-producer";
 
     public int BatchSize { get; set; } = 100;

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -243,6 +243,12 @@ namespace RabbitMQ.Stream.Client
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public async ValueTask Send(ulong publishingId, Message message)
         {
+            if (message.Size > _client.MaxFrameSize)
+            {
+                throw new InvalidOperationException($"Message size is to big. " +
+                                                    $"Max allowed is {_client.MaxFrameSize}");
+            }
+
             await SemaphoreWait();
 
             var msg = new OutgoingMsg(_publisherId, publishingId, message);

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -178,7 +178,7 @@ namespace RabbitMQ.Stream.Client
 
             if (messages.Count != 0 && !_client.IsClosed)
             {
-                await SendMessages(messages, false);
+                await SendMessages(messages, false).ConfigureAwait(false);
             }
         }
 
@@ -258,13 +258,13 @@ namespace RabbitMQ.Stream.Client
                         messages.Add((msg.PublishingId, msg.Data));
                         if (messages.Count == _config.MessagesBufferSize)
                         {
-                            await SendMessages(messages);
+                            await SendMessages(messages).ConfigureAwait(false);
                         }
                     }
 
                     if (messages.Count > 0)
                     {
-                        await SendMessages(messages);
+                        await SendMessages(messages).ConfigureAwait(false);
                     }
                 }
             }

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -199,23 +199,24 @@ namespace RabbitMQ.Stream.Client
 
         private async Task SemaphoreWait()
         {
-            if (!await _semaphore.WaitAsync(0) && !_client.IsClosed)
-            {
-                // Nope, we have maxed our In-Flight messages, let's asynchronously wait for confirms
-                if (!await _semaphore.WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false))
-                {
-                    _logger.LogWarning("Semaphore Wait timeout during publishing.");
-                }
-            }
+            await _semaphore.WaitAsync();
+            // if (!await _semaphore.WaitAsync(0) && !_client.IsClosed)
+            // {
+            //     // Nope, we have maxed our In-Flight messages, let's asynchronously wait for confirms
+            //     if (!await _semaphore.WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false))
+            //     {
+            //         _logger.LogWarning("Semaphore Wait timeout during publishing.");
+            //     }
+            // }
         }
 
         private async Task SendMessages(List<(ulong, Message)> messages, bool clearMessagesList = true)
         {
-            var publishTask = _client.Publish(new Publish(_publisherId, messages));
-            if (!publishTask.IsCompletedSuccessfully)
-            {
-                await publishTask.ConfigureAwait(false);
-            }
+            await _client.Publish(new Publish(_publisherId, messages));
+            // if (!publishTask.IsCompletedSuccessfully)
+            // {
+            //     await publishTask.ConfigureAwait(false);
+            // }
 
             if (clearMessagesList)
             {

--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -181,7 +181,9 @@ public class Producer : ProducerFactory
     /// In case of error the message is considered as timed out, you will receive a confirmation with the status TimedOut.
     public async ValueTask Send(Message message)
     {
+
         await SemaphoreSlim.WaitAsync();
+
         Interlocked.Increment(ref _publishingId);
         _confirmationPipe.AddUnConfirmedMessage(_publishingId, message);
         try
@@ -224,9 +226,9 @@ public class Producer : ProducerFactory
     /// In case of error the messages are considered as timed out, you will receive a confirmation with the status TimedOut.
     public async ValueTask Send(List<Message> messages, CompressionType compressionType)
     {
+        await SemaphoreSlim.WaitAsync();
         Interlocked.Increment(ref _publishingId);
         _confirmationPipe.AddUnConfirmedMessage(_publishingId, messages);
-        await SemaphoreSlim.WaitAsync();
         try
         {
             if (!_inReconnection)

--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -181,9 +181,9 @@ public class Producer : ProducerFactory
     /// In case of error the message is considered as timed out, you will receive a confirmation with the status TimedOut.
     public async ValueTask Send(Message message)
     {
+        await SemaphoreSlim.WaitAsync();
         Interlocked.Increment(ref _publishingId);
         _confirmationPipe.AddUnConfirmedMessage(_publishingId, message);
-        await SemaphoreSlim.WaitAsync();
         try
         {
             // This flags avoid some race condition,
@@ -264,6 +264,7 @@ public class Producer : ProducerFactory
     /// In case of error the messages are considered as timed out, you will receive a confirmation with the status TimedOut.
     public async ValueTask Send(List<Message> messages)
     {
+        await SemaphoreSlim.WaitAsync();
         var messagesToSend = new List<(ulong, Message)>();
         foreach (var message in messages)
         {
@@ -276,7 +277,6 @@ public class Producer : ProducerFactory
             _confirmationPipe.AddUnConfirmedMessage(msg.Item1, msg.Item2);
         }
 
-        await SemaphoreSlim.WaitAsync();
         try
         {
             // This flags avoid some race condition,

--- a/Tests/MultiThreadTests.cs
+++ b/Tests/MultiThreadTests.cs
@@ -1,0 +1,80 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2007-2023 VMware, Inc.
+
+using System.Threading;
+using System.Threading.Tasks;
+using RabbitMQ.Stream.Client.Reliable;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests;
+
+// Test some multi-threading scenarios
+public class MultiThreadTests
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public MultiThreadTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    /// <summary>
+    /// Producer send messages in multi threads
+    /// Messages internally should be send one at a time
+    /// The best way to use the producer is to send messages in one thread
+    /// but we have to guarantee the multi-threading scenario
+    /// In this PR https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/pull/220
+    /// we improved the producer to send messages in multi threads avoiding the
+    /// client timeout error
+    /// </summary>
+    [Fact]
+    public async Task PublishMessagesInMultiThreads()
+    {
+        SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
+        var receivedTask = new TaskCompletionSource<int>();
+        var confirmed = 0;
+        var error = 0;
+        var producer = await Producer.Create(new ProducerConfig(system, stream)
+        {
+            ConfirmationHandler = async confirmation =>
+            {
+                switch (confirmation.Status)
+                {
+                    case ConfirmationStatus.Confirmed:
+                        Interlocked.Increment(ref confirmed);
+                        break;
+
+                    default:
+                        Interlocked.Increment(ref error);
+                        break;
+                }
+
+                if (error + confirmed == 802)
+                {
+                    receivedTask.SetResult(confirmed);
+                }
+
+                await Task.CompletedTask;
+            }
+        });
+
+        for (var i = 0; i < 2; i++)
+        {
+            _ = Task.Run(async () =>
+            {
+                for (var j = 0; j < 401; j++)
+                {
+                    await producer.Send(new RabbitMQ.Stream.Client.Message(new byte[3]));
+                }
+            });
+        }
+
+        new Utils<int>(_testOutputHelper).WaitUntilTaskCompletes(receivedTask);
+        Assert.Equal(802, confirmed);
+        Assert.Equal(802, receivedTask.Task.Result);
+        Assert.Equal(0, error);
+        await system.DeleteStream(stream);
+    }
+}

--- a/Tests/RawProducerSystemTests.cs
+++ b/Tests/RawProducerSystemTests.cs
@@ -272,7 +272,7 @@ namespace Tests
         }
 
         [Fact]
-        public async void ProducerBatchSendValidate()
+        public async void ProducerSendValidate()
         {
             SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
             // validate that the messages batch size is not greater than the MaxInFlight
@@ -296,6 +296,10 @@ namespace Tests
             // we can't send messages greater than 1048576 bytes
             messages.Add((1, new Message(new byte[1048576 * 2]))); // 2MB >  MaxFrameSize so it must raise an exception
             await Assert.ThrowsAsync<InvalidOperationException>(() => rawProducer.Send(messages).AsTask());
+
+            var messagetoBig = new Message(new byte[1048576 * 2]); // 2MB >  MaxFrameSize so it must raise an exception
+            await Assert.ThrowsAsync<InvalidOperationException>(() => rawProducer.Send(2, messagetoBig).AsTask());
+
             await system.DeleteStream(stream);
             await system.Close();
         }

--- a/Tests/RawProducerSystemTests.cs
+++ b/Tests/RawProducerSystemTests.cs
@@ -129,7 +129,7 @@ namespace Tests
         }
 
         [Fact]
-        public async void ProducerMessagesListLenValidation()
+        public async Task ProducerMessagesListLenValidation()
         {
             // by protocol the subEntryList is ushort
             var messages = new List<Message>();

--- a/kubernetes/stream_cluster.yaml
+++ b/kubernetes/stream_cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stream-clients-test
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: rabbitmq-stream
+  namespace: stream-clients-test
+spec:
+  replicas: 1
+  service:
+    type: LoadBalancer
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 800m
+      memory: 1Gi
+  rabbitmq:
+    additionalPlugins:
+      - rabbitmq_stream
+      - rabbitmq_stream_management


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/pull/220 and part of https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/145

How to reproduce the issue:
---
See https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/221#issuecomment-1408242039
Important:
 - Server has to be remote
 - the body needs to be bigger than 3k


Main changes:
---

- Make the `WriteCommand` Async:
https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/blob/5c695ef3862dd2f6ec0b72c52570e9c282a0ef34/RabbitMQ.Stream.Client/Connection.cs#L99-L114

Remove sync Waits (because of https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2012) :
https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/blob/5c695ef3862dd2f6ec0b72c52570e9c282a0ef34/RabbitMQ.Stream.Client/Connection.cs#L89-L97
 

- Make the Async Blocking:
https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/blob/5c695ef3862dd2f6ec0b72c52570e9c282a0ef34/RabbitMQ.Stream.Client/RawProducer.cs#L161-L164
It caused a lot of timeout operations but without any action to handle the problem.


- Move the semaphore scope on the Producer Class:
https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/blob/5c695ef3862dd2f6ec0b72c52570e9c282a0ef34/RabbitMQ.Stream.Client/Reliable/Producer.cs#L207

It caused `Client timeout Error` in case of multi-threads publish


Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>