### PR TITLE
Improve the reconnect

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -224,6 +224,9 @@ csharp_space_between_square_brackets = false
 # Analyzers
 dotnet_code_quality.ca1802.api_surface = private, internal
 
+# CA2007: Do not directly await a Task
+dotnet_diagnostic.CA2007.severity = warning
+
 # IDE0073: File header
 dotnet_diagnostic.IDE0073.severity = warning
 file_header_template =  This source code is dual-licensed under the Apache License, version\n2.0, and the Mozilla Public License, version 2.0.\nCopyright (c) 2007-2023 VMware, Inc.

--- a/Examples/SuperStream/SuperStreamConsumer.cs
+++ b/Examples/SuperStream/SuperStreamConsumer.cs
@@ -17,6 +17,7 @@ public static class SuperStreamConsumer
         var system = await StreamSystem.Create(config);
 
         Console.WriteLine("Super Stream Consumer connected to RabbitMQ. ConsumerName {0}", consumerName);
+
         var consumer = await Consumer.Create(new ConsumerConfig(system, Costants.StreamName)
         {
             IsSuperStream = true, // Mandatory for enabling the super stream
@@ -25,12 +26,13 @@ public static class SuperStreamConsumer
             // must have the same ReferenceName for all the consumers
             Reference = "MyApp",
             OffsetSpec = new OffsetTypeFirst(),
+            
             MessageHandler = async (stream, consumer1, context, message) =>
             {
                 Console.WriteLine(
                     $"Consumer Name {consumerName} -Received message id: {message.Properties.MessageId} body: {Encoding.UTF8.GetString(message.Data.Contents)}, Stream {stream}");
-                await Task.CompletedTask;
+                await Task.CompletedTask.ConfigureAwait(false);
             }
-        });
+        }).ConfigureAwait(false);
     }
 }

--- a/Examples/SuperStream/SuperStreamProducer.cs
+++ b/Examples/SuperStream/SuperStreamProducer.cs
@@ -15,7 +15,7 @@ public class SuperStreamProducer
     {
         Console.WriteLine("Starting SuperStream Producer");
         var config = new StreamSystemConfig();
-        var system = await StreamSystem.Create(config);
+        var system = await StreamSystem.Create(config).ConfigureAwait(false);
         Console.WriteLine("Super Stream Producer connected to RabbitMQ");
         // We define a Producer with the SuperStream name (that is the Exchange name)
         var producer = await Producer.Create(new ProducerConfig(system, Costants.StreamName)
@@ -25,7 +25,7 @@ public class SuperStreamProducer
                 // The super stream is enable and we define the routing hashing algorithm
                 Routing = msg => msg.Properties.MessageId.ToString()
             }
-        });
+        }).ConfigureAwait(false);
         const int NumberOfMessages = 1_000_000;
         for (var i = 0; i < NumberOfMessages; i++)
         {
@@ -33,7 +33,7 @@ public class SuperStreamProducer
             {
                 Properties = new Properties() {MessageId = $"hello{i}"}
             };
-            await producer.Send(message);
+            await producer.Send(message).ConfigureAwait(false);
             Console.WriteLine("Super Stream Producer sent {0} messages to {1}", i, Costants.StreamName);
             Thread.Sleep(TimeSpan.FromSeconds(1));
         }

--- a/RabbitMQ.Stream.Client/AbstractEntity.cs
+++ b/RabbitMQ.Stream.Client/AbstractEntity.cs
@@ -2,10 +2,24 @@
 // 2.0, and the Mozilla Public License, version 2.0.
 // Copyright (c) 2007-2023 VMware, Inc.
 
+using System.Threading;
+
 namespace RabbitMQ.Stream.Client
 {
     public abstract class AbstractEntity
     {
+        private readonly CancellationTokenSource _cancelTokenSource = new();
+        protected CancellationToken Token => _cancelTokenSource.Token;
+
+        // here the _cancelTokenSource is disposed and the token is cancelled
+        // in producer is used to cancel the send task
+        // in consumer is used to cancel the receive task
+        protected void MaybeCancelToken()
+        {
+            if (!_cancelTokenSource.IsCancellationRequested)
+                _cancelTokenSource.Cancel();
+        }
+
         protected Client _client;
     }
 }

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -190,7 +190,8 @@ namespace RabbitMQ.Stream.Client
         {
             if (ConnectionClosed != null)
             {
-                await ConnectionClosed?.Invoke(reason)!;
+                var t = ConnectionClosed?.Invoke(reason)!;
+                await t.ConfigureAwait(false);
             }
         }
 
