### PR TITLE
ConfigureAwait(false) for close stream/consumer/producer, query offset and create producer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -224,6 +224,9 @@ csharp_space_between_square_brackets = false
 # Analyzers
 dotnet_code_quality.ca1802.api_surface = private, internal
 
+# CA2007: Do not directly await a Task
+dotnet_diagnostic.CA2007.severity = warning
+
 # IDE0073: File header
 dotnet_diagnostic.IDE0073.severity = warning
 file_header_template =  This source code is dual-licensed under the Apache License, version\n2.0, and the Mozilla Public License, version 2.0.\nCopyright (c) 2007-2023 VMware, Inc.

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -301,7 +301,7 @@ namespace RabbitMQ.Stream.Client
             return (subscriptionId,
                 await Request<SubscribeRequest, SubscribeResponse>(corr =>
                     new SubscribeRequest(corr, subscriptionId, config.Stream, config.OffsetSpec, initialCredit,
-                        properties)));
+                        properties)).ConfigureAwait(false));
         }
 
         public async Task<UnsubscribeResponse> Unsubscribe(byte subscriptionId)
@@ -354,7 +354,7 @@ namespace RabbitMQ.Stream.Client
         private async Task HandleClosed(string reason)
         {
             InternalClose();
-            await OnConnectionClosed(reason);
+            await OnConnectionClosed(reason).ConfigureAwait(false);
         }
 
         private async Task HandleIncoming(Memory<byte> frameMemory)
@@ -408,7 +408,7 @@ namespace RabbitMQ.Stream.Client
                     var consumerEventsUpd = consumers[consumerUpdateQueryResponse.SubscriptionId];
                     await ConsumerUpdateResponse(
                         consumerUpdateQueryResponse.CorrelationId,
-                        await consumerEventsUpd.ConsumerUpdateHandler(consumerUpdateQueryResponse.IsActive));
+                        await consumerEventsUpd.ConsumerUpdateHandler(consumerUpdateQueryResponse.IsActive).ConfigureAwait(false)).ConfigureAwait(false);
                     break;
                 case CreditResponse.Key:
                     CreditResponse.Read(frame, out var creditResponse);
@@ -522,7 +522,7 @@ namespace RabbitMQ.Stream.Client
 
         private async ValueTask<bool> SendHeartBeat()
         {
-            return await Publish(new HeartBeatRequest());
+            return await Publish(new HeartBeatRequest()).ConfigureAwait(false);
         }
 
         private void InternalClose()
@@ -533,7 +533,7 @@ namespace RabbitMQ.Stream.Client
 
         private async ValueTask<bool> ConsumerUpdateResponse(uint rCorrelationId, IOffsetType offsetSpecification)
         {
-            return await Publish(new ConsumerUpdateRequest(rCorrelationId, offsetSpecification));
+            return await Publish(new ConsumerUpdateRequest(rCorrelationId, offsetSpecification)).ConfigureAwait(false);
         }
 
         public async Task<CloseResponse> Close(string reason)
@@ -584,12 +584,12 @@ namespace RabbitMQ.Stream.Client
         public async ValueTask<QueryPublisherResponse> QueryPublisherSequence(string publisherRef, string stream)
         {
             return await Request<QueryPublisherRequest, QueryPublisherResponse>(corr =>
-                new QueryPublisherRequest(corr, publisherRef, stream));
+                new QueryPublisherRequest(corr, publisherRef, stream)).ConfigureAwait(false);
         }
 
         public async ValueTask<bool> StoreOffset(string reference, string stream, ulong offsetValue)
         {
-            return await Publish(new StoreOffsetRequest(stream, reference, offsetValue));
+            return await Publish(new StoreOffsetRequest(stream, reference, offsetValue)).ConfigureAwait(false);
         }
 
         public async ValueTask<MetaDataResponse> QueryMetadata(string[] streams)
@@ -600,7 +600,7 @@ namespace RabbitMQ.Stream.Client
         public async Task<bool> StreamExists(string stream)
         {
             var streams = new[] { stream };
-            var response = await QueryMetadata(streams);
+            var response = await QueryMetadata(streams).ConfigureAwait(false);
             return response.StreamInfos is { Count: >= 1 } &&
                    response.StreamInfos[stream].ResponseCode == ResponseCode.Ok;
         }
@@ -613,17 +613,17 @@ namespace RabbitMQ.Stream.Client
 
         public async ValueTask<CreateResponse> CreateStream(string stream, IDictionary<string, string> args)
         {
-            return await Request<CreateRequest, CreateResponse>(corr => new CreateRequest(corr, stream, args));
+            return await Request<CreateRequest, CreateResponse>(corr => new CreateRequest(corr, stream, args)).ConfigureAwait(false);
         }
 
         public async ValueTask<DeleteResponse> DeleteStream(string stream)
         {
-            return await Request<DeleteRequest, DeleteResponse>(corr => new DeleteRequest(corr, stream));
+            return await Request<DeleteRequest, DeleteResponse>(corr => new DeleteRequest(corr, stream)).ConfigureAwait(false);
         }
 
         public async ValueTask<bool> Credit(byte subscriptionId, ushort credit)
         {
-            return await Publish(new CreditRequest(subscriptionId, credit));
+            return await Publish(new CreditRequest(subscriptionId, credit)).ConfigureAwait(false);
         }
     }
 

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -197,7 +197,7 @@ namespace RabbitMQ.Stream.Client
         public static async Task<Client> Create(ClientParameters parameters, ILogger logger = null)
         {
             var client = new Client(parameters, logger);
-            
+
             client.connection = await Connection.Create(parameters.Endpoint, client.HandleIncoming, client.HandleClosed, parameters.Ssl).ConfigureAwait(false);
 
             // exchange properties

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -190,7 +190,8 @@ namespace RabbitMQ.Stream.Client
         {
             if (ConnectionClosed != null)
             {
-                await ConnectionClosed?.Invoke(reason)!;
+                var t = ConnectionClosed?.Invoke(reason)!;
+                await t.ConfigureAwait(false);
             }
         }
 
@@ -234,7 +235,7 @@ namespace RabbitMQ.Stream.Client
 
         public async ValueTask<bool> Publish(Publish publishMsg)
         {
-            var publishTask = await Publish<Publish>(publishMsg);
+            var publishTask = await Publish<Publish>(publishMsg).ConfigureAwait(false);
 
             publishCommandsSent += 1;
             messagesSent += publishMsg.MessageCount;
@@ -254,7 +255,7 @@ namespace RabbitMQ.Stream.Client
             var publisherId = nextPublisherId++;
             publishers.Add(publisherId, (confirmCallback, errorCallback));
             return (publisherId, await Request<DeclarePublisherRequest, DeclarePublisherResponse>(corr =>
-                new DeclarePublisherRequest(corr, publisherId, publisherRef, stream)));
+                new DeclarePublisherRequest(corr, publisherId, publisherRef, stream)).ConfigureAwait(false));
         }
 
         public async Task<DeletePublisherResponse> DeletePublisher(byte publisherId)
