### PR TITLE
Switch to Random.Shared

### DIFF
--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -97,8 +97,7 @@ namespace RabbitMQ.Stream.Client
 
         private async Task MayBeReconnectLocator()
         {
-            var rnd = new Random();
-            var advId = rnd.Next(0, _clientParameters.Endpoints.Count);
+            var advId = Random.Shared.Next(0, _clientParameters.Endpoints.Count);
 
             try
             {


### PR DESCRIPTION
Hi,

`Random.Shared` is already used in other places in the codebase and I don't see any reasons why it should not be used here.