### PR TITLE
Fix RawConsumer bug in DEBUG log statement causing exceptions

### DIFF
--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -105,7 +105,7 @@ namespace RabbitMQ.Stream.Client
             _logger = logger ?? NullLogger.Instance;
             _initialCredits = config.InitialCredits;
             _logger.LogDebug("creating consumer {Consumer} with initial credits {InitialCredits}, " +
-                             "offset {OffsetSpec}, is single active consumer {IsSingleActiveConsumer}, super stream {SuperStream}, client provided name {ClientProvidedName}, " +
+                             "offset {OffsetSpec}, is single active consumer {IsSingleActiveConsumer}, super stream {SuperStream}, client provided name {ClientProvidedName}",
                              config.Reference,
                 _initialCredits, config.OffsetSpec, config.SuperStream, config.IsSingleActiveConsumer,
                 config.ClientProvidedName);

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -106,9 +106,7 @@ namespace RabbitMQ.Stream.Client
             _initialCredits = config.InitialCredits;
             _logger.LogDebug("creating consumer {Consumer} with initial credits {InitialCredits}, " +
                              "offset {OffsetSpec}, is single active consumer {IsSingleActiveConsumer}, super stream {SuperStream}, client provided name {ClientProvidedName}",
-                             config.Reference,
-                _initialCredits, config.OffsetSpec, config.SuperStream, config.IsSingleActiveConsumer,
-                config.ClientProvidedName);
+                             config.Reference, _initialCredits, config.OffsetSpec, config.IsSingleActiveConsumer, config.SuperStream, config.ClientProvidedName);
 
             // _chunksBuffer is a channel that is used to buffer the chunks
             _chunksBuffer = Channel.CreateBounded<Chunk>(new BoundedChannelOptions(_initialCredits)


### PR DESCRIPTION
Bug in DEBUG level log statement for creation of `RawConsumer`. Occurs only when DEBUG level was specified for the consumer. Confirmed using the following:

```
var factory = LoggerFactory.Create(builder =>
            {
                builder.AddSimpleConsole();
                builder.AddFilter("RabbitMQ.Stream", LogLevel.Debug);
            });

...
 var consumerLogger = factory.CreateLogger<Consumer>();
 var consumer = await system.CreateRawConsumer(
                new RawConsumerConfig(stream)
                {
                    Reference = "consumer",
                    MessageHandler = async (consumer, ctx, message) =>
                    {
                        await Task.CompletedTask;
                    }
                }, consumerLogger);
```