@@ -282,7 +283,7 @@ namespace RabbitMQ.Stream.Client
                 initialCredit,
                 properties,
                 deliverHandler,
-                consumerUpdateHandler);
+                consumerUpdateHandler).ConfigureAwait(false);
         }
 
         public async Task<(byte, SubscribeResponse)> Subscribe(RawConsumerConfig config,

--- a/RabbitMQ.Stream.Client/Compression.cs
+++ b/RabbitMQ.Stream.Client/Compression.cs
@@ -152,10 +152,7 @@ namespace RabbitMQ.Stream.Client
 
         public static void UnRegisterCodec(CompressionType compressionType)
         {
-            if (AvailableCompressCodecs.ContainsKey(compressionType))
-            {
-                AvailableCompressCodecs.Remove(compressionType);
-            }
+            AvailableCompressCodecs.Remove(compressionType);
         }
 
         public static ICompressionCodec GetCompressionCodec(CompressionType compressionType)

--- a/RabbitMQ.Stream.Client/Connection.cs
+++ b/RabbitMQ.Stream.Client/Connection.cs
@@ -153,7 +153,7 @@ namespace RabbitMQ.Stream.Client
 
                 // Mark the PipeReader as complete
 
-                await reader.CompleteAsync();
+                await reader.CompleteAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -166,7 +166,8 @@ namespace RabbitMQ.Stream.Client
             finally
             {
                 isClosed = true;
-                await closedCallback?.Invoke("TCP Connection Closed")!;
+                var t = closedCallback?.Invoke("TCP Connection Closed")!;
+                await t.ConfigureAwait(false);
                 Debug.WriteLine("TCP Connection Closed");
             }
         }

--- a/RabbitMQ.Stream.Client/HeartBeatHandler.cs
+++ b/RabbitMQ.Stream.Client/HeartBeatHandler.cs
@@ -57,7 +57,7 @@ public class HeartBeatHandler
     private async Task PerformHeartBeatAsync()
     {
         var f = _sendHeartbeatFunc();
-        await f.AsTask().WaitAsync(TimeSpan.FromMilliseconds(1000));
+        await f.AsTask().WaitAsync(TimeSpan.FromMilliseconds(1000)).ConfigureAwait(false);
 
         var seconds = (DateTime.Now - _lastUpdate).TotalSeconds;
         if (seconds < _heartbeat)

--- a/RabbitMQ.Stream.Client/HeartBeatHandler.cs
+++ b/RabbitMQ.Stream.Client/HeartBeatHandler.cs
@@ -77,7 +77,7 @@ public class HeartBeatHandler
         // client will be closed
         _logger.LogCritical("Too many heartbeats missed: {MissedHeartbeatCounter}", _missedHeartbeat);
         Close();
-        await _close($"Too many heartbeats missed: {_missedHeartbeat}. Client connection will be closed.");
+        await _close($"Too many heartbeats missed: {_missedHeartbeat}. Client connection will be closed.").ConfigureAwait(false);
     }
 
     internal void UpdateHeartBeat()

--- a/RabbitMQ.Stream.Client/MetaData.cs
+++ b/RabbitMQ.Stream.Client/MetaData.cs
@@ -131,7 +131,7 @@ namespace RabbitMQ.Stream.Client
                 if (brokers.Count > 0)
                 {
                     var replicas = replicaRefs.Select(r => brokers[r]).ToList();
-                    var leader = brokers.ContainsKey(leaderRef) ? brokers[leaderRef] : default;
+                    var leader = brokers.TryGetValue(leaderRef, out var value) ? value : default;
                     streamInfos.Add(stream, new StreamInfo(stream, (ResponseCode)code, leader, replicas));
                 }
                 else

--- a/RabbitMQ.Stream.Client/RasSuperStreamConsumer.cs
+++ b/RabbitMQ.Stream.Client/RasSuperStreamConsumer.cs
@@ -83,7 +83,7 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
                         stream
                     );
                     _consumers.TryRemove(stream, out _);
-                    await GetConsumer(stream);
+                    await GetConsumer(stream).ConfigureAwait(false);
                 }
             },
             MessageHandler = async (consumer, context, message) =>
@@ -148,7 +148,7 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
                     });
                 }
             },
-            OffsetSpec = _config.OffsetSpec.ContainsKey(stream) ? _config.OffsetSpec[stream] : new OffsetTypeNext(),
+            OffsetSpec = _config.OffsetSpec.TryGetValue(stream, out var value) ? value : new OffsetTypeNext(),
         };
     }
 

--- a/RabbitMQ.Stream.Client/RasSuperStreamConsumer.cs
+++ b/RabbitMQ.Stream.Client/RasSuperStreamConsumer.cs
@@ -156,7 +156,7 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
     {
         var c = await RawConsumer.Create(
             _clientParameters with { ClientProvidedName = _clientParameters.ClientProvidedName },
-            FromStreamConfig(stream), _streamInfos[stream], _logger);
+            FromStreamConfig(stream), _streamInfos[stream], _logger).ConfigureAwait(false);
         _logger?.LogDebug("Consumer {ConsumerReference} created for Stream {StreamIdentifier}", _config.Reference,
             stream);
         return c;
