### PR TITLE
Force localhost connections when client connects to localhost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ test: build
 rabbitmq-server:
 	docker run -it --rm --name rabbitmq-stream-docker \
 		-p 5552:5552 -p 5672:5672 -p 15672:15672 \
-		-e RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-rabbitmq_stream advertised_host localhost" \
 		--pull always \
 		pivotalrabbitmq/rabbitmq-stream
 

--- a/Tests/FilterTest.cs
+++ b/Tests/FilterTest.cs
@@ -18,10 +18,14 @@ public class FilterTest
 {
     // When the Filter is set also Values must be set and PostFilter must be set
     // Values must be a list of string and must contain at least one element
-    [Fact]
+    [SkippableFact]
     public async void ValidateFilter()
     {
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
+        if (!AvailableFeaturesSingleton.Instance.PublishFilter)
+        {
+            throw new SkipException("broker does not support filter");
+        }
 
         await Assert.ThrowsAsync<ArgumentException>(() => Consumer.Create(
             new ConsumerConfig(system, stream) { Filter = new ConsumerFilter() }
@@ -54,10 +58,14 @@ public class FilterTest
     // We send 100 messages with two different states (Alabama and New York)
     // By using the filter we should be able to consume only the messages from Alabama 
     // and the server has to send only one chunk with all the messages from Alabama
-    [Fact]
+    [SkippableFact]
     public async void FilterShouldReturnOnlyOneChunk()
     {
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
+        if (!AvailableFeaturesSingleton.Instance.PublishFilter)
+        {
+            throw new SkipException("broker does not support filter");
+        }
 
         var producer = await Producer.Create(
             new ProducerConfig(system, stream)
@@ -171,10 +179,15 @@ public class FilterTest
     // For the producer side we have the ConfirmationHandler the messages with errors 
     // will be reported as not confirmed and the user can handle them.
     // for the consumer the messages will be skipped and logged with the standard logger
-    [Fact]
+    [SkippableFact]
     public async void ErrorFiltersFunctionWontDeliverTheMessage()
     {
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
+        if (!AvailableFeaturesSingleton.Instance.PublishFilter)
+        {
+            throw new SkipException("broker does not support filter");
+        }
+
         var messagesConfirmed = 0;
         var messagesError = 0;
         var testPassed = new TaskCompletionSource<int>();

--- a/Tests/RawProducerSystemTests.cs
+++ b/Tests/RawProducerSystemTests.cs
@@ -325,16 +325,16 @@ namespace Tests
             const int NumberOfMessages = 100;
             var rawProducer = await system.CreateRawProducer(new
                 RawProducerConfig(stream)
+            {
+                Reference = "producer",
+                ConfirmHandler = confirmation =>
                 {
-                    Reference = "producer",
-                    ConfirmHandler = confirmation =>
+                    if (confirmation.PublishingId == NumberOfMessages)
                     {
-                        if (confirmation.PublishingId == NumberOfMessages)
-                        {
-                            testPassed.SetResult(true);
-                        }
+                        testPassed.SetResult(true);
                     }
                 }
+            }
             );
             var messages = new List<(ulong, Message)>();
             for (var i = 1; i <= NumberOfMessages; i++)
@@ -386,9 +386,10 @@ namespace Tests
             var testPassed = new TaskCompletionSource<bool>();
             var rawProducer = await system.CreateRawProducer(new
                 RawProducerConfig(stream)
-                {
-                    Reference = "producer", ConfirmHandler = _ => { testPassed.SetResult(true); }
-                }
+            {
+                Reference = "producer",
+                ConfirmHandler = _ => { testPassed.SetResult(true); }
+            }
             );
 
             const ulong PublishingId = 0;


### PR DESCRIPTION
Fixes #296

It is common to have a local instance of RabbitMQ running locally,
either via a local rabbit (e.g. installed from source), or inside a
container (e.g. Docker or local Kubernetes). In both cases, our client
may not work without providing an address resolver, or without changing
the advertised host/port in rabbit via an env variable. Specifically,
our clients won't work if the client can't resolve the hostname of the
local machine.

For exampe, a laptop may have a hostname mylaptop.some-company.com.
Rabbit won't be impacted as long as it works in a single-node
configuration. However, the client smart features to locate the stream
leaders and replicas will get "confused" because it can't resolve the
hostname.

This commit changes the smart layer, so that it won't try to locate the
stream replicas if the client is connected to localhost. Instead, it
will force the producer/consumer connections to be localhost, and it
will assume that stream replicas/leader are in localhost. This is true
for single-node rabbits in local development environments. The smart
feature to locate leader/replicas remains unchanged for non-local
connections.

