### PR TITLE
change default log for ProcessIncomingFrames thread

### DIFF
--- a/RabbitMQ.Stream.Client/Connection.cs
+++ b/RabbitMQ.Stream.Client/Connection.cs
@@ -224,7 +224,7 @@ namespace RabbitMQ.Stream.Client
                     socket.Dispose();
                     if (!_incomingFramesTask.Wait(Consts.MidWait))
                     {
-                        _logger?.LogWarning("ProcessIncomingFrames reader task did not exit in {ShortWait}", Consts.MidWait);
+                        _logger?.LogWarning("ProcessIncomingFrames reader task did not exit in {MidWait}", Consts.MidWait);
                     }
                 }
                 finally

--- a/RabbitMQ.Stream.Client/Connection.cs
+++ b/RabbitMQ.Stream.Client/Connection.cs
@@ -222,9 +222,9 @@ namespace RabbitMQ.Stream.Client
                     writer.Complete();
                     reader.Complete();
                     socket.Dispose();
-                    if (!_incomingFramesTask.Wait(Consts.ShortWait))
+                    if (!_incomingFramesTask.Wait(Consts.MidWait))
                     {
-                        _logger?.LogError("frame reader task did not exit in {ShortWait}", Consts.ShortWait);
+                        _logger?.LogWarning("ProcessIncomingFrames reader task did not exit in {ShortWait}", Consts.MidWait);
                     }
                 }
                 finally


### PR DESCRIPTION
In a pressure system, the process frame could take more time to be closed. 
This PR increase a bit the wait time and change the log from Error to Warning because it is not actually an error just a warning.   