@@ -166,7 +166,7 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
     {
         if (!_consumers.ContainsKey(stream))
         {
-            var p = await InitConsumer(stream);
+            var p = await InitConsumer(stream).ConfigureAwait(false);
             _consumers.TryAdd(stream, p);
         }
 

--- a/RabbitMQ.Stream.Client/RasSuperStreamConsumer.cs
+++ b/RabbitMQ.Stream.Client/RasSuperStreamConsumer.cs
@@ -93,7 +93,7 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
                 // it is useful client side to know from which stream the message is coming from
                 if (_config.MessageHandler != null)
                 {
-                    await _config.MessageHandler(stream, consumer, context, message);
+                    await _config.MessageHandler(stream, consumer, context, message).ConfigureAwait(false);
                 }
             },
             MetadataHandler = async update =>
@@ -141,11 +141,11 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
                             _config.Reference,
                             update.Stream
                         );
-                        var x = await _config.Client.QueryMetadata(new[] { update.Stream });
+                        var x = await _config.Client.QueryMetadata(new[] { update.Stream }).ConfigureAwait(false);
                         x.StreamInfos.TryGetValue(update.Stream, out var streamInfo);
                         _streamInfos.Add(update.Stream, streamInfo);
-                        await GetConsumer(update.Stream);
-                    });
+                        await GetConsumer(update.Stream).ConfigureAwait(false);
+                    }).ConfigureAwait(false);
                 }
             },
             OffsetSpec = _config.OffsetSpec.TryGetValue(stream, out var value) ? value : new OffsetTypeNext(),
@@ -177,7 +177,7 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
     {
         foreach (var stream in _streamInfos.Keys)
         {
-            await GetConsumer(stream);
+            await GetConsumer(stream).ConfigureAwait(false);
         }
     }
 

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -264,7 +264,7 @@ namespace RabbitMQ.Stream.Client
                     // receive the chunk from the deliver
                     // before parse the chunk, we ask for more credits
                     // in thi way we keep the network busy
-                    await _client.Credit(deliver.SubscriptionId, 1);
+                    await _client.Credit(deliver.SubscriptionId, 1).ConfigureAwait(false);
                     // parse the chunk, we have another function because the sequence reader
                     // can't be used in async context
                     ParseChunk(deliver.Chunk);
@@ -277,7 +277,7 @@ namespace RabbitMQ.Stream.Client
                         _config.StoredOffsetSpec = await _config.ConsumerUpdateListener(
                             _config.Reference,
                             _config.Stream,
-                            b);
+                            b).ConfigureAwait(false);
                     }
 
                     return _config.StoredOffsetSpec;

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -119,7 +119,7 @@ namespace RabbitMQ.Stream.Client
 
         public async Task StoreOffset(ulong offset)
         {
-            await _client.StoreOffset(_config.Reference, _config.Stream, offset);
+            await _client.StoreOffset(_config.Reference, _config.Stream, offset).ConfigureAwait(false);
         }
 
         public static async Task<IConsumer> Create(
@@ -129,9 +129,9 @@ namespace RabbitMQ.Stream.Client
             ILogger logger = null
         )
         {
-            var client = await RoutingHelper<Routing>.LookupRandomConnection(clientParameters, metaStreamInfo, logger);
+            var client = await RoutingHelper<Routing>.LookupRandomConnection(clientParameters, metaStreamInfo, logger).ConfigureAwait(false);
             var consumer = new RawConsumer((Client)client, config, logger);
-            await consumer.Init();
+            await consumer.Init().ConfigureAwait(false);
             return consumer;
         }
 

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -224,10 +224,10 @@ namespace RabbitMQ.Stream.Client
 
             _client.ConnectionClosed += async reason =>
             {
-                await Close();
+                await Close().ConfigureAwait(false);
                 if (_config.ConnectionClosedHandler != null)
                 {
-                    await _config.ConnectionClosedHandler(reason);
+                    await _config.ConnectionClosedHandler(reason).ConfigureAwait(false);
                 }
             };
             if (_config.MetadataHandler != null)
@@ -282,7 +282,7 @@ namespace RabbitMQ.Stream.Client
 
                     return _config.StoredOffsetSpec;
                 }