@@ -198,35 +199,30 @@ namespace RabbitMQ.Stream.Client
         {
             var client = new Client(parameters, logger);
 
-            client.connection = await Connection.Create(parameters.Endpoint,
-                client.HandleIncoming, client.HandleClosed, parameters.Ssl);
+            client.connection = await Connection.Create(parameters.Endpoint, client.HandleIncoming, client.HandleClosed, parameters.Ssl).ConfigureAwait(false);
 
             // exchange properties
-            var peerPropertiesResponse =
-                await client.Request<PeerPropertiesRequest, PeerPropertiesResponse>(corr =>
-                    new PeerPropertiesRequest(corr, parameters.Properties));
+            await client.Request<PeerPropertiesRequest, PeerPropertiesResponse>(corr =>
+                new PeerPropertiesRequest(corr, parameters.Properties)).ConfigureAwait(false);
             logger?.LogDebug("Server properties: {@Properties}", parameters.Properties);
 
             //auth
             var saslHandshakeResponse =
-                await client.Request<SaslHandshakeRequest, SaslHandshakeResponse>(
-                    corr => new SaslHandshakeRequest(corr));
+                await client.Request<SaslHandshakeRequest, SaslHandshakeResponse>(corr => new SaslHandshakeRequest(corr)).ConfigureAwait(false);
             logger?.LogDebug("Sasl mechanism: {Mechanisms}", saslHandshakeResponse.Mechanisms);
 
             var saslData = Encoding.UTF8.GetBytes($"\0{parameters.UserName}\0{parameters.Password}");
             var authResponse =
-                await client.Request<SaslAuthenticateRequest, SaslAuthenticateResponse>(corr =>
-                    new SaslAuthenticateRequest(corr, "PLAIN", saslData));
+                await client.Request<SaslAuthenticateRequest, SaslAuthenticateResponse>(corr => new SaslAuthenticateRequest(corr, "PLAIN", saslData)).ConfigureAwait(false);
             ClientExceptions.MaybeThrowException(authResponse.ResponseCode, parameters.UserName);
 
             //tune
-            await client.tuneReceived.Task;
+            await client.tuneReceived.Task.ConfigureAwait(false);
             await client.Publish(new TuneRequest(0,
-                (uint)client.Parameters.Heartbeat.TotalSeconds));
+                (uint)client.Parameters.Heartbeat.TotalSeconds)).ConfigureAwait(false);
 
             // open 
-            var open = await client.Request<OpenRequest, OpenResponse>(corr =>
-                new OpenRequest(corr, parameters.VirtualHost));
+            var open = await client.Request<OpenRequest, OpenResponse>(corr => new OpenRequest(corr, parameters.VirtualHost)).ConfigureAwait(false);
             ClientExceptions.MaybeThrowException(open.ResponseCode, parameters.VirtualHost);
             logger?.LogDebug("Open: ConnectionProperties: {ConnectionProperties}", open.ConnectionProperties);
             client.ConnectionProperties = open.ConnectionProperties;
@@ -239,7 +235,7 @@ namespace RabbitMQ.Stream.Client
 
         public async ValueTask<bool> Publish(Publish publishMsg)
         {
-            var publishTask = await Publish<Publish>(publishMsg);
+            var publishTask = await Publish<Publish>(publishMsg).ConfigureAwait(false);
 
             publishCommandsSent += 1;
             messagesSent += publishMsg.MessageCount;
@@ -259,7 +255,7 @@ namespace RabbitMQ.Stream.Client
             var publisherId = nextPublisherId++;
             publishers.Add(publisherId, (confirmCallback, errorCallback));
             return (publisherId, await Request<DeclarePublisherRequest, DeclarePublisherResponse>(corr =>
-                new DeclarePublisherRequest(corr, publisherId, publisherRef, stream)));
+                new DeclarePublisherRequest(corr, publisherId, publisherRef, stream)).ConfigureAwait(false));
         }
 
         public async Task<DeletePublisherResponse> DeletePublisher(byte publisherId)
