### PR TITLE
Add docs to timestamp offset; add additional constructors

### DIFF
--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -60,6 +60,8 @@ RabbitMQ.Stream.Client.IRoutingStrategy.Route(RabbitMQ.Stream.Client.Message mes
 RabbitMQ.Stream.Client.KeyRoutingStrategy
 RabbitMQ.Stream.Client.KeyRoutingStrategy.KeyRoutingStrategy(System.Func<RabbitMQ.Stream.Client.Message, string> routingKeyExtractor, System.Func<string, string, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.RouteQueryResponse>> routingKeyQFunc, string superStream) -> void
 RabbitMQ.Stream.Client.KeyRoutingStrategy.Route(RabbitMQ.Stream.Client.Message message, System.Collections.Generic.List<string> partitions) -> System.Threading.Tasks.Task<System.Collections.Generic.List<string>>
+RabbitMQ.Stream.Client.OffsetTypeTimestamp.OffsetTypeTimestamp(System.DateTime dateTime) -> void
+RabbitMQ.Stream.Client.OffsetTypeTimestamp.OffsetTypeTimestamp(System.DateTimeOffset dateTimeOffset) -> void
 RabbitMQ.Stream.Client.ProducerFilter
 RabbitMQ.Stream.Client.ProducerFilter.FilterValue.get -> System.Func<RabbitMQ.Stream.Client.Message, string>
 RabbitMQ.Stream.Client.ProducerFilter.FilterValue.set -> void

--- a/RabbitMQ.Stream.Client/Subscribe.cs
+++ b/RabbitMQ.Stream.Client/Subscribe.cs
@@ -86,7 +86,7 @@ namespace RabbitMQ.Stream.Client
     /// <summary>
     /// Offset of type timestamp.
     /// </summary>
-    /// <remarks>Note that timestamp itself is not UNIX timestamp but microsecond-precise UNIX timestamp.</remarks>
+    /// <remarks>Note that timestamp itself is not UNIX timestamp but millisecond-precise UNIX timestamp.</remarks>
     public readonly struct OffsetTypeTimestamp : IOffsetType
     {
         private readonly long _timestamp;
@@ -95,8 +95,8 @@ namespace RabbitMQ.Stream.Client
         /// <summary>
         /// Create offset of type timestamp from given timestamp.
         /// </summary>
-        /// <param name="timestamp">unix timestamp, microsecond precision</param>
-        /// <remarks>Note that timestamp itself is not UNIX timestamp but microsecond-precise UNIX timestamp.</remarks>
+        /// <param name="timestamp">unix timestamp, millisecond precision</param>
+        /// <remarks>Note that timestamp itself is not UNIX timestamp but millisecond-precise UNIX timestamp.</remarks>
         public OffsetTypeTimestamp(long timestamp)
         {
             _timestamp = timestamp;

--- a/RabbitMQ.Stream.Client/Subscribe.cs
+++ b/RabbitMQ.Stream.Client/Subscribe.cs
@@ -83,23 +83,47 @@ namespace RabbitMQ.Stream.Client
         }
     }
 
+    /// <summary>
+    /// Offset of type timestamp.
+    /// </summary>
+    /// <remarks>Note that timestamp itself is not UNIX timestamp but microsecond-precise UNIX timestamp.</remarks>
     public readonly struct OffsetTypeTimestamp : IOffsetType
     {
-        private readonly long timestamp;
+        private readonly long _timestamp;
         public OffsetTypeEnum OffsetType => OffsetTypeEnum.Timestamp;
 
+        /// <summary>
+        /// Create offset of type timestamp from given timestamp.
+        /// </summary>
+        /// <param name="timestamp">unix timestamp, microsecond precision</param>
+        /// <remarks>Note that timestamp itself is not UNIX timestamp but microsecond-precise UNIX timestamp.</remarks>
         public OffsetTypeTimestamp(long timestamp)
         {
-            this.timestamp = timestamp;
+            _timestamp = timestamp;
         }
 
-        internal long TimeStamp => timestamp;
+        public OffsetTypeTimestamp(DateTimeOffset dateTimeOffset)
+        {
+            _timestamp = dateTimeOffset.ToUnixTimeMilliseconds();
+        }
+
+        public OffsetTypeTimestamp(DateTime dateTime)
+        {
+            if (dateTime.Kind != DateTimeKind.Utc)
+            {
+                throw new UnsupportedOperationException("Given datetime has to be of kind Utc");
+            }
+
+            _timestamp = new DateTimeOffset(dateTime).ToUnixTimeMilliseconds();
+        }
+
+        internal long TimeStamp => _timestamp;
         public int Size => 10;
 
         public int Write(Span<byte> span)
         {
             var offset = WireFormatting.WriteUInt16(span, (ushort)OffsetType);
-            offset += WireFormatting.WriteInt64(span[offset..], timestamp);
+            offset += WireFormatting.WriteInt64(span[offset..], _timestamp);
             return offset;
         }
     }


### PR DESCRIPTION
I guess at minimum I'd like docs merged - the additional constructors are optional but would help out.
Essentially, I consider existing constructor to be a bit of a foot-gun - I only realized that giving normal timestamp didn't work properly because I've read a bug report here :D