### PR TITLE
Fixing Endpoint passed to StreamSystem

### DIFF
--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -66,12 +66,13 @@ namespace RabbitMQ.Stream.Client
             {
                 try
                 {
-                    var client = await Client.Create(clientParams with { Endpoint = endPoint }, logger)
+                    var paramsWithEndPoint = clientParams with { Endpoint = endPoint };
+                    var client = await Client.Create(paramsWithEndPoint, logger)
                         .ConfigureAwait(false);
                     if (!client.IsClosed)
                     {
                         logger?.LogDebug("Client connected to {@EndPoint}", endPoint);
-                        return new StreamSystem(clientParams, client, logger);
+                        return new StreamSystem(paramsWithEndPoint, client, logger);
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
This fix ensures that the clientParams passed to the StreamSystem matches the one set on the Client (and the one the connection has just been established to).

Fixes an issue where the server is bound to multiple IPs, and it advertises a local IP address over a public one.

Resolves: https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/315