@@ -268,7 +264,7 @@ namespace RabbitMQ.Stream.Client
             {
                 var result =
                     await Request<DeletePublisherRequest, DeletePublisherResponse>(corr =>
-                        new DeletePublisherRequest(corr, publisherId));
+                        new DeletePublisherRequest(corr, publisherId)).ConfigureAwait(false);
 
                 return result;
             }
@@ -287,7 +283,7 @@ namespace RabbitMQ.Stream.Client
                 initialCredit,
                 properties,
                 deliverHandler,
-                consumerUpdateHandler);
+                consumerUpdateHandler).ConfigureAwait(false);
         }
 
         public async Task<(byte, SubscribeResponse)> Subscribe(RawConsumerConfig config,
@@ -305,7 +301,7 @@ namespace RabbitMQ.Stream.Client
             return (subscriptionId,
                 await Request<SubscribeRequest, SubscribeResponse>(corr =>
                     new SubscribeRequest(corr, subscriptionId, config.Stream, config.OffsetSpec, initialCredit,
-                        properties)));
+                        properties)).ConfigureAwait(false));
         }
 
         public async Task<UnsubscribeResponse> Unsubscribe(byte subscriptionId)
@@ -314,7 +310,7 @@ namespace RabbitMQ.Stream.Client
             {
                 var result =
                     await Request<UnsubscribeRequest, UnsubscribeResponse>(corr =>
-                        new UnsubscribeRequest(corr, subscriptionId));
+                        new UnsubscribeRequest(corr, subscriptionId)).ConfigureAwait(false);
                 return result;
             }
             finally
@@ -327,7 +323,7 @@ namespace RabbitMQ.Stream.Client
         public async Task<PartitionsQueryResponse> QueryPartition(string superStream)
         {
             return await Request<PartitionsQueryRequest, PartitionsQueryResponse>(corr =>
-                new PartitionsQueryRequest(corr, superStream));
+                new PartitionsQueryRequest(corr, superStream)).ConfigureAwait(false);
         }
 
         private async ValueTask<TOut> Request<TIn, TOut>(Func<uint, TIn> request, TimeSpan? timeout = null)
@@ -336,15 +332,15 @@ namespace RabbitMQ.Stream.Client
             var corr = NextCorrelationId();
             var tcs = PooledTaskSource<TOut>.Rent();
             requests.TryAdd(corr, tcs);
-            await Publish(request(corr));
+            await Publish(request(corr)).ConfigureAwait(false);
             using var cts = new CancellationTokenSource(timeout ?? defaultTimeout);
             await using (cts.Token.Register(
                              valueTaskSource =>
                                  ((ManualResetValueTaskSource<TOut>)valueTaskSource).SetException(
-                                     new TimeoutException()), tcs))
+                                     new TimeoutException()), tcs).ConfigureAwait(false))
             {
                 var valueTask = new ValueTask<TOut>(tcs, tcs.Version);
-                var result = await valueTask;
+                var result = await valueTask.ConfigureAwait(false);
                 PooledTaskSource<TOut>.Return(tcs);
                 return result;
             }
@@ -358,7 +354,7 @@ namespace RabbitMQ.Stream.Client
         private async Task HandleClosed(string reason)
         {
             InternalClose();
-            await OnConnectionClosed(reason);
+            await OnConnectionClosed(reason).ConfigureAwait(false);
         }
 
         private async Task HandleIncoming(Memory<byte> frameMemory)
@@ -412,7 +408,7 @@ namespace RabbitMQ.Stream.Client
                     var consumerEventsUpd = consumers[consumerUpdateQueryResponse.SubscriptionId];
                     await ConsumerUpdateResponse(
                         consumerUpdateQueryResponse.CorrelationId,
-                        await consumerEventsUpd.ConsumerUpdateHandler(consumerUpdateQueryResponse.IsActive));
+                        await consumerEventsUpd.ConsumerUpdateHandler(consumerUpdateQueryResponse.IsActive).ConfigureAwait(false)).ConfigureAwait(false);
                     break;
                 case CreditResponse.Key:
                     CreditResponse.Read(frame, out var creditResponse);