-            );
+            ).ConfigureAwait(false);
             if (response.ResponseCode == ResponseCode.Ok)
             {
                 _subscriberId = consumerId;

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -91,10 +91,10 @@ namespace RabbitMQ.Stream.Client
         {
             _client.ConnectionClosed += async reason =>
             {
-                await Close();
+                await Close().ConfigureAwait(false);
                 if (_config.ConnectionClosedHandler != null)
                 {
-                    await _config.ConnectionClosedHandler(reason);
+                    await _config.ConnectionClosedHandler(reason).ConfigureAwait(false);
                 }
             };
 

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -153,11 +153,11 @@ namespace RabbitMQ.Stream.Client
         {
             if (subEntryMessages.Count != 0)
             {
-                await SemaphoreAwaitAsync();
+                await SemaphoreAwaitAsync().ConfigureAwait(false);
                 var publishTask =
                     _client.Publish(new SubEntryPublish(_publisherId, publishingId,
                         CompressionHelper.Compress(subEntryMessages, compressionType)));
-                await publishTask;
+                await publishTask.ConfigureAwait(false);
             }
         }
 

--- a/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
@@ -181,7 +181,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
 
         foreach (var (producer, list) in aggregate)
         {
-            await producer.Send(list);
+            await producer.Send(list).ConfigureAwait(false);
         }
     }
 
@@ -194,7 +194,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
         // and send them to the right producer
         foreach (var subMessage in subEntryMessages)
         {
-            var p = await GetProducerForMessage(subMessage);
+            var p = await GetProducerForMessage(subMessage).ConfigureAwait(false);
             if (aggregate.Any(a => a.Item1 == p))
             {
                 aggregate.First(a => a.Item1 == p).Item2.Add(subMessage);
@@ -209,7 +209,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
         // sub aggregate is a list of messages that have to be sent to the same producer
         foreach (var (producer, messages) in aggregate)
         {
-            await producer.Send(publishingId, messages, compressionType);
+            await producer.Send(publishingId, messages, compressionType).ConfigureAwait(false);
         }
     }
 

--- a/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
@@ -122,7 +122,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
     // The producer is created on demand when a message is sent to a stream
     private async Task<IProducer> InitProducer(string stream)
     {
-        var p = await RawProducer.Create(_clientParameters, FromStreamConfig(stream), _streamInfos[stream], _logger);
+        var p = await RawProducer.Create(_clientParameters, FromStreamConfig(stream), _streamInfos[stream], _logger).ConfigureAwait(false);
         _logger?.LogDebug("Producer {ProducerReference} created for Stream {StreamIdentifier}", _config.Reference,
             stream);
         return p;
@@ -132,7 +132,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
     {
         if (!_producers.ContainsKey(stream))
         {
-            var p = await InitProducer(stream);
+            var p = await InitProducer(stream).ConfigureAwait(false);
             _producers.TryAdd(stream, p);
         }
 
@@ -149,13 +149,13 @@ public class RawSuperStreamProducer : IProducer, IDisposable
 
         var routes = _defaultRoutingConfiguration.RoutingStrategy.Route(message,
             _streamInfos.Keys.ToList());
-        return await GetProducer(routes[0]);
+        return await GetProducer(routes[0]).ConfigureAwait(false);
     }
 
     public async ValueTask Send(ulong publishingId, Message message)
     {
-        var producer = await GetProducerForMessage(message);
-        await producer.Send(publishingId, message);
+        var producer = await GetProducerForMessage(message).ConfigureAwait(false);
+        await producer.Send(publishingId, message).ConfigureAwait(false);
     }
 
     public async ValueTask Send(List<(ulong, Message)> messages)
@@ -167,7 +167,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
         // and send them to the right producer
         foreach (var subMessage in messages)
         {
-            var p = await GetProducerForMessage(subMessage.Item2);
+            var p = await GetProducerForMessage(subMessage.Item2).ConfigureAwait(false);
             if (aggregate.Any(a => a.Item1 == p))
             {
                 aggregate.First(a => a.Item1 == p).Item2.Add((subMessage.Item1,

--- a/RabbitMQ.Stream.Client/Reliable/ConfirmationPipe.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConfirmationPipe.cs
@@ -124,7 +124,7 @@ public class ConfirmationPipe
 
         foreach (var pair in timedOutMessages)
         {
-            await RemoveUnConfirmedMessage(ConfirmationStatus.ClientTimeoutError, pair.Value.PublishingId, null);
+            await RemoveUnConfirmedMessage(ConfirmationStatus.ClientTimeoutError, pair.Value.PublishingId, null).ConfigureAwait(false);
         }
     }
 

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -144,7 +144,7 @@ public class Consumer : ConsumerFactory
     internal override async Task CreateNewEntity(bool boot)
     {
         _consumer = await CreateConsumer(boot).ConfigureAwait(false);
-        await _consumerConfig.ReconnectStrategy.WhenConnected(ToString());
+        await _consumerConfig.ReconnectStrategy.WhenConnected(ToString()).ConfigureAwait(false);
     }
 
     // just close the consumer. See base/metadataupdate

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -143,7 +143,7 @@ public class Consumer : ConsumerFactory
 
     internal override async Task CreateNewEntity(bool boot)
     {
-        _consumer = await CreateConsumer(boot);
+        _consumer = await CreateConsumer(boot).ConfigureAwait(false);
         await _consumerConfig.ReconnectStrategy.WhenConnected(ToString());
     }
 

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -134,7 +134,7 @@ public class Consumer : ConsumerFactory
     {
         consumerConfig.ReconnectStrategy ??= new BackOffReconnectStrategy(logger);
         var rConsumer = new Consumer(consumerConfig, logger);
-        await rConsumer.Init(consumerConfig.ReconnectStrategy);
+        await rConsumer.Init(consumerConfig.ReconnectStrategy).ConfigureAwait(false);
         logger?.LogDebug("Consumer: {Reference} created for Stream: {Stream}",
             consumerConfig.Reference, consumerConfig.Stream);
 
@@ -150,12 +150,12 @@ public class Consumer : ConsumerFactory
     // just close the consumer. See base/metadataupdate
     protected override async Task CloseEntity()
     {
-        await SemaphoreSlim.WaitAsync(10);
+        await SemaphoreSlim.WaitAsync(10).ConfigureAwait(false);
         try
         {
             if (_consumer != null)
             {
-                await _consumer.Close();
+                await _consumer.Close().ConfigureAwait(false);
             }
         }
         finally
@@ -167,7 +167,7 @@ public class Consumer : ConsumerFactory
     public override async Task Close()
     {
         _isOpen = false;
-        await CloseEntity();
+        await CloseEntity().ConfigureAwait(false);
         _logger?.LogDebug("Consumer closed for stream {Stream}", _consumerConfig.Stream);
     }
 

--- a/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
@@ -114,9 +114,9 @@ public abstract class ConsumerFactory : ReliableBase
                     if (_consumerConfig.MessageHandler != null)
                     {
                         await _consumerConfig.MessageHandler(stream, consumer, ctx,
-                            message);
+                            message).ConfigureAwait(false);
                     }
                 },
-            }, BaseLogger);
+            }, BaseLogger).ConfigureAwait(false);
     }
 }

--- a/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
@@ -27,10 +27,10 @@ public abstract class ConsumerFactory : ReliableBase
     {
         if (_consumerConfig.IsSuperStream)
         {
-            return await SuperConsumer(boot);
+            return await SuperConsumer(boot).ConfigureAwait(false);
         }
 
-        return await StandardConsumer(boot);
+        return await StandardConsumer(boot).ConfigureAwait(false);
     }
 
     private async Task<IConsumer> StandardConsumer(bool boot)
