### PR TITLE
Add Info class to the Producer/Consumer classes

### DIFF
--- a/RabbitMQ.Stream.Client/AbstractEntity.cs
+++ b/RabbitMQ.Stream.Client/AbstractEntity.cs
@@ -21,5 +21,7 @@ namespace RabbitMQ.Stream.Client
         }
 
         protected Client _client;
+
+        public Info Info { get; internal set; }
     }
 }

--- a/RabbitMQ.Stream.Client/EntityInfo.cs
+++ b/RabbitMQ.Stream.Client/EntityInfo.cs
@@ -1,0 +1,17 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2007-2023 VMware, Inc.
+
+namespace RabbitMQ.Stream.Client;
+
+public class Info
+{
+    public string Reference { get; }
+    public string Stream { get; }
+
+    internal Info(string reference, string stream)
+    {
+        Reference = reference;
+        Stream = stream;
+    }
+}

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -12,6 +12,8 @@ public interface IConsumer
     public Task StoreOffset(ulong offset);
     public Task<ResponseCode> Close();
     public void Dispose();
+
+    public Info Info { get; }
 }
 
 public record IConsumerConfig : INamedEntity

--- a/RabbitMQ.Stream.Client/IProducer.cs
+++ b/RabbitMQ.Stream.Client/IProducer.cs
@@ -67,6 +67,11 @@ public interface IProducer
     public int PublishCommandsSent { get; }
 
     public int PendingCount { get; }
+
+    /// <summary>
+    /// Info contains the reference and the stream name.
+    /// </summary>
+    public Info Info { get; }
 }
 
 public record ProducerFilter

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 const RabbitMQ.Stream.Client.RouteQueryResponse.Key = 24 -> ushort
 const RabbitMQ.Stream.Client.StreamStatsResponse.Key = 28 -> ushort
+RabbitMQ.Stream.Client.AbstractEntity.Info.get -> RabbitMQ.Stream.Client.Info
 RabbitMQ.Stream.Client.AbstractEntity.MaybeCancelToken() -> void
 RabbitMQ.Stream.Client.AbstractEntity.Token.get -> System.Threading.CancellationToken
 RabbitMQ.Stream.Client.AuthMechanism
@@ -25,6 +26,7 @@ RabbitMQ.Stream.Client.ConsumerFilter.Values.set -> void
 RabbitMQ.Stream.Client.CrcException
 RabbitMQ.Stream.Client.CrcException.CrcException(string s) -> void
 RabbitMQ.Stream.Client.HashRoutingMurmurStrategy.Route(RabbitMQ.Stream.Client.Message message, System.Collections.Generic.List<string> partitions) -> System.Threading.Tasks.Task<System.Collections.Generic.List<string>>
+RabbitMQ.Stream.Client.IConsumer.Info.get -> RabbitMQ.Stream.Client.Info
 RabbitMQ.Stream.Client.IConsumerConfig.Crc32.get -> RabbitMQ.Stream.Client.ICrc32
 RabbitMQ.Stream.Client.IConsumerConfig.Crc32.set -> void
 RabbitMQ.Stream.Client.IConsumerConfig.ConsumerFilter.get -> RabbitMQ.Stream.Client.ConsumerFilter
@@ -54,6 +56,10 @@ RabbitMQ.Stream.Client.IConsumerConfig.InitialCredits.get -> ushort
 RabbitMQ.Stream.Client.IConsumerConfig.InitialCredits.set -> void
 RabbitMQ.Stream.Client.ICrc32
 RabbitMQ.Stream.Client.ICrc32.Hash(byte[] data) -> byte[]
+RabbitMQ.Stream.Client.Info
+RabbitMQ.Stream.Client.Info.Reference.get -> string
+RabbitMQ.Stream.Client.Info.Stream.get -> string
+RabbitMQ.Stream.Client.IProducer.Info.get -> RabbitMQ.Stream.Client.Info
 RabbitMQ.Stream.Client.IProducerConfig.Filter.get -> RabbitMQ.Stream.Client.ProducerFilter
 RabbitMQ.Stream.Client.IProducerConfig.Filter.set -> void
 RabbitMQ.Stream.Client.IRoutingStrategy.Route(RabbitMQ.Stream.Client.Message message, System.Collections.Generic.List<string> partitions) -> System.Threading.Tasks.Task<System.Collections.Generic.List<string>>
@@ -73,6 +79,8 @@ RabbitMQ.Stream.Client.PublishFilter.PublishFilter() -> void
 RabbitMQ.Stream.Client.PublishFilter.PublishFilter(byte publisherId, System.Collections.Generic.List<(ulong, RabbitMQ.Stream.Client.Message)> messages, System.Func<RabbitMQ.Stream.Client.Message, string> filterValueExtractor, Microsoft.Extensions.Logging.ILogger logger) -> void
 RabbitMQ.Stream.Client.PublishFilter.SizeNeeded.get -> int
 RabbitMQ.Stream.Client.PublishFilter.Write(System.Span<byte> span) -> int
+RabbitMQ.Stream.Client.RawSuperStreamConsumer.Info.get -> RabbitMQ.Stream.Client.Info
+RabbitMQ.Stream.Client.RawSuperStreamProducer.Info.get -> RabbitMQ.Stream.Client.Info
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.get -> RabbitMQ.Stream.Client.RoutingStrategyType
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.set -> void
 RabbitMQ.Stream.Client.Reliable.ConsumerConfig.Crc32.get -> RabbitMQ.Stream.Client.ICrc32
@@ -84,6 +92,7 @@ RabbitMQ.Stream.Client.Reliable.ConsumerConfig.InitialCredits.set -> void
 RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer
 RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.Close() -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.GetLastPublishedId() -> System.Threading.Tasks.Task<ulong>
+RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.Info.get -> RabbitMQ.Stream.Client.Info
 RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.IsOpen() -> bool
 RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.Send(ulong publishing, RabbitMQ.Stream.Client.Message message) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Stream.Client.Reliable.DeduplicatingProducerConfig
@@ -91,6 +100,7 @@ RabbitMQ.Stream.Client.Reliable.DeduplicatingProducerConfig.DeduplicatingProduce
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Filter.get -> RabbitMQ.Stream.Client.ProducerFilter
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Filter.set -> void
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.set -> void
+RabbitMQ.Stream.Client.Reliable.ReliableBase.Info.get -> RabbitMQ.Stream.Client.Info
 RabbitMQ.Stream.Client.Reliable.SuperStreamConfig.RoutingStrategyType.get -> RabbitMQ.Stream.Client.RoutingStrategyType
 RabbitMQ.Stream.Client.Reliable.SuperStreamConfig.RoutingStrategyType.set -> void
 RabbitMQ.Stream.Client.RouteNotFoundException

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -140,7 +140,7 @@ namespace RabbitMQ.Stream.Client
             _initialCredits = config.InitialCredits;
             _config = config;
             _logger.LogDebug("Creating... {ConsumerInfo}", ConsumerInfo());
-
+            Info = new Info(_config.Reference, _config.Stream);
             // _chunksBuffer is a channel that is used to buffer the chunks
             _chunksBuffer = Channel.CreateBounded<Chunk>(new BoundedChannelOptions(_initialCredits)
             {

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -79,6 +79,7 @@ namespace RabbitMQ.Stream.Client
         {
             _client = client;
             _config = config;
+            Info = new Info(_config.Reference, _config.Stream);
             _messageBuffer = Channel.CreateBounded<OutgoingMsg>(new BoundedChannelOptions(10000)
             {
                 AllowSynchronousContinuations = false,

--- a/RabbitMQ.Stream.Client/RawSuperStreamConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamConsumer.cs
@@ -55,6 +55,7 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
         _streamInfos = streamInfos;
         _clientParameters = clientParameters;
         _logger = logger ?? NullLogger.Instance;
+        Info = new Info(_config.Reference, _config.SuperStream);
 
         StartConsumers().Wait(CancellationToken.None);
     }
@@ -217,6 +218,8 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
         _disposed = true;
         GC.SuppressFinalize(this);
     }
+
+    public Info Info { get; internal set; }
 }
 
 public record RawSuperStreamConsumerConfig : IConsumerConfig

--- a/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
@@ -56,13 +56,13 @@ public class RawSuperStreamProducer : IProducer, IDisposable
     private RawSuperStreamProducer(
         RawSuperStreamProducerConfig config,
         IDictionary<string, StreamInfo> streamInfos,
-        ClientParameters clientParameters,
-        ILogger logger = null
+        ClientParameters clientParameters, ILogger logger = null
     )
     {
         _config = config;
         _streamInfos = streamInfos;
         _clientParameters = clientParameters;
+        Info = new Info(config.Reference, config.SuperStream);
         _defaultRoutingConfiguration.RoutingStrategy = _config.RoutingStrategyType switch
         {
             RoutingStrategyType.Key => new KeyRoutingStrategy(_config.Routing,
@@ -277,6 +277,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
     public int IncomingFrames => _producers.Sum(x => x.Value.IncomingFrames);
     public int PublishCommandsSent => _producers.Sum(x => x.Value.PublishCommandsSent);
     public int PendingCount => _producers.Sum(x => x.Value.PendingCount);
+    public Info Info { get; }
 }
 
 public enum RoutingStrategyType

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -165,6 +165,7 @@ public class Consumer : ConsumerFactory
     {
         _logger = logger ?? NullLogger<Consumer>.Instance;
         _consumerConfig = consumerConfig;
+        Info = new Info(consumerConfig.Reference, consumerConfig.Stream);
     }
 
     public static async Task<Consumer> Create(ConsumerConfig consumerConfig, ILogger<Consumer> logger = null)

--- a/RabbitMQ.Stream.Client/Reliable/DeduplicatingProducer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/DeduplicatingProducer.cs
@@ -86,4 +86,6 @@ public class DeduplicatingProducer
     {
         return await _producer.GetLastPublishingId().ConfigureAwait(false);
     }
+
+    public Info Info => _producer.Info;
 }

--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -138,6 +138,7 @@ public class Producer : ProducerFactory
             producerConfig.TimeoutMessageAfter,
             producerConfig.MaxInFlight
         );
+        Info = new Info(producerConfig.Reference, producerConfig.Stream);
         _logger = logger ?? NullLogger<Producer>.Instance;
     }
 

--- a/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
@@ -216,4 +216,6 @@ public abstract class ReliableBase
     {
         return _isOpen;
     }
+
+    public Info Info { get; internal set; }
 }


### PR DESCRIPTION
The call returns the Reference and Stream.
So that you know, the `Reference` is deprecated for the producer class and will be removed at some point. So the `info.reference` for the producer will also be removed.

We can add other info about the consumer and producer and the consumer in the future.

ref: https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/discussions/321 

To get the info:

```csharp
 var consumer = await Consumer.Create(new ConsumerConfig(system, "MyStream") { Reference = "consumer", });

entityInfo = consumer.Info;
Assert.Equal("MyStream", entityInfo.Stream);
Assert.Equal("consumer", entityInfo.Reference);
``` 


and also in the handler:

```csharp
MessageHandler = async (sourceStream, consumer, ctx, message) =>
{
                        
    Console.WriteLine($"Consumer info Reference: {consumer.Info.Reference} ");
```