@@ -526,7 +522,7 @@ namespace RabbitMQ.Stream.Client
 
         private async ValueTask<bool> SendHeartBeat()
         {
-            return await Publish(new HeartBeatRequest());
+            return await Publish(new HeartBeatRequest()).ConfigureAwait(false);
         }
 
         private void InternalClose()
@@ -537,7 +533,7 @@ namespace RabbitMQ.Stream.Client
 
         private async ValueTask<bool> ConsumerUpdateResponse(uint rCorrelationId, IOffsetType offsetSpecification)
         {
-            return await Publish(new ConsumerUpdateRequest(rCorrelationId, offsetSpecification));
+            return await Publish(new ConsumerUpdateRequest(rCorrelationId, offsetSpecification)).ConfigureAwait(false);
         }
 
         public async Task<CloseResponse> Close(string reason)
@@ -551,7 +547,7 @@ namespace RabbitMQ.Stream.Client
             {
                 var result =
                     await Request<CloseRequest, CloseResponse>(corr => new CloseRequest(corr, reason),
-                        TimeSpan.FromSeconds(10));
+                        TimeSpan.FromSeconds(10)).ConfigureAwait(false);
 
                 InternalClose();
                 connection.Dispose();
@@ -588,23 +584,23 @@ namespace RabbitMQ.Stream.Client
         public async ValueTask<QueryPublisherResponse> QueryPublisherSequence(string publisherRef, string stream)
         {
             return await Request<QueryPublisherRequest, QueryPublisherResponse>(corr =>
-                new QueryPublisherRequest(corr, publisherRef, stream));
+                new QueryPublisherRequest(corr, publisherRef, stream)).ConfigureAwait(false);
         }
 
         public async ValueTask<bool> StoreOffset(string reference, string stream, ulong offsetValue)
         {
-            return await Publish(new StoreOffsetRequest(stream, reference, offsetValue));
+            return await Publish(new StoreOffsetRequest(stream, reference, offsetValue)).ConfigureAwait(false);
         }
 
         public async ValueTask<MetaDataResponse> QueryMetadata(string[] streams)
         {
-            return await Request<MetaDataQuery, MetaDataResponse>(corr => new MetaDataQuery(corr, streams.ToList()));
+            return await Request<MetaDataQuery, MetaDataResponse>(corr => new MetaDataQuery(corr, streams.ToList())).ConfigureAwait(false);
         }
 
         public async Task<bool> StreamExists(string stream)
         {
             var streams = new[] { stream };
-            var response = await QueryMetadata(streams);
+            var response = await QueryMetadata(streams).ConfigureAwait(false);
             return response.StreamInfos is { Count: >= 1 } &&
                    response.StreamInfos[stream].ResponseCode == ResponseCode.Ok;
         }
@@ -612,22 +608,22 @@ namespace RabbitMQ.Stream.Client
         public async ValueTask<QueryOffsetResponse> QueryOffset(string reference, string stream)
         {
             return await Request<QueryOffsetRequest, QueryOffsetResponse>(corr =>
-                new QueryOffsetRequest(stream, corr, reference));
+                new QueryOffsetRequest(stream, corr, reference)).ConfigureAwait(false);
         }
 
         public async ValueTask<CreateResponse> CreateStream(string stream, IDictionary<string, string> args)
         {
-            return await Request<CreateRequest, CreateResponse>(corr => new CreateRequest(corr, stream, args));
+            return await Request<CreateRequest, CreateResponse>(corr => new CreateRequest(corr, stream, args)).ConfigureAwait(false);
         }
 
         public async ValueTask<DeleteResponse> DeleteStream(string stream)
         {
-            return await Request<DeleteRequest, DeleteResponse>(corr => new DeleteRequest(corr, stream));
+            return await Request<DeleteRequest, DeleteResponse>(corr => new DeleteRequest(corr, stream)).ConfigureAwait(false);
         }
 
         public async ValueTask<bool> Credit(byte subscriptionId, ushort credit)
         {
-            return await Publish(new CreditRequest(subscriptionId, credit));
+            return await Publish(new CreditRequest(subscriptionId, credit)).ConfigureAwait(false);
         }
     }
 

