### PR TITLE
Implement Deduplicating Producer

### DIFF
--- a/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
@@ -658,7 +658,6 @@ RabbitMQ.Stream.Client.Reliable.ProducerConfig.MessagesBufferSize.get -> int
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.MessagesBufferSize.set -> void
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.ProducerConfig(RabbitMQ.Stream.Client.StreamSystem streamSystem, string stream) -> void
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.get -> string
-RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.set -> void
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.SuperStreamConfig.get -> RabbitMQ.Stream.Client.Reliable.SuperStreamConfig
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.SuperStreamConfig.set -> void
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.TimeoutMessageAfter.get -> System.TimeSpan

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -1,3 +1,12 @@
 RabbitMQ.Stream.Client.AbstractEntity.MaybeCancelToken() -> void
 RabbitMQ.Stream.Client.AbstractEntity.Token.get -> System.Threading.CancellationToken
 RabbitMQ.Stream.Client.Chunk.MagicVersion.get -> byte
+RabbitMQ.Stream.Client.Reliable.DeduplicationProducer
+RabbitMQ.Stream.Client.Reliable.DeduplicationProducer.Close() -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.Reliable.DeduplicationProducer.GetLastPublishedId() -> System.Threading.Tasks.Task<ulong>
+RabbitMQ.Stream.Client.Reliable.DeduplicationProducer.IsOpen() -> bool
+RabbitMQ.Stream.Client.Reliable.DeduplicationProducer.Send(ulong publishing, RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.Reliable.DeduplicationProducerConfig
+RabbitMQ.Stream.Client.Reliable.DeduplicationProducerConfig.DeduplicationProducerConfig(RabbitMQ.Stream.Client.StreamSystem streamSystem, string stream, string reference) -> void
+RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.set -> void
+static RabbitMQ.Stream.Client.Reliable.DeduplicationProducer.Create(RabbitMQ.Stream.Client.Reliable.DeduplicationProducerConfig producerConfig, Microsoft.Extensions.Logging.ILogger<RabbitMQ.Stream.Client.Reliable.Producer> logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.DeduplicationProducer>

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -1,12 +1,12 @@
 RabbitMQ.Stream.Client.AbstractEntity.MaybeCancelToken() -> void
 RabbitMQ.Stream.Client.AbstractEntity.Token.get -> System.Threading.CancellationToken
 RabbitMQ.Stream.Client.Chunk.MagicVersion.get -> byte
-RabbitMQ.Stream.Client.Reliable.DeduplicationProducer
-RabbitMQ.Stream.Client.Reliable.DeduplicationProducer.Close() -> System.Threading.Tasks.Task
-RabbitMQ.Stream.Client.Reliable.DeduplicationProducer.GetLastPublishedId() -> System.Threading.Tasks.Task<ulong>
-RabbitMQ.Stream.Client.Reliable.DeduplicationProducer.IsOpen() -> bool
-RabbitMQ.Stream.Client.Reliable.DeduplicationProducer.Send(ulong publishing, RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Stream.Client.Reliable.DeduplicationProducerConfig
-RabbitMQ.Stream.Client.Reliable.DeduplicationProducerConfig.DeduplicationProducerConfig(RabbitMQ.Stream.Client.StreamSystem streamSystem, string stream, string reference) -> void
+RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer
+RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.Close() -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.GetLastPublishedId() -> System.Threading.Tasks.Task<ulong>
+RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.IsOpen() -> bool
+RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.Send(ulong publishing, RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.Reliable.DeduplicatingProducerConfig
+RabbitMQ.Stream.Client.Reliable.DeduplicatingProducerConfig.DeduplicatingProducerConfig(RabbitMQ.Stream.Client.StreamSystem streamSystem, string stream, string reference) -> void
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.set -> void
-static RabbitMQ.Stream.Client.Reliable.DeduplicationProducer.Create(RabbitMQ.Stream.Client.Reliable.DeduplicationProducerConfig producerConfig, Microsoft.Extensions.Logging.ILogger<RabbitMQ.Stream.Client.Reliable.Producer> logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.DeduplicationProducer>
+static RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.Create(RabbitMQ.Stream.Client.Reliable.DeduplicatingProducerConfig producerConfig, Microsoft.Extensions.Logging.ILogger<RabbitMQ.Stream.Client.Reliable.Producer> logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer>

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -59,7 +59,8 @@ namespace RabbitMQ.Stream.Client
             ILogger logger = null
         )
         {
-            var client = await RoutingHelper<Routing>.LookupLeaderConnection(clientParameters, metaStreamInfo, logger).ConfigureAwait(false);
+            var client = await RoutingHelper<Routing>.LookupLeaderConnection(clientParameters, metaStreamInfo, logger)
+                .ConfigureAwait(false);
 
             var producer = new RawProducer((Client)client, config, logger);
             await producer.Init().ConfigureAwait(false);
@@ -224,7 +225,13 @@ namespace RabbitMQ.Stream.Client
         /// <returns>The last sequence id stored by the producer.</returns>
         public async Task<ulong> GetLastPublishingId()
         {
-            var response = await _client.QueryPublisherSequence(_config.Reference, _config.Stream).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(_config.Reference))
+            {
+                return 0;
+            }
+
+            var response = await _client.QueryPublisherSequence(_config.Reference, _config.Stream)
+                .ConfigureAwait(false);
             ClientExceptions.MaybeThrowException(response.ResponseCode,
                 $"GetLastPublishingId stream: {_config.Stream}, reference: {_config.Reference}");
             return response.Sequence;
@@ -310,7 +317,8 @@ namespace RabbitMQ.Stream.Client
                 // in this case we reduce the waiting time
                 // the producer could be removed because of stream deleted 
                 // so it is not necessary to wait.
-                var closeResponse = await _client.DeletePublisher(_publisherId).WaitAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+                var closeResponse = await _client.DeletePublisher(_publisherId).WaitAsync(TimeSpan.FromSeconds(3))
+                    .ConfigureAwait(false);
                 result = closeResponse.ResponseCode;
             }
             catch (Exception e)

--- a/RabbitMQ.Stream.Client/Reliable/DeduplicatingProducer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/DeduplicatingProducer.cs
@@ -19,7 +19,7 @@ public record DeduplicatingProducerConfig : ProducerConfig
     }
 }
 
-// DeduplicationProducer is a wrapper around the Producer class
+// DeduplicatingProducer is a wrapper around the Producer class
 // to handle the deduplication of the messages.
 // The deduplication is enabled by setting the reference in the DeduplicationProducerConfig 
 // and it is mandatory to set the reference.
@@ -61,7 +61,8 @@ public class DeduplicatingProducer
 
     // Send a message with a specific publishing id
     // the publishing id is used to deduplicate the messages
-    // the publishing id must be unique and incremental. It can accept gaps the important is to be incremental
+    // the publishing id must be unique and incremental. The publishing ID may have gaps.
+    // It is important to always increment the ID, otherwise, messages will be discarded by the deduplication algorithm
     public async ValueTask Send(ulong publishing, Message message)
     {
         await _producer.SendInternal(publishing, message).ConfigureAwait(false);

--- a/RabbitMQ.Stream.Client/Reliable/DeduplicatingProducer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/DeduplicatingProducer.cs
@@ -8,9 +8,9 @@ using Microsoft.Extensions.Logging;
 
 namespace RabbitMQ.Stream.Client.Reliable;
 
-public record DeduplicationProducerConfig : ProducerConfig
+public record DeduplicatingProducerConfig : ProducerConfig
 {
-    public DeduplicationProducerConfig(StreamSystem streamSystem, string stream, string reference) : base(streamSystem,
+    public DeduplicatingProducerConfig(StreamSystem streamSystem, string stream, string reference) : base(streamSystem,
         stream)
     {
         if (string.IsNullOrWhiteSpace(reference))
@@ -29,14 +29,14 @@ public record DeduplicationProducerConfig : ProducerConfig
 // to decide deduplication or not.
 // The best way to handle the deduplication is to use a single thread avoiding the id overlaps.
 
-public class DeduplicationProducer
+public class DeduplicatingProducer
 {
     private Producer _producer = null!;
 
-    public static async Task<DeduplicationProducer> Create(DeduplicationProducerConfig producerConfig,
+    public static async Task<DeduplicatingProducer> Create(DeduplicatingProducerConfig producerConfig,
         ILogger<Producer> logger = null)
     {
-        var x = new DeduplicationProducer()
+        var x = new DeduplicatingProducer()
         {
             _producer = await Producer
                 .Create(
@@ -55,7 +55,7 @@ public class DeduplicationProducer
         return x;
     }
 
-    private DeduplicationProducer()
+    private DeduplicatingProducer()
     {
     }
 

--- a/RabbitMQ.Stream.Client/Reliable/DeduplicationProducer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/DeduplicationProducer.cs
@@ -36,7 +36,7 @@ public class DeduplicationProducer
     public static async Task<DeduplicationProducer> Create(DeduplicationProducerConfig producerConfig,
         ILogger<Producer> logger = null)
     {
-        var x = new DeduplicationProducer(producerConfig, logger)
+        var x = new DeduplicationProducer()
         {
             _producer = await Producer
                 .Create(
@@ -55,8 +55,7 @@ public class DeduplicationProducer
         return x;
     }
 
-    // ReSharper disable once ContextualLoggerProblem
-    private DeduplicationProducer(ProducerConfig producerConfig, ILogger<Producer> logger = null)
+    private DeduplicationProducer()
     {
     }
 

--- a/RabbitMQ.Stream.Client/Reliable/DeduplicationProducer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/DeduplicationProducer.cs
@@ -1,0 +1,88 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2007-2023 VMware, Inc.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace RabbitMQ.Stream.Client.Reliable;
+
+public record DeduplicationProducerConfig : ProducerConfig
+{
+    public DeduplicationProducerConfig(StreamSystem streamSystem, string stream, string reference) : base(streamSystem,
+        stream)
+    {
+        if (string.IsNullOrWhiteSpace(reference))
+            throw new ArgumentException("Reference cannot be null or empty", nameof(reference));
+        _reference = reference;
+    }
+}
+
+// DeduplicationProducer is a wrapper around the Producer class
+// to handle the deduplication of the messages.
+// The deduplication is enabled by setting the reference in the DeduplicationProducerConfig 
+// and it is mandatory to set the reference.
+// This class it to use in an easy way the deduplication feature.
+// the low level API is the RawProducer class, this class sets the right parameters to enable the deduplication
+// The only api is `Send(ulong publishing, Message message)`. In this case the user has to manage the sequence
+// to decide deduplication or not.
+// The best way to handle the deduplication is to use a single thread avoiding the id overlaps.
+
+public class DeduplicationProducer
+{
+    private Producer _producer = null!;
+
+    public static async Task<DeduplicationProducer> Create(DeduplicationProducerConfig producerConfig,
+        ILogger<Producer> logger = null)
+    {
+        var x = new DeduplicationProducer(producerConfig, logger)
+        {
+            _producer = await Producer
+                .Create(
+                    new ProducerConfig(producerConfig.StreamSystem, producerConfig.Stream)
+                    {
+                        _reference = producerConfig.Reference,
+                        ConfirmationHandler = producerConfig.ConfirmationHandler,
+                        ReconnectStrategy = producerConfig.ReconnectStrategy,
+                        ClientProvidedName = producerConfig.ClientProvidedName,
+                        MaxInFlight = producerConfig.MaxInFlight,
+                        MessagesBufferSize = producerConfig.MessagesBufferSize,
+                        TimeoutMessageAfter = producerConfig.TimeoutMessageAfter,
+                    }, logger)
+                .ConfigureAwait(false)
+        };
+        return x;
+    }
+
+    // ReSharper disable once ContextualLoggerProblem
+    private DeduplicationProducer(ProducerConfig producerConfig, ILogger<Producer> logger = null)
+    {
+    }
+
+    // Send a message with a specific publishing id
+    // the publishing id is used to deduplicate the messages
+    // the publishing id must be unique and incremental. It can accept gaps the important is to be incremental
+    public async ValueTask Send(ulong publishing, Message message)
+    {
+        await _producer.SendInternal(publishing, message).ConfigureAwait(false);
+    }
+
+    public async Task Close()
+    {
+        await _producer.Close().ConfigureAwait(false);
+    }
+
+    public bool IsOpen()
+    {
+        return _producer.IsOpen();
+    }
+
+    // Get the last publishing id from the producer/reference
+    // this is useful to know the last id used to deduplicate the messages
+    // so it is possible to restart the producer with the last id
+    public async Task<ulong> GetLastPublishedId()
+    {
+        return await _producer.GetLastPublishingId().ConfigureAwait(false);
+    }
+}

--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -35,15 +35,15 @@ public record ProducerConfig : ReliableConfig
 
     /// <summary>
     /// Reference used for deduplication.
-    /// For the Producer Class it is not needed to set this value.
-    /// See DeduplicationProducer for Deduplication Messages where this value is needed.
+    /// For the Producer Class, it is not needed to set this value
+    /// See DeduplicatingProducer for Deduplication Messages where this value is needed.
     /// </summary>
     internal string _reference;
 
     public string Reference
     {
         get { return _reference; }
-        [Obsolete("Deprecated. Use ClientProvidedName instead. Se DeduplicationProducer for Deduplication Messages ",
+        [Obsolete("Deprecated. Use ClientProvidedName instead. Se DeduplicatingProducer for Deduplication Messages ",
             false)]
         set { _reference = value; }
     }
@@ -243,8 +243,6 @@ public class Producer : ProducerFactory
 
     internal async ValueTask SendInternal(ulong publishingId, Message message)
     {
-        // await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
-        // Interlocked.Increment(ref _publishingId);
         _confirmationPipe.AddUnConfirmedMessage(publishingId, message);
         try
         {
@@ -265,10 +263,6 @@ public class Producer : ProducerFactory
                                  "Most likely the message is not sent to the stream: {Stream}." +
                                  "Message wont' receive confirmation so you will receive a timeout error",
                 _producerConfig.Stream);
-        }
-        finally
-        {
-            // SemaphoreSlim.Release();
         }
     }
 

--- a/Tests/DeduplicationProducerTests.cs
+++ b/Tests/DeduplicationProducerTests.cs
@@ -34,10 +34,10 @@ public class DeduplicationProducerTests
     public async Task ValidateDeduplicationProducer()
     {
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
-        Assert.Throws<ArgumentException>(() => new DeduplicationProducerConfig(system, stream, null));
+        Assert.Throws<ArgumentException>(() => new DeduplicatingProducerConfig(system, stream, null));
         await Assert.ThrowsAsync<ArgumentException>(async () =>
             // reference is white space, not valid
-            await DeduplicationProducer.Create(new DeduplicationProducerConfig(system, stream, " ")));
+            await DeduplicatingProducer.Create(new DeduplicatingProducerConfig(system, stream, " ")));
         await SystemUtils.CleanUpStreamSystem(system, stream);
     }
 
@@ -51,8 +51,8 @@ public class DeduplicationProducerTests
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
         var testPassed = new TaskCompletionSource<ulong>();
         const ulong TotalMessages = 1000UL;
-        var p = await DeduplicationProducer.Create(
-            new DeduplicationProducerConfig(system, stream, "my_producer_reference")
+        var p = await DeduplicatingProducer.Create(
+            new DeduplicatingProducerConfig(system, stream, "my_producer_reference")
             {
                 ConfirmationHandler = async confirmation =>
                 {
@@ -87,8 +87,8 @@ public class DeduplicationProducerTests
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
         var testPassed = new TaskCompletionSource<ulong>();
         const ulong TotalMessages = 1000UL;
-        var p = await DeduplicationProducer.Create(
-            new DeduplicationProducerConfig(system, stream, "my_producer_reference")
+        var p = await DeduplicatingProducer.Create(
+            new DeduplicatingProducerConfig(system, stream, "my_producer_reference")
             {
                 ConfirmationHandler = async confirmation =>
                 {

--- a/Tests/DeduplicationProducerTests.cs
+++ b/Tests/DeduplicationProducerTests.cs
@@ -1,0 +1,131 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2007-2023 VMware, Inc.
+
+/* Unmerged change from project 'Tests(net7.0)'
+Before:
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+After:
+using System.Threading.Tasks;
+*/
+
+using System;
+using System.Threading.Tasks;
+using RabbitMQ.Stream.Client;
+using RabbitMQ.Stream.Client.Reliable;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests;
+
+public class DeduplicationProducerTests
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public DeduplicationProducerTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async Task ValidateDeduplicationProducer()
+    {
+        SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
+        Assert.Throws<ArgumentException>(() => new DeduplicationProducerConfig(system, stream, null));
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            // reference is white space, not valid
+            await DeduplicationProducer.Create(new DeduplicationProducerConfig(system, stream, " ")));
+        await SystemUtils.CleanUpStreamSystem(system, stream);
+    }
+
+    [Fact]
+    public async Task GetLastIdShouldBeEqualtoTheMessagesSent()
+    {
+        // here we create a producer with a reference
+        // the reference is used to  enable the deduplication
+        // then we query the sequence externally form the producer to be sure that
+        // the values are the same
+        SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
+        var testPassed = new TaskCompletionSource<ulong>();
+        const ulong TotalMessages = 1000UL;
+        var p = await DeduplicationProducer.Create(
+            new DeduplicationProducerConfig(system, stream, "my_producer_reference")
+            {
+                ConfirmationHandler = async confirmation =>
+                {
+                    if (confirmation.PublishingId == TotalMessages)
+                        testPassed.SetResult(TotalMessages);
+                    await Task.CompletedTask;
+                },
+            });
+        for (ulong i = 1; i <= TotalMessages; i++)
+        {
+            await p.Send(i, new Message(new byte[10]));
+        }
+
+        new Utils<ulong>(_testOutputHelper).WaitUntilTaskCompletes(testPassed);
+        SystemUtils.Wait();
+        Assert.Equal(TotalMessages, await p.GetLastPublishedId());
+        await p.Close();
+        Assert.False(p.IsOpen());
+
+        // here we query the sequence externally form the producer to be sure that
+        // the values are the same
+        Assert.Equal(TotalMessages, await system.QuerySequence("my_producer_reference", stream));
+        await SystemUtils.CleanUpStreamSystem(system, stream);
+    }
+
+    [Fact]
+    public async Task DeduplicationInActionSendingTheSameIdMessagesWontStore()
+    {
+        // in this test we send the same messages again with the same publishing id
+        // to see the deduplication in action
+
+        SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
+        var testPassed = new TaskCompletionSource<ulong>();
+        const ulong TotalMessages = 1000UL;
+        var p = await DeduplicationProducer.Create(
+            new DeduplicationProducerConfig(system, stream, "my_producer_reference")
+            {
+                ConfirmationHandler = async confirmation =>
+                {
+                    if (confirmation.PublishingId == TotalMessages)
+                        testPassed.SetResult(TotalMessages);
+                    await Task.CompletedTask;
+                },
+            });
+        // first send and the messages are stored
+        for (ulong i = 1; i <= TotalMessages; i++)
+        {
+            await p.Send(i, new Message(new byte[10]));
+        }
+
+        new Utils<ulong>(_testOutputHelper).WaitUntilTaskCompletes(testPassed);
+        SystemUtils.Wait();
+        Assert.Equal(TotalMessages, await p.GetLastPublishedId());
+
+        // we send the same messages again with the same publishing id
+        // so the messages won't be stored due of the deduplication
+        for (ulong i = 1; i <= TotalMessages; i++)
+        {
+            await p.Send(i, new Message(new byte[10]));
+        }
+
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount(stream) == (int)TotalMessages);
+
+        // we are out of the deduplication window so the messages will be stored
+        // we start from the last published id + 1
+        await p.Send(await p.GetLastPublishedId() + 1, new Message(new byte[10]));
+        await p.Send(await p.GetLastPublishedId() + 2, new Message(new byte[10]));
+
+        // the total messages should be the TotalMessages + 2 new messages
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount(stream) == (int)TotalMessages + 2);
+        await p.Close();
+        Assert.False(p.IsOpen());
+
+        await SystemUtils.CleanUpStreamSystem(system, stream);
+    }
+}

--- a/Tests/DeduplicationProducerTests.cs
+++ b/Tests/DeduplicationProducerTests.cs
@@ -2,16 +2,6 @@
 // 2.0, and the Mozilla Public License, version 2.0.
 // Copyright (c) 2007-2023 VMware, Inc.
 
-/* Unmerged change from project 'Tests(net7.0)'
-Before:
-using System.Collections.Generic;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
-After:
-using System.Threading.Tasks;
-*/
-
 using System;
 using System.Threading.Tasks;
 using RabbitMQ.Stream.Client;

--- a/Tests/ReliableTests.cs
+++ b/Tests/ReliableTests.cs
@@ -235,9 +235,10 @@ public class ReliableTests
     public async void AutoPublishIdDefaultShouldStartFromTheLast()
     {
         // RProducer automatically retrieves the last producer offset.
-        // see IPublishingIdStrategy implementation
         // This tests if the the last id stored 
         // A new RProducer should restart from the last offset. 
+        // This test will be removed when Reference will be mandatory 
+        // in the DeduplicationProducer
 
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
         var testPassed = new TaskCompletionSource<ulong>();
@@ -247,8 +248,8 @@ public class ReliableTests
         var producer = await Producer.Create(
             new ProducerConfig(system, stream)
             {
+                _reference = reference,
                 ClientProvidedName = clientProviderName,
-                Reference = reference,
                 ConfirmationHandler = confirm =>
                 {
                     if (Interlocked.Increment(ref count) != 5)
@@ -284,7 +285,7 @@ public class ReliableTests
         var producerSecond = await Producer.Create(
             new ProducerConfig(system, stream)
             {
-                Reference = reference,
+                _reference = reference,
                 ClientProvidedName = clientProviderName,
                 ConfirmationHandler = confirm =>
                 {

--- a/Tests/ReliableTests.cs
+++ b/Tests/ReliableTests.cs
@@ -35,19 +35,22 @@ public class ReliableTests
                 l.Add(confirmation.Status);
                 if (confirmation.PublishingId == 2)
                 {
+                    await Task.CompletedTask;
                     confirmationTask.SetResult(2);
                 }
-
-                await Task.CompletedTask;
+                else
+                {
+                    await Task.CompletedTask;
+                }
             },
             TimeSpan.FromSeconds(2), 100
         );
         confirmationPipe.Start();
-        var message = new Message(Encoding.UTF8.GetBytes($"hello"));
-        confirmationPipe.AddUnConfirmedMessage(1, message);
-        confirmationPipe.AddUnConfirmedMessage(2, new List<Message>() { message });
+        confirmationPipe.AddUnConfirmedMessage(1, new Message(Encoding.UTF8.GetBytes($"hello")));
+        confirmationPipe.AddUnConfirmedMessage(2, new List<Message>() { new Message(Encoding.UTF8.GetBytes($"hello")) });
         new Utils<int>(_testOutputHelper).WaitUntilTaskCompletes(confirmationTask);
         Assert.Equal(2, confirmationTask.Task.Result);
+        Assert.Equal(2, l.Count);
         // time out error is sent by the internal time that checks the status
         // if the message doesn't receive the confirmation within X time, the timeout error is raised.
         Assert.Equal(ConfirmationStatus.ClientTimeoutError, l[0]);

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -113,6 +113,12 @@ namespace Tests
             x.Wait();
         }
 
+        public static async Task CleanUpStreamSystem(StreamSystem system, string stream)
+        {
+            await system.DeleteStream(stream);
+            await system.Close();
+        }
+
         public static async Task PublishMessages(StreamSystem system, string stream, int numberOfMessages,
             ITestOutputHelper testOutputHelper)
         {


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/227


Implement the `DeduplicationProducer` make the `ProducerConfig.Reference` deprecated.
The `Producer` does not need the `Reference` to work. `Reference` is needed only for the Deduplication part.

The low-level Class is the `RawProducer` class; this class sets the correct parameters to enable the deduplication and to make it easy to use. 



 

Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>