@@ -92,7 +92,7 @@ public abstract class ConsumerFactory : ReliableBase
         }
         else
         {
-            var partitions = await _consumerConfig.StreamSystem.QueryPartition(_consumerConfig.Stream);
+            var partitions = await _consumerConfig.StreamSystem.QueryPartition(_consumerConfig.Stream).ConfigureAwait(false);
             foreach (var partition in partitions)
             {
                 offsetSpecs[partition] =

--- a/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
@@ -52,7 +52,7 @@ public abstract class ConsumerFactory : ReliableBase
             OffsetSpec = offsetSpec,
             ConnectionClosedHandler = async _ =>
             {
-                await TryToReconnect(_consumerConfig.ReconnectStrategy);
+                await TryToReconnect(_consumerConfig.ReconnectStrategy).ConfigureAwait(false);
             },
             MetadataHandler = update =>
             {
@@ -70,11 +70,10 @@ public abstract class ConsumerFactory : ReliableBase
                 _lastOffsetConsumed[_consumerConfig.Stream] = ctx.Offset;
                 if (_consumerConfig.MessageHandler != null)
                 {
-                    await _consumerConfig.MessageHandler(_consumerConfig.Stream, consumer, ctx,
-                        message);
+                    await _consumerConfig.MessageHandler(_consumerConfig.Stream, consumer, ctx, message).ConfigureAwait(false);
                 }
             },
-        }, BaseLogger);
+        }, BaseLogger).ConfigureAwait(false);
     }
 
     private async Task<IConsumer> SuperConsumer(bool boot)

--- a/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
+++ b/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
@@ -62,7 +62,7 @@ internal class BackOffReconnectStrategy : IReconnectStrategy
             connectionIdentifier,
             Tentatives * 100
         );
-        await Task.Delay(TimeSpan.FromMilliseconds(Tentatives * 100));
+        await Task.Delay(TimeSpan.FromMilliseconds(Tentatives * 100)).ConfigureAwait(false);
         MaybeResetTentatives();
         return true;
     }

--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -133,7 +133,7 @@ public class Producer : ProducerFactory
     {
         producerConfig.ReconnectStrategy ??= new BackOffReconnectStrategy(logger);
         var rProducer = new Producer(producerConfig, logger);
-        await rProducer.Init(producerConfig.ReconnectStrategy);
+        await rProducer.Init(producerConfig.ReconnectStrategy).ConfigureAwait(false);
         logger?.LogDebug(
             "Producer: {Reference} created for Stream: {Stream}",
             producerConfig.Reference,
@@ -145,7 +145,7 @@ public class Producer : ProducerFactory
 
     internal override async Task CreateNewEntity(bool boot)
     {
-        _producer = await CreateProducer();
+        _producer = await CreateProducer().ConfigureAwait(false);
 
         await _producerConfig.ReconnectStrategy.WhenConnected(ToString());
 
@@ -178,14 +178,14 @@ public class Producer : ProducerFactory
 
     public override async Task Close()
     {
-        await SemaphoreSlim.WaitAsync(TimeSpan.FromMilliseconds(10));
+        await SemaphoreSlim.WaitAsync(TimeSpan.FromMilliseconds(10)).ConfigureAwait(false);
         try
         {
             _isOpen = false;
             _confirmationPipe.Stop();
             if (_producer != null)
             {
-                await _producer.Close();
+                await _producer.Close().ConfigureAwait(false);
                 _logger?.LogDebug("Producer closed for {Stream}", _producerConfig.Stream);
             }
         }

--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -147,13 +147,13 @@ public class Producer : ProducerFactory
     {
         _producer = await CreateProducer().ConfigureAwait(false);
 
-        await _producerConfig.ReconnectStrategy.WhenConnected(ToString());
+        await _producerConfig.ReconnectStrategy.WhenConnected(ToString()).ConfigureAwait(false);
 
         if (boot)
         {
             // Init the publishing id
             Interlocked.Exchange(ref _publishingId,
-                await _producer.GetLastPublishingId());
+                await _producer.GetLastPublishingId().ConfigureAwait(false));
 
             // confirmation Pipe can start only if the producer is ready
             _confirmationPipe.Start();
@@ -162,12 +162,12 @@ public class Producer : ProducerFactory
 
     protected override async Task CloseEntity()
     {
-        await SemaphoreSlim.WaitAsync(10);
+        await SemaphoreSlim.WaitAsync(10).ConfigureAwait(false);
         try
         {
             if (_producer != null)
             {
-                await _producer.Close();
+                await _producer.Close().ConfigureAwait(false);
             }
         }
         finally
@@ -206,7 +206,7 @@ public class Producer : ProducerFactory
     public async ValueTask Send(Message message)
     {
 
-        await SemaphoreSlim.WaitAsync();
+        await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
 
         Interlocked.Increment(ref _publishingId);
         _confirmationPipe.AddUnConfirmedMessage(_publishingId, message);
@@ -219,7 +219,7 @@ public class Producer : ProducerFactory
             // on the _waitForConfirmation list. The user will get Timeout Error
             if (!(_inReconnection))
             {
-                await _producer.Send(_publishingId, message);
+                await _producer.Send(_publishingId, message).ConfigureAwait(false);
             }
         }
 
@@ -250,14 +250,14 @@ public class Producer : ProducerFactory
     /// In case of error the messages are considered as timed out, you will receive a confirmation with the status TimedOut.
     public async ValueTask Send(List<Message> messages, CompressionType compressionType)
     {
-        await SemaphoreSlim.WaitAsync();
+        await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
         Interlocked.Increment(ref _publishingId);
         _confirmationPipe.AddUnConfirmedMessage(_publishingId, messages);
         try
         {
             if (!_inReconnection)
             {
-                await _producer.Send(_publishingId, messages, compressionType);
+                await _producer.Send(_publishingId, messages, compressionType).ConfigureAwait(false);
             }
         }
 
@@ -290,7 +290,7 @@ public class Producer : ProducerFactory
     /// In case of error the messages are considered as timed out, you will receive a confirmation with the status TimedOut.
     public async ValueTask Send(List<Message> messages)
     {
-        await SemaphoreSlim.WaitAsync();
+        await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
         var messagesToSend = new List<(ulong, Message)>();
         foreach (var message in messages)
         {
@@ -312,7 +312,7 @@ public class Producer : ProducerFactory
             // on the _waitForConfirmation list. The user will get Timeout Error
             if (!(_inReconnection))
             {
-                await _producer.Send(messagesToSend);
+                await _producer.Send(messagesToSend).ConfigureAwait(false);
             }
         }
 

--- a/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
@@ -23,10 +23,10 @@ public abstract class ProducerFactory : ReliableBase
     {
         if (_producerConfig.SuperStreamConfig is { Enabled: true })
         {
-            return await SuperStreamProducer();
+            return await SuperStreamProducer().ConfigureAwait(false);
         }
 
-        return await StandardProducer();
+        return await StandardProducer().ConfigureAwait(false);
     }
 
     private async Task<IProducer> SuperStreamProducer()
@@ -55,7 +55,7 @@ public abstract class ProducerFactory : ReliableBase
                     _confirmationPipe.RemoveUnConfirmedMessage(confirmationStatus, confirmation.PublishingId,
                         stream);
                 }
-            }, BaseLogger);
+            }, BaseLogger).ConfigureAwait(false);
     }
 
     private async Task<IProducer> StandardProducer()
@@ -77,7 +77,7 @@ public abstract class ProducerFactory : ReliableBase
                         _producerConfig.StreamSystem).WaitAsync(CancellationToken.None);
                 });
             },