--- a/RabbitMQ.Stream.Client/Compression.cs
+++ b/RabbitMQ.Stream.Client/Compression.cs
@@ -152,10 +152,7 @@ namespace RabbitMQ.Stream.Client
 
         public static void UnRegisterCodec(CompressionType compressionType)
         {
-            if (AvailableCompressCodecs.ContainsKey(compressionType))
-            {
-                AvailableCompressCodecs.Remove(compressionType);
-            }
+            AvailableCompressCodecs.Remove(compressionType);
         }
 
         public static ICompressionCodec GetCompressionCodec(CompressionType compressionType)

--- a/RabbitMQ.Stream.Client/Connection.cs
+++ b/RabbitMQ.Stream.Client/Connection.cs
@@ -64,7 +64,7 @@ namespace RabbitMQ.Stream.Client
 
             try
             {
-                await socket.ConnectAsync(endpoint);
+                await socket.ConnectAsync(endpoint).ConfigureAwait(false);
             }
             catch (SocketException ex)
             {
@@ -88,7 +88,7 @@ namespace RabbitMQ.Stream.Client
 
         public async ValueTask<bool> Write<T>(T command) where T : struct, ICommand
         {
-            await WriteCommand(command);
+            await WriteCommand(command).ConfigureAwait(false);
             // we return true to indicate that the command was written
             // In this PR https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/pull/220
             // we made all WriteCommand async so await is enough to indicate that the command was written
@@ -99,16 +99,16 @@ namespace RabbitMQ.Stream.Client
         private async Task WriteCommand<T>(T command) where T : struct, ICommand
         {
             // Only one thread should be able to write to the output pipeline at a time.
-            await _writeLock.WaitAsync();
+            await _writeLock.WaitAsync().ConfigureAwait(false);
             try
             {
                 var size = command.SizeNeeded;
                 var mem = new byte[4 + size]; // + 4 to write the size
                 WireFormatting.WriteUInt32(mem, (uint)size);
                 var written = command.Write(mem.AsSpan()[4..]);
-                await writer.WriteAsync(new ReadOnlyMemory<byte>(mem));
+                await writer.WriteAsync(new ReadOnlyMemory<byte>(mem)).ConfigureAwait(false);
                 Debug.Assert(size == written);
-                await writer.FlushAsync();
+                await writer.FlushAsync().ConfigureAwait(false);
             }
             finally
             {
@@ -153,7 +153,7 @@ namespace RabbitMQ.Stream.Client
 
                 // Mark the PipeReader as complete
 
-                await reader.CompleteAsync();
+                await reader.CompleteAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -166,7 +166,8 @@ namespace RabbitMQ.Stream.Client
             finally
             {
                 isClosed = true;
-                await closedCallback?.Invoke("TCP Connection Closed")!;
+                var t = closedCallback?.Invoke("TCP Connection Closed")!;
+                await t.ConfigureAwait(false);
                 Debug.WriteLine("TCP Connection Closed");
             }
         }

--- a/RabbitMQ.Stream.Client/HeartBeatHandler.cs
+++ b/RabbitMQ.Stream.Client/HeartBeatHandler.cs
@@ -57,7 +57,7 @@ public class HeartBeatHandler
     private async Task PerformHeartBeatAsync()
     {
         var f = _sendHeartbeatFunc();
-        await f.AsTask().WaitAsync(TimeSpan.FromMilliseconds(1000));
+        await f.AsTask().WaitAsync(TimeSpan.FromMilliseconds(1000)).ConfigureAwait(false);
 
         var seconds = (DateTime.Now - _lastUpdate).TotalSeconds;
         if (seconds < _heartbeat)
@@ -77,7 +77,7 @@ public class HeartBeatHandler
         // client will be closed
         _logger.LogCritical("Too many heartbeats missed: {MissedHeartbeatCounter}", _missedHeartbeat);
         Close();
-        await _close($"Too many heartbeats missed: {_missedHeartbeat}. Client connection will be closed.");
+        await _close($"Too many heartbeats missed: {_missedHeartbeat}. Client connection will be closed.").ConfigureAwait(false);
     }
 
     internal void UpdateHeartBeat()

--- a/RabbitMQ.Stream.Client/MetaData.cs
+++ b/RabbitMQ.Stream.Client/MetaData.cs
@@ -131,7 +131,7 @@ namespace RabbitMQ.Stream.Client
                 if (brokers.Count > 0)
                 {
                     var replicas = replicaRefs.Select(r => brokers[r]).ToList();
-                    var leader = brokers.ContainsKey(leaderRef) ? brokers[leaderRef] : default;
+                    var leader = brokers.TryGetValue(leaderRef, out var value) ? value : default;
                     streamInfos.Add(stream, new StreamInfo(stream, (ResponseCode)code, leader, replicas));
                 }
                 else

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
+RabbitMQ.Stream.Client.AbstractEntity.MaybeCancelToken() -> void
+RabbitMQ.Stream.Client.AbstractEntity.Token.get -> System.Threading.CancellationToken
 RabbitMQ.Stream.Client.Chunk.MagicVersion.get -> byte

--- a/RabbitMQ.Stream.Client/Reliable/ConfirmationPipe.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConfirmationPipe.cs
@@ -124,7 +124,7 @@ public class ConfirmationPipe
 
         foreach (var pair in timedOutMessages)
         {
-            await RemoveUnConfirmedMessage(ConfirmationStatus.ClientTimeoutError, pair.Value.PublishingId, null);
+            await RemoveUnConfirmedMessage(ConfirmationStatus.ClientTimeoutError, pair.Value.PublishingId, null).ConfigureAwait(false);
         }
     }
 

--- a/RabbitMQ.Stream.Client/Reliable/ConfirmationPipe.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConfirmationPipe.cs
@@ -136,7 +136,13 @@ public class ConfirmationPipe
     internal void AddUnConfirmedMessage(ulong publishingId, List<Message> messages)
     {
         _waitForConfirmation.TryAdd(publishingId,
-            new MessagesConfirmation { Messages = messages, PublishingId = publishingId, InsertDateTime = DateTime.Now });
+            new MessagesConfirmation
+            {
+                // We need to copy the messages because the user can reuse the same message or deleted them.
+                Messages = new List<Message>(messages),
+                PublishingId = publishingId,
+                InsertDateTime = DateTime.Now
+            });
     }
 
     internal Task RemoveUnConfirmedMessage(ConfirmationStatus confirmationStatus, ulong publishingId, string stream)

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -134,7 +134,7 @@ public class Consumer : ConsumerFactory
     {
         consumerConfig.ReconnectStrategy ??= new BackOffReconnectStrategy(logger);
         var rConsumer = new Consumer(consumerConfig, logger);
-        await rConsumer.Init(consumerConfig.ReconnectStrategy);
+        await rConsumer.Init(consumerConfig.ReconnectStrategy).ConfigureAwait(false);
         logger?.LogDebug("Consumer: {Reference} created for Stream: {Stream}",
             consumerConfig.Reference, consumerConfig.Stream);
 
@@ -143,19 +143,19 @@ public class Consumer : ConsumerFactory
 
     internal override async Task CreateNewEntity(bool boot)
     {
-        _consumer = await CreateConsumer(boot);
-        await _consumerConfig.ReconnectStrategy.WhenConnected(ToString());
+        _consumer = await CreateConsumer(boot).ConfigureAwait(false);
+        await _consumerConfig.ReconnectStrategy.WhenConnected(ToString()).ConfigureAwait(false);
     }
 
     // just close the consumer. See base/metadataupdate
     protected override async Task CloseEntity()
     {
-        await SemaphoreSlim.WaitAsync(10);
+        await SemaphoreSlim.WaitAsync(10).ConfigureAwait(false);
         try
         {
             if (_consumer != null)
             {
-                await _consumer.Close();
+                await _consumer.Close().ConfigureAwait(false);
             }
         }
         finally
@@ -167,7 +167,7 @@ public class Consumer : ConsumerFactory
     public override async Task Close()
     {
         _isOpen = false;
-        await CloseEntity();
+        await CloseEntity().ConfigureAwait(false);
         _logger?.LogDebug("Consumer closed for stream {Stream}", _consumerConfig.Stream);
     }
 

--- a/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
@@ -27,10 +27,10 @@ public abstract class ConsumerFactory : ReliableBase
     {
         if (_consumerConfig.IsSuperStream)
         {
-            return await SuperConsumer(boot);
+            return await SuperConsumer(boot).ConfigureAwait(false);
         }
 
-        return await StandardConsumer(boot);
+        return await StandardConsumer(boot).ConfigureAwait(false);
     }
 
     private async Task<IConsumer> StandardConsumer(bool boot)
@@ -52,7 +52,7 @@ public abstract class ConsumerFactory : ReliableBase
             OffsetSpec = offsetSpec,
             ConnectionClosedHandler = async _ =>
             {
-                await TryToReconnect(_consumerConfig.ReconnectStrategy);
+                await TryToReconnect(_consumerConfig.ReconnectStrategy).ConfigureAwait(false);
             },
             MetadataHandler = update =>
             {
@@ -70,11 +70,10 @@ public abstract class ConsumerFactory : ReliableBase
                 _lastOffsetConsumed[_consumerConfig.Stream] = ctx.Offset;
                 if (_consumerConfig.MessageHandler != null)
                 {
-                    await _consumerConfig.MessageHandler(_consumerConfig.Stream, consumer, ctx,
-                        message);
+                    await _consumerConfig.MessageHandler(_consumerConfig.Stream, consumer, ctx, message).ConfigureAwait(false);
                 }
             },
-        }, BaseLogger);
+        }, BaseLogger).ConfigureAwait(false);
     }
 
     private async Task<IConsumer> SuperConsumer(bool boot)
