### PR TITLE
Enable possibility for RawConsumers to use SuperStreams

### DIFF
--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+RabbitMQ.Stream.Client.RawConsumerConfig.SuperStream.get -> string
+RabbitMQ.Stream.Client.RawConsumerConfig.SuperStream.set -> void
 RabbitMQ.Stream.Client.AbstractEntity.MaybeCancelToken() -> void
 RabbitMQ.Stream.Client.AbstractEntity.Token.get -> System.Threading.CancellationToken
 RabbitMQ.Stream.Client.Chunk.MagicVersion.get -> byte

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -75,8 +75,7 @@ namespace RabbitMQ.Stream.Client
         // it is needed to be able to add the subscriptions arguments
         // see consumerProperties["super-stream"] = SuperStream;
         // in this way the consumer is notified is something happens in the super stream
-        // it is internal because it is used only internally
-        internal string SuperStream { get; set; }
+        public string SuperStream { get; set; }
 
         public IOffsetType OffsetSpec { get; set; } = new OffsetTypeNext();
 


### PR DESCRIPTION
Had a quick chat with @Gsantomaggio about this..

This opens up the possibility to use a `RawConsumer` (with all it options) with SuperStream capabilities which has advantages in some edge-case-scenarios like:

* You need to start a consumer for a single partition, and not all partitions of the superstream
* You need specific event-callbacks for each partition in the SuperStream
* You want to implement your own `ConnectionClosedHandler` and/or `MetadataHandler` 


