### PR TITLE
Add DateTimeOffset test

### DIFF
--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -583,7 +583,7 @@ namespace RabbitMQ.Stream.Client
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Error during disposing of consumer: {SubscriberId}.", _subscriberId);
+                _logger.LogError(e, "Error during disposing of consumer: {SubscriberId}", _subscriberId);
             }
             finally
             {

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -397,7 +397,7 @@ namespace RabbitMQ.Stream.Client
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Error during disposing Consumer: {PublisherId}.", _publisherId);
+                _logger.LogError(e, "Error during disposing Consumer: {PublisherId}", _publisherId);
             }
 
             GC.SuppressFinalize(this);

--- a/Tests/ReliableTests.cs
+++ b/Tests/ReliableTests.cs
@@ -80,8 +80,8 @@ public class ReliableTests
         var message = new Message(Encoding.UTF8.GetBytes($"hello"));
         confirmationPipe.AddUnConfirmedMessage(1, message);
         confirmationPipe.AddUnConfirmedMessage(2, new List<Message>() { message });
-        confirmationPipe.RemoveUnConfirmedMessage(ConfirmationStatus.Confirmed, 1, null);
-        confirmationPipe.RemoveUnConfirmedMessage(ConfirmationStatus.Confirmed, 2, null);
+        confirmationPipe.RemoveUnConfirmedMessage(ConfirmationStatus.Confirmed, 1, null).ConfigureAwait(false);
+        confirmationPipe.RemoveUnConfirmedMessage(ConfirmationStatus.Confirmed, 2, null).ConfigureAwait(false);
         new Utils<List<MessagesConfirmation>>(_testOutputHelper).WaitUntilTaskCompletes(confirmationTask);
         Assert.Equal(ConfirmationStatus.Confirmed, confirmationTask.Task.Result[0].Status);
         Assert.Equal(ConfirmationStatus.Confirmed, confirmationTask.Task.Result[1].Status);


### PR DESCRIPTION
- Add DateTimeOffset test. The test is not 100% perfect since it depends on the data time starting. In this case, the test returns all the messages. 
- Constant naming refactor.