@@ -92,7 +91,7 @@ public abstract class ConsumerFactory : ReliableBase
         }
         else
         {
-            var partitions = await _consumerConfig.StreamSystem.QueryPartition(_consumerConfig.Stream);
+            var partitions = await _consumerConfig.StreamSystem.QueryPartition(_consumerConfig.Stream).ConfigureAwait(false);
             foreach (var partition in partitions)
             {
                 offsetSpecs[partition] =
@@ -115,9 +114,9 @@ public abstract class ConsumerFactory : ReliableBase
                     if (_consumerConfig.MessageHandler != null)
                     {
                         await _consumerConfig.MessageHandler(stream, consumer, ctx,
-                            message);
+                            message).ConfigureAwait(false);
                     }
                 },
-            }, BaseLogger);
+            }, BaseLogger).ConfigureAwait(false);
     }
 }

--- a/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
+++ b/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
@@ -62,7 +62,7 @@ internal class BackOffReconnectStrategy : IReconnectStrategy
             connectionIdentifier,
             Tentatives * 100
         );
-        await Task.Delay(TimeSpan.FromMilliseconds(Tentatives * 100));
+        await Task.Delay(TimeSpan.FromMilliseconds(Tentatives * 100)).ConfigureAwait(false);
         MaybeResetTentatives();
         return true;
     }