-            ConnectionClosedHandler = async _ => { await TryToReconnect(_producerConfig.ReconnectStrategy); },
+            ConnectionClosedHandler = async _ => { await TryToReconnect(_producerConfig.ReconnectStrategy).ConfigureAwait(false); },
             ConfirmHandler = confirmation =>
             {
                 var confirmationStatus = confirmation.Code switch
@@ -93,6 +93,6 @@ public abstract class ProducerFactory : ReliableBase
                 _confirmationPipe.RemoveUnConfirmedMessage(confirmationStatus, confirmation.PublishingId,
                     confirmation.Stream);
             }
-        }, BaseLogger);
+        }, BaseLogger).ConfigureAwait(false);
     }
 }

--- a/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
@@ -45,7 +45,7 @@ public abstract class ReliableBase
 
     internal async Task Init(IReconnectStrategy reconnectStrategy)
     {
-        await Init(true, reconnectStrategy);
+        await Init(true, reconnectStrategy).ConfigureAwait(false);
     }
 
     // <summary>
@@ -58,11 +58,11 @@ public abstract class ReliableBase
     private async Task Init(bool boot, IReconnectStrategy reconnectStrategy)
     {
         var reconnect = false;
-        await SemaphoreSlim.WaitAsync();
+        await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
         try
         {
             _isOpen = true;
-            await CreateNewEntity(boot);
+            await CreateNewEntity(boot).ConfigureAwait(false);
         }
 
         catch (Exception e)
@@ -84,7 +84,7 @@ public abstract class ReliableBase
 
         if (reconnect)
         {
-            await TryToReconnect(reconnectStrategy);
+            await TryToReconnect(reconnectStrategy).ConfigureAwait(false);
         }
     }
 

--- a/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
@@ -107,15 +107,15 @@ public abstract class ReliableBase
         _inReconnection = true;
         try
         {
-            switch (await reconnectStrategy.WhenDisconnected(ToString()) && _isOpen)
+            switch (await reconnectStrategy.WhenDisconnected(ToString()).ConfigureAwait(false) && _isOpen)
             {
                 case true:
                     BaseLogger.LogInformation("{Identity} is disconnected. Client will try reconnect", ToString());
-                    await Init(false, reconnectStrategy);
+                    await Init(false, reconnectStrategy).ConfigureAwait(false);
                     break;
                 case false:
                     BaseLogger.LogInformation("{Identity} is asked to be closed", ToString());
-                    await Close();
+                    await Close().ConfigureAwait(false);
                     break;
             }
         }
@@ -140,8 +140,8 @@ public abstract class ReliableBase
     {
         // This sleep is needed. When a stream is deleted it takes sometime.
         // The StreamExists/1 could return true even the stream doesn't exist anymore.
-        await Task.Delay(500);
-        if (await system.StreamExists(stream))
+        await Task.Delay(500).ConfigureAwait(false);
+        if (await system.StreamExists(stream).ConfigureAwait(false))
         {
             BaseLogger.LogInformation("Meta data update stream: {StreamIdentifier}. The stream still exists. Client: {Identity}",
                 stream,
@@ -150,7 +150,7 @@ public abstract class ReliableBase
             // Here we just close the producer connection
             // the func TryToReconnect/0 will be called. 
 
-            await CloseEntity();
+            await CloseEntity().ConfigureAwait(false);
         }
         else
         {
@@ -160,7 +160,7 @@ public abstract class ReliableBase
                 stream,
                 ToString()
             );
-            await Close();
+            await Close().ConfigureAwait(false);
         }
     }
 

