### PR TITLE
Removed unused class MyMethodAttribute from Producer.cs

### DIFF
--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -20,17 +20,6 @@ public record SuperStreamConfig
     public RoutingStrategyType RoutingStrategyType { get; set; } = RoutingStrategyType.Hash;
 }
 
-[AttributeUsage(AttributeTargets.Method)]
-internal class MyMethodAttribute : Attribute
-{
-    public string Message { get; }
-
-    public MyMethodAttribute(string message)
-    {
-        Message = message;
-    }
-}
-
 public record ProducerConfig : ReliableConfig
 {
     private readonly TimeSpan _timeoutMessageAfter = TimeSpan.FromSeconds(3);


### PR DESCRIPTION
Found an unused internal class in Producer.cs. Unless there is a future use for this, it is not needed. But the naming seems to indicate that this was test code.