--- a/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
@@ -23,10 +23,10 @@ public abstract class ProducerFactory : ReliableBase
     {
         if (_producerConfig.SuperStreamConfig is { Enabled: true })
         {
-            return await SuperStreamProducer();
+            return await SuperStreamProducer().ConfigureAwait(false);
         }
 
-        return await StandardProducer();
+        return await StandardProducer().ConfigureAwait(false);
     }
 
     private async Task<IProducer> SuperStreamProducer()
@@ -55,7 +55,7 @@ public abstract class ProducerFactory : ReliableBase
                     _confirmationPipe.RemoveUnConfirmedMessage(confirmationStatus, confirmation.PublishingId,
                         stream);
                 }
-            }, BaseLogger);
+            }, BaseLogger).ConfigureAwait(false);
     }
 
     private async Task<IProducer> StandardProducer()
@@ -77,7 +77,7 @@ public abstract class ProducerFactory : ReliableBase
                         _producerConfig.StreamSystem).WaitAsync(CancellationToken.None);
                 });
             },
-            ConnectionClosedHandler = async _ => { await TryToReconnect(_producerConfig.ReconnectStrategy); },
+            ConnectionClosedHandler = async _ => { await TryToReconnect(_producerConfig.ReconnectStrategy).ConfigureAwait(false); },
             ConfirmHandler = confirmation =>
             {
                 var confirmationStatus = confirmation.Code switch
@@ -93,6 +93,6 @@ public abstract class ProducerFactory : ReliableBase
                 _confirmationPipe.RemoveUnConfirmedMessage(confirmationStatus, confirmation.PublishingId,
                     confirmation.Stream);
             }