--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -186,7 +186,7 @@ namespace RabbitMQ.Stream.Client
         public async Task<IConsumer> CreateSuperStreamConsumer(RawSuperStreamConsumerConfig rawSuperStreamConsumerConfig,
             ILogger logger = null)
         {
-            await MayBeReconnectLocator();
+            await MayBeReconnectLocator().ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(rawSuperStreamConsumerConfig.SuperStream))
             {
                 throw new CreateProducerException("Super Stream name can't be empty");
@@ -194,7 +194,7 @@ namespace RabbitMQ.Stream.Client
 
             rawSuperStreamConsumerConfig.Client = _client;
 
-            var partitions = await _client.QueryPartition(rawSuperStreamConsumerConfig.SuperStream);
+            var partitions = await _client.QueryPartition(rawSuperStreamConsumerConfig.SuperStream).ConfigureAwait(false);
             if (partitions.ResponseCode != ResponseCode.Ok)
             {
                 throw new CreateConsumerException($"consumer could not be created code: {partitions.ResponseCode}");
@@ -203,7 +203,7 @@ namespace RabbitMQ.Stream.Client
             IDictionary<string, StreamInfo> streamInfos = new Dictionary<string, StreamInfo>();
             foreach (var partitionsStream in partitions.Streams)
             {
-                var metaDataResponse = await _client.QueryMetadata(new[] { partitionsStream });
+                var metaDataResponse = await _client.QueryMetadata(new[] { partitionsStream }).ConfigureAwait(false);
                 streamInfos[partitionsStream] = metaDataResponse.StreamInfos[partitionsStream];
             }
 
@@ -256,7 +256,7 @@ namespace RabbitMQ.Stream.Client
 
         public async Task CreateStream(StreamSpec spec)
         {
-            var response = await _client.CreateStream(spec.Name, spec.Args);
+            var response = await _client.CreateStream(spec.Name, spec.Args).ConfigureAwait(false);
             if (response.ResponseCode is ResponseCode.Ok or ResponseCode.StreamAlreadyExists)
             {
                 return;
@@ -267,7 +267,7 @@ namespace RabbitMQ.Stream.Client
 
         public async Task<bool> StreamExists(string stream)
         {
-            return await _client.StreamExists(stream);
+            return await _client.StreamExists(stream).ConfigureAwait(false);
         }
 
         private static void MaybeThrowQueryException(string reference, string stream)
@@ -304,9 +304,9 @@ namespace RabbitMQ.Stream.Client
         /// <returns></returns>
         public async Task<ulong> QuerySequence(string reference, string stream)
         {
-            await MayBeReconnectLocator();
+            await MayBeReconnectLocator().ConfigureAwait(false);
             MaybeThrowQueryException(reference, stream);
-            var response = await _client.QueryPublisherSequence(reference, stream);
+            var response = await _client.QueryPublisherSequence(reference, stream).ConfigureAwait(false);
             ClientExceptions.MaybeThrowException(response.ResponseCode,
                 $"QuerySequence stream: {stream}, reference: {reference}");
             return response.Sequence;
@@ -314,8 +314,8 @@ namespace RabbitMQ.Stream.Client
 
         public async Task DeleteStream(string stream)
         {
-            await MayBeReconnectLocator();
-            var response = await _client.DeleteStream(stream);
+            await MayBeReconnectLocator().ConfigureAwait(false);
+            var response = await _client.DeleteStream(stream).ConfigureAwait(false);
             if (response.ResponseCode == ResponseCode.Ok)
             {
                 return;

--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -63,7 +63,7 @@ namespace RabbitMQ.Stream.Client
             {
                 try
                 {
-                    var client = await Client.Create(clientParams with { Endpoint = endPoint }, logger);
+                    var client = await Client.Create(clientParams with { Endpoint = endPoint }, logger).ConfigureAwait(false);
                     if (!client.IsClosed)
                     {
                         logger?.LogDebug("Client connected to {@EndPoint}", endPoint);
@@ -88,7 +88,7 @@ namespace RabbitMQ.Stream.Client
 
         public async Task Close()
         {
-            await _client.Close("system close");
+            await _client.Close("system close").ConfigureAwait(false);
             _logger?.LogDebug("Client Closed");
         }
 
@@ -101,17 +101,15 @@ namespace RabbitMQ.Stream.Client
 
             try
             {
-                await _semClientProvidedName.WaitAsync();
+                await _semClientProvidedName.WaitAsync().ConfigureAwait(false);
+                if (_client.IsClosed)
                 {
-                    if (_client.IsClosed)
+                    _client = await Client.Create(_client.Parameters with
                     {
-                        _client = await Client.Create(_client.Parameters with
-                        {
-                            ClientProvidedName = _clientParameters.ClientProvidedName,
-                            Endpoint = _clientParameters.Endpoints[advId]
-                        });
-                        _logger?.LogDebug("Locator reconnected to {@EndPoint}", _clientParameters.Endpoints[advId]);
-                    }
+                        ClientProvidedName = _clientParameters.ClientProvidedName,
+                        Endpoint = _clientParameters.Endpoints[advId]
+                    }).ConfigureAwait(false);
+                    _logger?.LogDebug("Locator reconnected to {@EndPoint}", _clientParameters.Endpoints[advId]);
                 }
             }
             finally
@@ -132,7 +130,7 @@ namespace RabbitMQ.Stream.Client
         public async Task<IProducer> CreateRawSuperStreamProducer(
             RawSuperStreamProducerConfig rawSuperStreamProducerConfig, ILogger logger = null)
         {
-            await MayBeReconnectLocator();
+            await MayBeReconnectLocator().ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(rawSuperStreamProducerConfig.SuperStream))
             {
                 throw new CreateProducerException("Super Stream name can't be empty");
@@ -150,7 +148,7 @@ namespace RabbitMQ.Stream.Client
 
             rawSuperStreamProducerConfig.Client = _client;
 
-            var partitions = await _client.QueryPartition(rawSuperStreamProducerConfig.SuperStream);
+            var partitions = await _client.QueryPartition(rawSuperStreamProducerConfig.SuperStream).ConfigureAwait(false);
             if (partitions.ResponseCode != ResponseCode.Ok)
             {
                 throw new CreateProducerException($"producer could not be created code: {partitions.ResponseCode}");
@@ -159,7 +157,7 @@ namespace RabbitMQ.Stream.Client
             IDictionary<string, StreamInfo> streamInfos = new Dictionary<string, StreamInfo>();
             foreach (var partitionsStream in partitions.Streams)
             {
-                var metaDataResponse = await _client.QueryMetadata(new[] { partitionsStream });
+                var metaDataResponse = await _client.QueryMetadata(new[] { partitionsStream }).ConfigureAwait(false);
                 streamInfos[partitionsStream] = metaDataResponse.StreamInfos[partitionsStream];
             }
 
@@ -175,8 +173,8 @@ namespace RabbitMQ.Stream.Client
 
         public async Task<string[]> QueryPartition(string superStream)
         {
-            await MayBeReconnectLocator();
-            var partitions = await _client.QueryPartition(superStream);
+            await MayBeReconnectLocator().ConfigureAwait(false);
+            var partitions = await _client.QueryPartition(superStream).ConfigureAwait(false);
             if (partitions.ResponseCode != ResponseCode.Ok)
             {
                 throw new QueryException($"query partitions failed code: {partitions.ResponseCode}");
@@ -227,8 +225,8 @@ namespace RabbitMQ.Stream.Client
                 throw new CreateProducerException("Batch Size must be bigger than 0");
             }
 
-            await MayBeReconnectLocator();
-            var meta = await _client.QueryMetadata(new[] { rawProducerConfig.Stream });
+            await MayBeReconnectLocator().ConfigureAwait(false);
+            var meta = await _client.QueryMetadata(new[] { rawProducerConfig.Stream }).ConfigureAwait(false);
 
             var metaStreamInfo = meta.StreamInfos[rawProducerConfig.Stream];
             if (metaStreamInfo.ResponseCode != ResponseCode.Ok)
@@ -240,11 +238,11 @@ namespace RabbitMQ.Stream.Client
 
             try
             {
-                await _semClientProvidedName.WaitAsync();
+                await _semClientProvidedName.WaitAsync().ConfigureAwait(false);
 
                 var p = await RawProducer.Create(
                     _clientParameters with { ClientProvidedName = rawProducerConfig.ClientProvidedName },
-                    rawProducerConfig, metaStreamInfo, logger);
+                    rawProducerConfig, metaStreamInfo, logger).ConfigureAwait(false);
                 _logger?.LogDebug("Raw Producer: {Reference} created for Stream: {Stream}",
                     rawProducerConfig.Reference, rawProducerConfig.Stream);
 
@@ -291,7 +289,7 @@ namespace RabbitMQ.Stream.Client
         {
             MaybeThrowQueryException(reference, stream);
 
-            var response = await _client.QueryOffset(reference, stream);
+            var response = await _client.QueryOffset(reference, stream).ConfigureAwait(false);
             ClientExceptions.MaybeThrowException(response.ResponseCode,
                 $"QueryOffset stream: {stream}, reference: {reference}");
             return response.Offset;
@@ -329,8 +327,8 @@ namespace RabbitMQ.Stream.Client
         public async Task<IConsumer> CreateRawConsumer(RawConsumerConfig rawConsumerConfig,
             ILogger logger = null)
         {
-            await MayBeReconnectLocator();
-            var meta = await _client.QueryMetadata(new[] { rawConsumerConfig.Stream });
+            await MayBeReconnectLocator().ConfigureAwait(false);
+            var meta = await _client.QueryMetadata(new[] { rawConsumerConfig.Stream }).ConfigureAwait(false);
             var metaStreamInfo = meta.StreamInfos[rawConsumerConfig.Stream];
             if (metaStreamInfo.ResponseCode != ResponseCode.Ok)
             {
@@ -341,10 +339,10 @@ namespace RabbitMQ.Stream.Client
 
             try
             {
-                await _semClientProvidedName.WaitAsync();
+                await _semClientProvidedName.WaitAsync().ConfigureAwait(false);
                 var s = _clientParameters with { ClientProvidedName = rawConsumerConfig.ClientProvidedName };
                 var c = await RawConsumer.Create(s,
-                    rawConsumerConfig, metaStreamInfo, logger);
+                    rawConsumerConfig, metaStreamInfo, logger).ConfigureAwait(false);
                 _logger?.LogDebug("Raw Consumer: {Reference} created for Stream: {Stream}",
                     rawConsumerConfig.Reference, rawConsumerConfig.Stream);
 

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -1,0 +1,2 @@
+[*.{cs,vb}]
+dotnet_diagnostic.CA2007.severity = none

--- a/Tests/ClientTests.cs
+++ b/Tests/ClientTests.cs
@@ -239,7 +239,7 @@ namespace Tests
                 }));
             new Utils<Deliver>(testOutputHelper).WaitUntilTaskCompletes(testPassed);
 
-            Assert.Equal(2, messages.Count());
+            Assert.Equal(2, messages.Count);
             await client.DeleteStream(stream);
             await client.Close("done");
         }

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -339,7 +339,7 @@ namespace Tests
                 return 0;
             }
 
-            return obj.ContainsKey("messages_ready") ? Convert.ToInt32(obj["messages_ready"].ToString()) : 0;
+            return obj.TryGetValue("messages_ready", out var value) ? Convert.ToInt32(value.ToString()) : 0;
         }
 
         public static void HttpPost(string jsonBody, string api)


### PR DESCRIPTION
The changes in https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/pull/230 were good but not enough to fix deadlocks when trying to close consumers connections.
Adding a `ConfigureAwait(false)` _only_ to `MaybeClose` was not enough because when it was being called by `RawConsumer.Close` like this:

```C#
await _client.MaybeClose($"_client-close-subscriber: {_subscriberId}");
```
A deadlock was still happening.
The `ConfigureAwait` in .NET is kind of... eeh.. stupid. You basically have to call it for **every** `await` you do inside library code because, other wise, you would be getting the application's `SynchronizationContext`. Since this code is supposed to be used anywhere, we don't actually know how the client `SynchronizationContext` works, we don't know it's limitations. If it is a single thread `SynchronizationContext`, for example, we would be causing a deadlock awaiting on the current thread to finish a job that it self started.

See the following example:

```C#
SynchronizationContext.SetSynchronizationContext(new MainThreadSynchronizationContext());
await LibraryCode();

async Task LibraryCode()
{
    await DoWork();
}

async Task DoWork()
{
    await Task.Delay(1000).ConfigureAwait(false);
}

```

On the example above, calling `ConfigureAwait(false)` on the `Task.Delay(1000)` method won't be enough. It will, for unblocking code after `Task.Delay(1000)`, but once we are back to the last `await`(in `LibraryCode` method), the application `SynchronizationContext` will once again be used. That way we are now waiting on the current thread to finish work that it self started, making it busy to listen for the completed stated of `DoWork`. Deadlock.

If we simply add:

```C#
  await DoWork().ConfigureAwait(false);
```

It will now be the app responsability to deal with the task returned by the `Task LibraryCode` method.
It could either call an `await` like it is doing in our example above (but if so, would need to call `.ConfigureAwait(false)` on the `LibraryCode` as well. Same thing as the last paragraph), or it could do a `while(!task.IsCompleted) {}` to run code only after the task is completed.

TLDR:
`ConfigureAwait(false)` everywhere for library code.

Reference: https://devblogs.microsoft.com/dotnet/configureawait-faq/#:~:text=ConfigureAwait(false)%20involves%20a%20task,context%20that%20was%20there%20previously.