-        }, BaseLogger);
+        }, BaseLogger).ConfigureAwait(false);
     }
 }

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -1,0 +1,2 @@
+[*.{cs,vb}]
+dotnet_diagnostic.CA2007.severity = none

--- a/Tests/ClientTests.cs
+++ b/Tests/ClientTests.cs
@@ -239,7 +239,7 @@ namespace Tests
                 }));
             new Utils<Deliver>(testOutputHelper).WaitUntilTaskCompletes(testPassed);
 
-            Assert.Equal(2, messages.Count());
+            Assert.Equal(2, messages.Count);
             await client.DeleteStream(stream);
             await client.Close("done");
         }

--- a/Tests/MultiThreadTests.cs
+++ b/Tests/MultiThreadTests.cs
@@ -108,7 +108,6 @@ public class MultiThreadTests
             Assert.All(producers, p => Assert.False(p.IsOpen()));
         }
 
-
         var consumers = new List<Consumer>();
         for (var i = 0; i < 10; i++)
         {
@@ -127,7 +126,6 @@ public class MultiThreadTests
 
         SystemUtils.Wait();
         Assert.All(consumers, c => Assert.False(c.IsOpen()));
-
 
         await system.DeleteStream(stream);
         await system.Close();

--- a/Tests/MultiThreadTests.cs
+++ b/Tests/MultiThreadTests.cs
@@ -101,10 +101,10 @@ public class MultiThreadTests
             });
             for (var j = 0; j < 10000; j++)
             {
-                await producer.Send(new RabbitMQ.Stream.Client.Message(new byte[3]));
+                await producer.Send(new Message(new byte[3]));
             }
 
-            SystemUtils.Wait();
+            SystemUtils.WaitUntil(() => producers.TrueForAll(c => !c.IsOpen()));
             Assert.All(producers, p => Assert.False(p.IsOpen()));
         }
 
@@ -124,9 +124,8 @@ public class MultiThreadTests
             });
         }
 
-        SystemUtils.Wait();
+        SystemUtils.WaitUntil(() => consumers.TrueForAll(c => !c.IsOpen()));
         Assert.All(consumers, c => Assert.False(c.IsOpen()));
-
         await system.DeleteStream(stream);
         await system.Close();
     }

--- a/Tests/ReliableTests.cs
+++ b/Tests/ReliableTests.cs
@@ -227,7 +227,7 @@ public class ReliableTests
         await producer.HandleMetaDataMaybeReconnect(stream, system);
         SystemUtils.Wait();
         Assert.True(producer.IsOpen());
-        // await system.DeleteStream(stream);
+        await system.DeleteStream(stream);
         await system.Close();
     }
 

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -339,7 +339,7 @@ namespace Tests
                 return 0;
             }
 
-            return obj.ContainsKey("messages_ready") ? Convert.ToInt32(obj["messages_ready"].ToString()) : 0;
+            return obj.TryGetValue("messages_ready", out var value) ? Convert.ToInt32(value.ToString()) : 0;
         }
 
         public static void HttpPost(string jsonBody, string api)


### PR DESCRIPTION
Handle some edge cases where the producer or consumer could go into a deadlock waiting for the semaphore.

Add the Cancellation token producer side and call the token cancellation when the producer and the consumer are forced to disconnect.

I did this [CaosTest](https://github.com/Gsantomaggio/rabbitmq-utils/tree/master/client_caos/Caos) for the stream client.

Where the connections are closed randomly.
```
Messages sent: 344800 -Messages confirmed: 227737 - Messages error: 1024 - Total 228761  Messages consumed: 169337
Messages sent: 397000 -Messages confirmed: 279919 - Messages error: 116082 - Total 396001  Messages consumed: 206422
```

Client should be able to reconnect and continue to produce and consume 

 

Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>