### PR TITLE
New event to handle Metadata update

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -68,7 +68,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-v2-nuget-
       - name: Wait RabbitMQ is Up 
-        run: docker exec -it ${{ job.services.rabbitmq.id }} rabbitmqctl wait --pid 1 --timeout 60
+        run: docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl wait --pid 1 --timeout 60
       - name: Enable RabbitMQ Plugins
         run: docker exec ${{ job.services.rabbitmq.id }} rabbitmq-plugins enable rabbitmq_stream rabbitmq_stream_management rabbitmq_amqp1_0
       - name: Restore

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -67,6 +67,8 @@ jobs:
           key: ${{ runner.os }}-v2-nuget-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
             ${{ runner.os }}-v2-nuget-
+      - name: Wait RabbitMQ is Up 
+        run: docker exec -it ${{ job.services.rabbitmq.id }} rabbitmqctl wait --pid 1 --timeout 60
       - name: Enable RabbitMQ Plugins
         run: docker exec ${{ job.services.rabbitmq.id }} rabbitmq-plugins enable rabbitmq_stream rabbitmq_stream_management rabbitmq_amqp1_0
       - name: Restore

--- a/RabbitMQ.Stream.Client/AbstractEntity.cs
+++ b/RabbitMQ.Stream.Client/AbstractEntity.cs
@@ -9,30 +9,35 @@ using Microsoft.Extensions.Logging;
 
 namespace RabbitMQ.Stream.Client
 {
-
     internal enum EntityStatus
     {
         Open,
         Closed,
         Disposed
     }
-    public abstract class AbstractEntity
+
+    public interface IClosable
+    {
+        public Task<ResponseCode> Close(bool ignoreIfClosed = false);
+    }
+
+    public abstract class AbstractEntity : IClosable
     {
         private readonly CancellationTokenSource _cancelTokenSource = new();
         protected CancellationToken Token => _cancelTokenSource.Token;
 
         internal EntityStatus _status = EntityStatus.Closed;
+
         // here the _cancelTokenSource is disposed and the token is cancelled
         // in producer is used to cancel the send task
         // in consumer is used to cancel the receive task
         protected void MaybeCancelToken()
         {
-
             if (!_cancelTokenSource.IsCancellationRequested)
                 _cancelTokenSource.Cancel();
         }
 
-        public abstract Task<ResponseCode> Close();
+        public abstract Task<ResponseCode> Close(bool ignoreIfClosed = false);
 
         protected void Dispose(bool disposing, string entityInfo, ILogger logger)
         {
@@ -70,6 +75,5 @@ namespace RabbitMQ.Stream.Client
         }
 
         internal Client _client;
-
     }
 }

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -560,7 +560,6 @@ namespace RabbitMQ.Stream.Client
                     break;
                 case MetaDataUpdate.Key:
                     MetaDataUpdate.Read(frame, out var metaDataUpdate);
-                    // Parameters.MetadataHandler(metaDataUpdate);
                     Parameters.FireMetadataUpdate(metaDataUpdate);
                     break;
                 case TuneResponse.Key:

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -7,10 +7,9 @@ using System.Threading.Tasks;
 
 namespace RabbitMQ.Stream.Client;
 
-public interface IConsumer
+public interface IConsumer : IClosable
 {
     public Task StoreOffset(ulong offset);
-    public Task<ResponseCode> Close();
     public void Dispose();
 
     public ConsumerInfo Info { get; }

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -15,11 +15,9 @@ public interface IConsumer : IClosable
     public ConsumerInfo Info { get; }
 }
 
-public record IConsumerConfig : INamedEntity
+public record IConsumerConfig : EntityCommonConfig, INamedEntity
 {
     private ushort _initialCredits = Consts.ConsumerInitialCredits;
-
-    internal ConnectionsPool Pool { get; set; }
 
     // StoredOffsetSpec configuration it is needed to keep the offset spec.
     // since the offset can be decided from the ConsumerConfig.OffsetSpec.

--- a/RabbitMQ.Stream.Client/IProducer.cs
+++ b/RabbitMQ.Stream.Client/IProducer.cs
@@ -15,7 +15,7 @@ namespace RabbitMQ.Stream.Client;
 // - Super-Stream producer
 // </summary>
 
-public interface IProducer
+public interface IProducer : IClosable
 {
     /// <summary>
     /// Send the message to the stream in asynchronous mode.
@@ -48,8 +48,6 @@ public interface IProducer
     /// <param name="compressionType"> Type of compression. By default the client supports GZIP and none</param>
     /// <returns></returns>
     public ValueTask Send(ulong publishingId, List<Message> subEntryMessages, CompressionType compressionType);
-
-    public Task<ResponseCode> Close();
 
     /// <summary>
     /// Return the last publishing id.

--- a/RabbitMQ.Stream.Client/IProducer.cs
+++ b/RabbitMQ.Stream.Client/IProducer.cs
@@ -81,10 +81,8 @@ public record ProducerFilter
     public Func<Message, string> FilterValue { get; set; } = null;
 }
 
-public record IProducerConfig : INamedEntity
+public record IProducerConfig : EntityCommonConfig, INamedEntity
 {
-
-    internal ConnectionsPool Pool { get; set; }
 
     public string Reference { get; set; }
     public int MaxInFlight { get; set; } = 1_000;

--- a/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
@@ -188,7 +188,6 @@ RabbitMQ.Stream.Client.Client.StoreOffset(string reference, string stream, ulong
 RabbitMQ.Stream.Client.Client.StreamExists(string stream) -> System.Threading.Tasks.Task<bool>
 RabbitMQ.Stream.Client.Client.Subscribe(RabbitMQ.Stream.Client.RawConsumerConfig config, ushort initialCredit, System.Collections.Generic.Dictionary<string, string> properties, System.Func<RabbitMQ.Stream.Client.Deliver, System.Threading.Tasks.Task> deliverHandler, System.Func<bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>> consumerUpdateHandler) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.SubscribeResponse)>
 RabbitMQ.Stream.Client.Client.Subscribe(string stream, RabbitMQ.Stream.Client.IOffsetType offsetType, ushort initialCredit, System.Collections.Generic.Dictionary<string, string> properties, System.Func<RabbitMQ.Stream.Client.Deliver, System.Threading.Tasks.Task> deliverHandler, System.Func<bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>> consumerUpdateHandler = null) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.SubscribeResponse)>
-RabbitMQ.Stream.Client.Client.Unsubscribe(byte subscriptionId) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.UnsubscribeResponse>
 RabbitMQ.Stream.Client.ClientParameters
 RabbitMQ.Stream.Client.ClientParameters.AddressResolver.get -> RabbitMQ.Stream.Client.AddressResolver
 RabbitMQ.Stream.Client.ClientParameters.AddressResolver.set -> void
@@ -198,8 +197,6 @@ RabbitMQ.Stream.Client.ClientParameters.Endpoint.get -> System.Net.EndPoint
 RabbitMQ.Stream.Client.ClientParameters.Endpoint.set -> void
 RabbitMQ.Stream.Client.ClientParameters.Heartbeat.get -> System.TimeSpan
 RabbitMQ.Stream.Client.ClientParameters.Heartbeat.set -> void
-RabbitMQ.Stream.Client.ClientParameters.MetadataHandler.get -> System.Action<RabbitMQ.Stream.Client.MetaDataUpdate>
-RabbitMQ.Stream.Client.ClientParameters.MetadataHandler.set -> void
 RabbitMQ.Stream.Client.ClientParameters.Password.get -> string
 RabbitMQ.Stream.Client.ClientParameters.Password.set -> void
 RabbitMQ.Stream.Client.ClientParameters.Properties.get -> System.Collections.Generic.IDictionary<string, string>

--- a/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
@@ -335,7 +335,6 @@ RabbitMQ.Stream.Client.ICompressionCodec.UnCompress(System.Buffers.ReadOnlySeque
 RabbitMQ.Stream.Client.ICompressionCodec.UnCompressedSize.get -> int
 RabbitMQ.Stream.Client.ICompressionCodec.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.IConsumer
-RabbitMQ.Stream.Client.IConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.IConsumer.Dispose() -> void
 RabbitMQ.Stream.Client.IConsumer.StoreOffset(ulong offset) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.IConsumerConfig
@@ -357,7 +356,6 @@ RabbitMQ.Stream.Client.IOffsetType.OffsetType.get -> RabbitMQ.Stream.Client.Offs
 RabbitMQ.Stream.Client.IOffsetType.Size.get -> int
 RabbitMQ.Stream.Client.IOffsetType.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.IProducer
-RabbitMQ.Stream.Client.IProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.IProducer.ConfirmFrames.get -> int
 RabbitMQ.Stream.Client.IProducer.Dispose() -> void
 RabbitMQ.Stream.Client.IProducer.GetLastPublishingId() -> System.Threading.Tasks.Task<ulong>
@@ -559,7 +557,6 @@ RabbitMQ.Stream.Client.RawProducerConfig.MetadataHandler.set -> void
 RabbitMQ.Stream.Client.RawProducerConfig.RawProducerConfig(string stream) -> void
 RabbitMQ.Stream.Client.RawProducerConfig.Stream.get -> string
 RabbitMQ.Stream.Client.RawSuperStreamConsumer
-RabbitMQ.Stream.Client.RawSuperStreamConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamConsumer.Dispose() -> void
 RabbitMQ.Stream.Client.RawSuperStreamConsumer.StoreOffset(ulong offset) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig
@@ -570,7 +567,6 @@ RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig.OffsetSpec.set -> void
 RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig.RawSuperStreamConsumerConfig(string superStream) -> void
 RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig.SuperStream.get -> string
 RabbitMQ.Stream.Client.RawSuperStreamProducer
-RabbitMQ.Stream.Client.RawSuperStreamProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamProducer.ConfirmFrames.get -> int
 RabbitMQ.Stream.Client.RawSuperStreamProducer.Dispose() -> void
 RabbitMQ.Stream.Client.RawSuperStreamProducer.GetLastPublishingId() -> System.Threading.Tasks.Task<ulong>

--- a/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
@@ -169,7 +169,6 @@ RabbitMQ.Stream.Client.Client.ConnectionCloseHandler
 RabbitMQ.Stream.Client.Client.ConnectionProperties.get -> System.Collections.Generic.IDictionary<string, string>
 RabbitMQ.Stream.Client.Client.CreateStream(string stream, System.Collections.Generic.IDictionary<string, string> args) -> System.Threading.Tasks.ValueTask<RabbitMQ.Stream.Client.CreateResponse>
 RabbitMQ.Stream.Client.Client.Credit(byte subscriptionId, ushort credit) -> System.Threading.Tasks.ValueTask<bool>
-RabbitMQ.Stream.Client.Client.DeletePublisher(byte publisherId) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.DeletePublisherResponse>
 RabbitMQ.Stream.Client.Client.DeleteStream(string stream) -> System.Threading.Tasks.ValueTask<RabbitMQ.Stream.Client.DeleteResponse>
 RabbitMQ.Stream.Client.Client.IncomingFrames.get -> int
 RabbitMQ.Stream.Client.Client.IsClosed.get -> bool

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -1,12 +1,19 @@
-abstract RabbitMQ.Stream.Client.AbstractEntity.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+abstract RabbitMQ.Stream.Client.AbstractEntity.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+abstract RabbitMQ.Stream.Client.AbstractEntity.DeleteEntityFromTheServer(bool ignoreIfAlreadyDeleted = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+abstract RabbitMQ.Stream.Client.AbstractEntity.DumpEntityConfiguration() -> string
+abstract RabbitMQ.Stream.Client.AbstractEntity.GetStream() -> string
 const RabbitMQ.Stream.Client.RouteQueryResponse.Key = 24 -> ushort
 const RabbitMQ.Stream.Client.StreamStatsResponse.Key = 28 -> ushort
 override RabbitMQ.Stream.Client.Broker.ToString() -> string
-override RabbitMQ.Stream.Client.RawConsumer.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
-override RabbitMQ.Stream.Client.RawProducer.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
-RabbitMQ.Stream.Client.AbstractEntity.Dispose(bool disposing, string entityInfo, Microsoft.Extensions.Logging.ILogger logger) -> void
+override RabbitMQ.Stream.Client.RawConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+override RabbitMQ.Stream.Client.RawProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+RabbitMQ.Stream.Client.AbstractEntity.Dispose(bool disposing) -> void
+RabbitMQ.Stream.Client.AbstractEntity.EntityId.get -> byte
+RabbitMQ.Stream.Client.AbstractEntity.EntityId.set -> void
 RabbitMQ.Stream.Client.AbstractEntity.IsOpen() -> bool
-RabbitMQ.Stream.Client.AbstractEntity.MaybeCancelToken() -> void
+RabbitMQ.Stream.Client.AbstractEntity.Logger.get -> Microsoft.Extensions.Logging.ILogger
+RabbitMQ.Stream.Client.AbstractEntity.Logger.init -> void
+RabbitMQ.Stream.Client.AbstractEntity.Shutdown(RabbitMQ.Stream.Client.EntityCommonConfig config, bool ignoreIfAlreadyDeleted = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.AbstractEntity.Token.get -> System.Threading.CancellationToken
 RabbitMQ.Stream.Client.AuthMechanism
 RabbitMQ.Stream.Client.AuthMechanism.External = 1 -> RabbitMQ.Stream.Client.AuthMechanism
@@ -19,6 +26,7 @@ RabbitMQ.Stream.Client.Chunk.MagicVersion.get -> byte
 RabbitMQ.Stream.Client.Client.ClientId.get -> string
 RabbitMQ.Stream.Client.Client.ClientId.init -> void
 RabbitMQ.Stream.Client.Client.DeclarePublisher(string publisherRef, string stream, System.Action<System.ReadOnlyMemory<ulong>> confirmCallback, System.Action<(ulong, RabbitMQ.Stream.Client.ResponseCode)[]> errorCallback, RabbitMQ.Stream.Client.ConnectionsPool pool = null) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.DeclarePublisherResponse)>
+RabbitMQ.Stream.Client.Client.DeletePublisher(byte publisherId, bool ignoreIfAlreadyRemoved = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.DeletePublisherResponse>
 RabbitMQ.Stream.Client.Client.ExchangeVersions() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.CommandVersionsResponse>
 RabbitMQ.Stream.Client.Client.QueryRoute(string superStream, string routingKey) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.RouteQueryResponse>
 RabbitMQ.Stream.Client.Client.StreamStats(string stream) -> System.Threading.Tasks.ValueTask<RabbitMQ.Stream.Client.StreamStatsResponse>
@@ -63,11 +71,12 @@ RabbitMQ.Stream.Client.ConsumerInfo.ConsumerInfo(string stream, string reference
 RabbitMQ.Stream.Client.ConsumerInfo.Reference.get -> string
 RabbitMQ.Stream.Client.CrcException
 RabbitMQ.Stream.Client.CrcException.CrcException(string s) -> void
+RabbitMQ.Stream.Client.EntityCommonConfig
 RabbitMQ.Stream.Client.HashRoutingMurmurStrategy.Route(RabbitMQ.Stream.Client.Message message, System.Collections.Generic.List<string> partitions) -> System.Threading.Tasks.Task<System.Collections.Generic.List<string>>
 RabbitMQ.Stream.Client.IClient.ClientId.get -> string
 RabbitMQ.Stream.Client.IClient.ClientId.init -> void
 RabbitMQ.Stream.Client.IClosable
-RabbitMQ.Stream.Client.IClosable.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+RabbitMQ.Stream.Client.IClosable.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.IConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
 RabbitMQ.Stream.Client.IConsumerConfig.Crc32.get -> RabbitMQ.Stream.Client.ICrc32
 RabbitMQ.Stream.Client.IConsumerConfig.Crc32.set -> void
@@ -128,9 +137,9 @@ RabbitMQ.Stream.Client.PublishFilter.SizeNeeded.get -> int
 RabbitMQ.Stream.Client.PublishFilter.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.RawConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
 RabbitMQ.Stream.Client.RawProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
-RabbitMQ.Stream.Client.RawSuperStreamConsumer.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+RabbitMQ.Stream.Client.RawSuperStreamConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
-RabbitMQ.Stream.Client.RawSuperStreamProducer.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+RabbitMQ.Stream.Client.RawSuperStreamProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.get -> RabbitMQ.Stream.Client.RoutingStrategyType
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.set -> void

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -24,6 +24,8 @@ RabbitMQ.Stream.Client.Client.QueryRoute(string superStream, string routingKey) 
 RabbitMQ.Stream.Client.Client.StreamStats(string stream) -> System.Threading.Tasks.ValueTask<RabbitMQ.Stream.Client.StreamStatsResponse>
 RabbitMQ.Stream.Client.ClientParameters.AuthMechanism.get -> RabbitMQ.Stream.Client.AuthMechanism
 RabbitMQ.Stream.Client.ClientParameters.AuthMechanism.set -> void
+RabbitMQ.Stream.Client.ClientParameters.MetadataUpdateHandler
+RabbitMQ.Stream.Client.ClientParameters.OnMetadataUpdate -> RabbitMQ.Stream.Client.ClientParameters.MetadataUpdateHandler
 RabbitMQ.Stream.Client.ConnectionItem
 RabbitMQ.Stream.Client.ConnectionItem.Available.get -> bool
 RabbitMQ.Stream.Client.ConnectionItem.BrokerInfo.get -> string
@@ -63,6 +65,7 @@ RabbitMQ.Stream.Client.CrcException.CrcException(string s) -> void
 RabbitMQ.Stream.Client.HashRoutingMurmurStrategy.Route(RabbitMQ.Stream.Client.Message message, System.Collections.Generic.List<string> partitions) -> System.Threading.Tasks.Task<System.Collections.Generic.List<string>>
 RabbitMQ.Stream.Client.IClient.ClientId.get -> string
 RabbitMQ.Stream.Client.IClient.ClientId.init -> void
+RabbitMQ.Stream.Client.IConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.IConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
 RabbitMQ.Stream.Client.IConsumerConfig.Crc32.get -> RabbitMQ.Stream.Client.ICrc32
 RabbitMQ.Stream.Client.IConsumerConfig.Crc32.set -> void
@@ -96,6 +99,7 @@ RabbitMQ.Stream.Client.ICrc32.Hash(byte[] data) -> byte[]
 RabbitMQ.Stream.Client.Info
 RabbitMQ.Stream.Client.Info.Info(string stream) -> void
 RabbitMQ.Stream.Client.Info.Stream.get -> string
+RabbitMQ.Stream.Client.IProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.IProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
 RabbitMQ.Stream.Client.IProducerConfig.Filter.get -> RabbitMQ.Stream.Client.ProducerFilter
 RabbitMQ.Stream.Client.IProducerConfig.Filter.set -> void
@@ -123,7 +127,9 @@ RabbitMQ.Stream.Client.PublishFilter.SizeNeeded.get -> int
 RabbitMQ.Stream.Client.PublishFilter.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.RawConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
 RabbitMQ.Stream.Client.RawProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
+RabbitMQ.Stream.Client.RawSuperStreamConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
+RabbitMQ.Stream.Client.RawSuperStreamProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.get -> RabbitMQ.Stream.Client.RoutingStrategyType
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.set -> void

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
-abstract RabbitMQ.Stream.Client.AbstractEntity.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+abstract RabbitMQ.Stream.Client.AbstractEntity.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 const RabbitMQ.Stream.Client.RouteQueryResponse.Key = 24 -> ushort
 const RabbitMQ.Stream.Client.StreamStatsResponse.Key = 28 -> ushort
 override RabbitMQ.Stream.Client.Broker.ToString() -> string
-override RabbitMQ.Stream.Client.RawConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
-override RabbitMQ.Stream.Client.RawProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+override RabbitMQ.Stream.Client.RawConsumer.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+override RabbitMQ.Stream.Client.RawProducer.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.AbstractEntity.Dispose(bool disposing, string entityInfo, Microsoft.Extensions.Logging.ILogger logger) -> void
 RabbitMQ.Stream.Client.AbstractEntity.IsOpen() -> bool
 RabbitMQ.Stream.Client.AbstractEntity.MaybeCancelToken() -> void
@@ -22,6 +22,7 @@ RabbitMQ.Stream.Client.Client.DeclarePublisher(string publisherRef, string strea
 RabbitMQ.Stream.Client.Client.ExchangeVersions() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.CommandVersionsResponse>
 RabbitMQ.Stream.Client.Client.QueryRoute(string superStream, string routingKey) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.RouteQueryResponse>
 RabbitMQ.Stream.Client.Client.StreamStats(string stream) -> System.Threading.Tasks.ValueTask<RabbitMQ.Stream.Client.StreamStatsResponse>
+RabbitMQ.Stream.Client.Client.Unsubscribe(byte subscriptionId, bool ignoreIfAlreadyRemoved = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.UnsubscribeResponse>
 RabbitMQ.Stream.Client.ClientParameters.AuthMechanism.get -> RabbitMQ.Stream.Client.AuthMechanism
 RabbitMQ.Stream.Client.ClientParameters.AuthMechanism.set -> void
 RabbitMQ.Stream.Client.ClientParameters.MetadataUpdateHandler
@@ -65,7 +66,8 @@ RabbitMQ.Stream.Client.CrcException.CrcException(string s) -> void
 RabbitMQ.Stream.Client.HashRoutingMurmurStrategy.Route(RabbitMQ.Stream.Client.Message message, System.Collections.Generic.List<string> partitions) -> System.Threading.Tasks.Task<System.Collections.Generic.List<string>>
 RabbitMQ.Stream.Client.IClient.ClientId.get -> string
 RabbitMQ.Stream.Client.IClient.ClientId.init -> void
-RabbitMQ.Stream.Client.IConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+RabbitMQ.Stream.Client.IClosable
+RabbitMQ.Stream.Client.IClosable.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.IConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
 RabbitMQ.Stream.Client.IConsumerConfig.Crc32.get -> RabbitMQ.Stream.Client.ICrc32
 RabbitMQ.Stream.Client.IConsumerConfig.Crc32.set -> void
@@ -99,7 +101,6 @@ RabbitMQ.Stream.Client.ICrc32.Hash(byte[] data) -> byte[]
 RabbitMQ.Stream.Client.Info
 RabbitMQ.Stream.Client.Info.Info(string stream) -> void
 RabbitMQ.Stream.Client.Info.Stream.get -> string
-RabbitMQ.Stream.Client.IProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.IProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
 RabbitMQ.Stream.Client.IProducerConfig.Filter.get -> RabbitMQ.Stream.Client.ProducerFilter
 RabbitMQ.Stream.Client.IProducerConfig.Filter.set -> void
@@ -127,9 +128,9 @@ RabbitMQ.Stream.Client.PublishFilter.SizeNeeded.get -> int
 RabbitMQ.Stream.Client.PublishFilter.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.RawConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
 RabbitMQ.Stream.Client.RawProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
-RabbitMQ.Stream.Client.RawSuperStreamConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+RabbitMQ.Stream.Client.RawSuperStreamConsumer.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
-RabbitMQ.Stream.Client.RawSuperStreamProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+RabbitMQ.Stream.Client.RawSuperStreamProducer.Close(bool ignoreIfClosed = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.get -> RabbitMQ.Stream.Client.RoutingStrategyType
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.set -> void

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -116,8 +116,7 @@ namespace RabbitMQ.Stream.Client
     public class RawConsumer : AbstractEntity, IConsumer, IDisposable
     {
         private readonly RawConsumerConfig _config;
-        private byte _subscriberId;
-        private readonly ILogger _logger;
+
         private readonly Channel<Chunk> _chunksBuffer;
         private readonly ushort _initialCredits;
 
@@ -127,13 +126,13 @@ namespace RabbitMQ.Stream.Client
         // assigned. 
         private readonly TaskCompletionSource _completeSubscription = new();
 
-        private string ConsumerInfo()
+        protected sealed override string DumpEntityConfiguration()
         {
             var superStream = string.IsNullOrEmpty(_config.SuperStream)
                 ? "No SuperStream"
                 : $"SuperStream {_config.SuperStream}";
             return
-                $"Consumer id {_subscriberId} for stream: {_config.Stream}, reference: {_config.Reference}, OffsetSpec {_config.OffsetSpec} " +
+                $"Consumer id {EntityId} for stream: {_config.Stream}, reference: {_config.Reference}, OffsetSpec {_config.OffsetSpec} " +
                 $"Client ProvidedName {_config.ClientProvidedName}, " +
                 $"{superStream}, IsSingleActiveConsumer: {_config.IsSingleActiveConsumer}, " +
                 $"Token IsCancellationRequested: {Token.IsCancellationRequested} ";
@@ -141,10 +140,10 @@ namespace RabbitMQ.Stream.Client
 
         private RawConsumer(Client client, RawConsumerConfig config, ILogger logger = null)
         {
-            _logger = logger ?? NullLogger.Instance;
+            Logger = logger ?? NullLogger.Instance;
             _initialCredits = config.InitialCredits;
             _config = config;
-            _logger.LogDebug("Creating... {ConsumerInfo}", ConsumerInfo());
+            Logger.LogDebug("Creating... {ConsumerInfo}", DumpEntityConfiguration());
             Info = new ConsumerInfo(_config.Stream, _config.Reference);
             // _chunksBuffer is a channel that is used to buffer the chunks
             _chunksBuffer = Channel.CreateBounded<Chunk>(new BoundedChannelOptions(_initialCredits)
@@ -174,6 +173,10 @@ namespace RabbitMQ.Stream.Client
             };
         }
 
+        protected override string GetStream()
+        {
+            return _config.Stream;
+        }
         public async Task StoreOffset(ulong offset)
         {
             await _client.StoreOffset(_config.Reference, _config.Stream, offset).ConfigureAwait(false);
@@ -233,16 +236,16 @@ namespace RabbitMQ.Stream.Client
                     {
                         if (Token.IsCancellationRequested)
                         {
-                            _logger?.LogDebug(
+                            Logger?.LogDebug(
                                 "Error while parsing message {ConsumerInfo}, Cancellation Requested, the consumer is closing. ",
-                                ConsumerInfo());
+                                DumpEntityConfiguration());
                             return null;
                         }
 
-                        _logger?.LogError(e,
-                            "Error while parsing message {ConsumerInfo}.  The message will be skipped. " +
+                        Logger?.LogError(e,
+                            "Error while parsing message {EntityInfo}.  The message will be skipped. " +
                             "Please report this issue to the RabbitMQ team on GitHub {Repo}",
-                            ConsumerInfo(), Consts.RabbitMQClientRepo);
+                            DumpEntityConfiguration(), Consts.RabbitMQClientRepo);
                     }
 
                     return null;
@@ -276,11 +279,11 @@ namespace RabbitMQ.Stream.Client
                                         }
                                         catch (Exception e)
                                         {
-                                            _logger.LogError(e,
+                                            Logger.LogError(e,
                                                 "Error while filtering message. Message  with offset {MessageOffset} won't be dispatched."
                                                 + "Suggestion: review the PostFilter value function"
-                                                + "{ConsumerInfo}",
-                                                message.MessageOffset, ConsumerInfo());
+                                                + "{EntityInfo}",
+                                                message.MessageOffset, DumpEntityConfiguration());
                                             canDispatch = false;
                                         }
                                     }
@@ -295,9 +298,9 @@ namespace RabbitMQ.Stream.Client
                                 }
                                 else
                                 {
-                                    _logger?.LogDebug(
-                                        "{ConsumerInfo} is not active. message won't dispatched",
-                                        ConsumerInfo());
+                                    Logger?.LogDebug(
+                                        "{EntityInfo} is not active. message won't dispatched",
+                                        DumpEntityConfiguration());
                                 }
                             }
                         }
@@ -305,23 +308,23 @@ namespace RabbitMQ.Stream.Client
 
                     catch (OperationCanceledException)
                     {
-                        _logger?.LogWarning(
-                            "OperationCanceledException. {ConsumerInfo} has been closed while consuming messages",
-                            ConsumerInfo());
+                        Logger?.LogWarning(
+                            "OperationCanceledException. {EntityInfo} has been closed while consuming messages",
+                            DumpEntityConfiguration());
                     }
                     catch (Exception e)
                     {
                         if (Token.IsCancellationRequested)
                         {
-                            _logger?.LogDebug(
-                                "Dispatching  {ConsumerInfo}, Cancellation Requested, the consumer is closing. ",
-                                ConsumerInfo());
+                            Logger?.LogDebug(
+                                "Dispatching  {EntityInfo}, Cancellation Requested, the consumer is closing. ",
+                                DumpEntityConfiguration());
                             return;
                         }
 
-                        _logger?.LogError(e,
-                            "Error while Dispatching message, ChunkId : {ChunkId} {ConsumerInfo}",
-                            chunk.ChunkId, ConsumerInfo());
+                        Logger?.LogError(e,
+                            "Error while Dispatching message, ChunkId : {ChunkId} {EntityInfo}",
+                            chunk.ChunkId, DumpEntityConfiguration());
                     }
                 }
 
@@ -377,9 +380,9 @@ namespace RabbitMQ.Stream.Client
             }
             catch (Exception e)
             {
-                _logger?.LogError(e,
-                    "Error while parsing chunk, ChunkId : {ChunkId} {ConsumerInfo}",
-                    chunk.ChunkId, ConsumerInfo());
+                Logger?.LogError(e,
+                    "Error while parsing chunk, ChunkId : {ChunkId} {EntityInfo}",
+                    chunk.ChunkId, DumpEntityConfiguration());
             }
         }
 
@@ -402,7 +405,7 @@ namespace RabbitMQ.Stream.Client
                             // we request the credit before process the check to keep the network busy
                             try
                             {
-                                await _client.Credit(_subscriberId, 1).ConfigureAwait(false);
+                                await _client.Credit(EntityId, 1).ConfigureAwait(false);
                             }
                             catch (InvalidOperationException)
                             {
@@ -413,9 +416,9 @@ namespace RabbitMQ.Stream.Client
                                 // The client will throw an InvalidOperationException
                                 // since the connection is closed
                                 // In this case we don't want to log the error to avoid log noise
-                                _logger?.LogDebug(
-                                    "Can't send the credit {ConsumerInfo}: The TCP client has been closed",
-                                    ConsumerInfo());
+                                Logger?.LogDebug(
+                                    "Can't send the credit {EntityInfo}: The TCP client has been closed",
+                                    DumpEntityConfiguration());
                                 break;
                             }
 
@@ -431,9 +434,9 @@ namespace RabbitMQ.Stream.Client
                         }
                     }
 
-                    _logger?.LogDebug(
-                        "The ProcessChunks {ConsumerInfo} task has been closed normally",
-                        ConsumerInfo());
+                    Logger?.LogDebug(
+                        "The ProcessChunks {EntityInfo} task has been closed normally",
+                        DumpEntityConfiguration());
                 }
                 catch (Exception e)
                 {
@@ -442,15 +445,15 @@ namespace RabbitMQ.Stream.Client
                     // In this case we don't want to log the error
                     if (Token.IsCancellationRequested)
                     {
-                        _logger?.LogDebug(
-                            "The ProcessChunks task for the stream: {ConsumerInfo}  has been closed due to cancellation",
-                            ConsumerInfo());
+                        Logger?.LogDebug(
+                            "The ProcessChunks task for the stream: {EntityInfo}  has been closed due to cancellation",
+                            DumpEntityConfiguration());
                         return;
                     }
 
-                    _logger?.LogError(e,
-                        "Error while process chunks the stream: {ConsumerInfo} The ProcessChunks task will be closed",
-                        ConsumerInfo());
+                    Logger?.LogError(e,
+                        "Error while process chunks the stream: {EntityInfo} The ProcessChunks task will be closed",
+                        DumpEntityConfiguration());
                 }
             }, Token);
         }
@@ -494,7 +497,7 @@ namespace RabbitMQ.Stream.Client
             var chunkConsumed = 0;
             // this the default value for the consumer.
             _config.StoredOffsetSpec = _config.OffsetSpec;
-            (_subscriberId, var response) = await _client.Subscribe(
+            (EntityId, var response) = await _client.Subscribe(
                 _config,
                 _initialCredits,
                 consumerProperties,
@@ -509,10 +512,10 @@ namespace RabbitMQ.Stream.Client
                     {
                         // the consumer is closing from the user but some chunks are still in the buffer
                         // simply skip the chunk
-                        _logger?.LogTrace(
-                            "CancellationToken requested. The {ConsumerInfo} " +
+                        Logger?.LogTrace(
+                            "CancellationToken requested. The {EntityInfo} " +
                             "The chunk won't be processed",
-                            ConsumerInfo());
+                            DumpEntityConfiguration());
                         return;
                     }
 
@@ -523,13 +526,13 @@ namespace RabbitMQ.Stream.Client
                         );
                         if (crcCalculated != deliver.Chunk.Crc)
                         {
-                            _logger?.LogError(
-                                "CRC32 does not match, server crc: {Crc}, local crc: {CrcCalculated}, {ConsumerInfo}, " +
-                                "Chunk Consumed {ChunkConsumed}", deliver.Chunk.Crc, crcCalculated, ConsumerInfo(),
+                            Logger?.LogError(
+                                "CRC32 does not match, server crc: {Crc}, local crc: {CrcCalculated}, {EntityInfo}, " +
+                                "Chunk Consumed {ChunkConsumed}", deliver.Chunk.Crc, crcCalculated, DumpEntityConfiguration(),
                                 chunkConsumed);
 
                             throw new CrcException(
-                                $"CRC32 does not match, server crc: {deliver.Chunk.Crc}, local crc: {crcCalculated}, {ConsumerInfo()}, " +
+                                $"CRC32 does not match, server crc: {deliver.Chunk.Crc}, local crc: {crcCalculated}, {DumpEntityConfiguration()}, " +
                                 $"Chunk Consumed {chunkConsumed}");
                         }
                     }
@@ -550,10 +553,10 @@ namespace RabbitMQ.Stream.Client
                     // Here we set the promotion status
                     // important for the dispatcher messages 
                     IsPromotedAsActive = promotedAsActive;
-                    _logger?.LogDebug(
+                    Logger?.LogDebug(
                         "The consumer active status is: {IsActive} for {ConsumeInfo}",
                         IsPromotedAsActive,
-                        ConsumerInfo());
+                        DumpEntityConfiguration());
                     return _config.StoredOffsetSpec;
                 }
             ).ConfigureAwait(false);
@@ -580,8 +583,7 @@ namespace RabbitMQ.Stream.Client
                 // we call the Close to re-enter to the standard behavior
                 // ignoreIfClosed is an optimization to avoid to send the unsubscribe
                 _config.MetadataHandler?.Invoke(metaDataUpdate);
-                Close(true).ConfigureAwait(false);
-
+                Shutdown(_config, true).ConfigureAwait(false);
                 // remove the event since the consumer is closed
                 // only if the stream is the valid
                 _client.Parameters.OnMetadataUpdate -= OnMetadataUpdate();
@@ -591,7 +593,7 @@ namespace RabbitMQ.Stream.Client
             async reason =>
             {
                 _config.Pool.Remove(_client.ClientId);
-                await Close(true).ConfigureAwait(false);
+                await Shutdown(_config, true).ConfigureAwait(false);
                 if (_config.ConnectionClosedHandler != null)
                 {
                     await _config.ConnectionClosedHandler(reason).ConfigureAwait(false);
@@ -601,55 +603,44 @@ namespace RabbitMQ.Stream.Client
                 _client.ConnectionClosed -= OnConnectionClosed();
             };
 
-        public override async Task<ResponseCode> Close(bool ignoreIfClosed = false)
+        protected override async Task<ResponseCode> DeleteEntityFromTheServer(bool ignoreIfAlreadyDeleted = false)
         {
-            // this unlock the consumer if it is waiting for a message
-            // see DispatchMessage method where the token is used
-            MaybeCancelToken();
-            if (!IsOpen())
-            {
-                return ResponseCode.Ok;
-            }
-
-            _status = EntityStatus.Closed;
-
-            var result = ResponseCode.Ok;
-
             try
             {
                 var unsubscribeResponse =
-                    await _client.Unsubscribe(_subscriberId, ignoreIfClosed).ConfigureAwait(false);
-                result = unsubscribeResponse.ResponseCode;
+                    await _client.Unsubscribe(EntityId, ignoreIfAlreadyDeleted).ConfigureAwait(false);
+                return unsubscribeResponse.ResponseCode;
             }
 
             catch (TimeoutException)
             {
-                _logger.LogError(
-                    "Timeout removing the consumer id: {SubscriberId}, {ConsumerInfo} from the server. " +
+                Logger.LogError(
+                    "Timeout removing the consumer id: {SubscriberId}, {EntityInfo} from the server. " +
                     "The consumer will be closed anyway",
-                    _subscriberId, ConsumerInfo());
+                    EntityId, DumpEntityConfiguration());
             }
 
             catch (Exception e)
             {
-                _logger.LogError(e,
-                    "Error removing {ConsumerInfo} from the server",
-                    ConsumerInfo());
+                Logger.LogError(e,
+                    "Error removing {EntityInfo} from the server",
+                    DumpEntityConfiguration());
             }
 
-            var closed = await _client.MaybeClose($"_client-close-subscriber: {_subscriberId}",
-                    _config.Stream, _config.Pool)
-                .ConfigureAwait(false);
-            ClientExceptions.MaybeThrowException(closed.ResponseCode, $"_client-close-subscriber: {_subscriberId}");
-            _logger.LogDebug("{ConsumerInfo} is closed", ConsumerInfo());
-            return result;
+            return ResponseCode.Ok;
+
+        }
+
+        public override async Task<ResponseCode> Close()
+        {
+            return await Shutdown(_config).ConfigureAwait(false);
         }
 
         public void Dispose()
         {
             try
             {
-                Dispose(true, ConsumerInfo(), _logger);
+                Dispose(true);
             }
             finally
             {

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -48,7 +48,7 @@ namespace RabbitMQ.Stream.Client
 
         internal void Validate()
         {
-            if (Filter is { FilterValue: not null } && !AvailableFeaturesSingleton.Instance.PublishFilter)
+            if (Filter is {FilterValue: not null} && !AvailableFeaturesSingleton.Instance.PublishFilter)
             {
                 throw new UnsupportedOperationException(Consts.FilterNotSupported);
             }
@@ -141,9 +141,7 @@ namespace RabbitMQ.Stream.Client
                         {
                             _config.ConfirmHandler(new Confirmation
                             {
-                                PublishingId = id,
-                                Code = ResponseCode.Ok,
-                                Stream = _config.Stream
+                                PublishingId = id, Code = ResponseCode.Ok, Stream = _config.Stream
                             });
                         }
                         catch (Exception e)
@@ -163,7 +161,7 @@ namespace RabbitMQ.Stream.Client
                 {
                     foreach (var (id, code) in errors)
                     {
-                        _config.ConfirmHandler(new Confirmation { PublishingId = id, Code = code, });
+                        _config.ConfirmHandler(new Confirmation {PublishingId = id, Code = code,});
                     }
 
                     _semaphore.Release(errors.Length);
@@ -178,7 +176,7 @@ namespace RabbitMQ.Stream.Client
             throw new CreateProducerException($"producer could not be created code: {response.ResponseCode}");
         }
 
-        private bool IsFilteringEnabled => _config.Filter is { FilterValue: not null };
+        private bool IsFilteringEnabled => _config.Filter is {FilterValue: not null};
 
         /// <summary>
         /// SubEntry Batch send: Aggregate more messages under the same publishingId.
@@ -358,6 +356,8 @@ namespace RabbitMQ.Stream.Client
 
             _status = EntityStatus.Closed;
             var result = ResponseCode.Ok;
+
+
             try
             {
                 // The  default timeout is usually 10 seconds 

--- a/RabbitMQ.Stream.Client/RawSuperStreamConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamConsumer.cs
@@ -112,8 +112,7 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
                 Thread.Sleep(500);
 
                 _streamInfos.Remove(update.Stream);
-                _consumers.TryRemove(update.Stream, out var consumerMetadata);
-                consumerMetadata?.Close();
+                _consumers.TryRemove(update.Stream, out _);
 
                 // this check is needed only for an edge case 
                 // when the system is closed and the connections for the steam are still open for
@@ -197,7 +196,7 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
         throw new NotImplementedException("use the store offset on the stream consumer, instead");
     }
 
-    public Task<ResponseCode> Close()
+    public Task<ResponseCode> Close(bool ignoreIfClosed = false)
     {
         if (_disposed)
         {

--- a/RabbitMQ.Stream.Client/RawSuperStreamConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamConsumer.cs
@@ -196,7 +196,7 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
         throw new NotImplementedException("use the store offset on the stream consumer, instead");
     }
 
-    public Task<ResponseCode> Close(bool ignoreIfClosed = false)
+    public Task<ResponseCode> Close()
     {
         if (_disposed)
         {

--- a/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
@@ -119,7 +119,6 @@ public class RawSuperStreamProducer : IProducer, IDisposable
                 }
 
                 _producers.TryRemove(update.Stream, out var producer);
-                producer?.Close();
             },
             ClientProvidedName = _config.ClientProvidedName,
             BatchSize = _config.BatchSize,
@@ -230,7 +229,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
         }
     }
 
-    public Task<ResponseCode> Close()
+    public Task<ResponseCode> Close(bool ignoreIfClosed = false)
     {
         if (_disposed)
         {

--- a/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
@@ -229,7 +229,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
         }
     }
 
-    public Task<ResponseCode> Close(bool ignoreIfClosed = false)
+    public Task<ResponseCode> Close()
     {
         if (_disposed)
         {

--- a/RabbitMQ.Stream.Client/RoutingClient.cs
+++ b/RabbitMQ.Stream.Client/RoutingClient.cs
@@ -170,9 +170,10 @@ namespace RabbitMQ.Stream.Client
         {
             var brokers = new List<Broker>() { metaDataInfo.Leader };
             brokers.AddRange(metaDataInfo.Replicas);
-            brokers.Sort((_, _) => Random.Shared.Next(-1, 1));
+            // brokers.Sort((_, _) => Random.Shared.Next(-1, 1));
+            var br = brokers.OrderBy(x => Random.Shared.Next()).ToList();
             var exceptions = new List<Exception>();
-            foreach (var broker in brokers)
+            foreach (var broker in br)
             {
                 try
                 {

--- a/Tests/ClientTests.cs
+++ b/Tests/ClientTests.cs
@@ -77,7 +77,12 @@ namespace Tests
         {
             var stream = Guid.NewGuid().ToString();
             var testPassed = new TaskCompletionSource<MetaDataUpdate>();
-            var clientParameters = new ClientParameters { MetadataHandler = m => testPassed.SetResult(m) };
+            var clientParameters = new ClientParameters();
+            clientParameters.OnMetadataUpdate += (update) =>
+            {
+                testPassed.SetResult(update);
+            };
+
             var client = await Client.Create(clientParameters);
             await client.CreateStream(stream, new Dictionary<string, string>());
             Action<ReadOnlyMemory<ulong>> confirmed = (pubIds) => { };


### PR DESCRIPTION
With this PR https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/pull/328 the client can handle multi-producers and consumers per connection.

This PR removes [`MetadataHandler`](https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/pull/332/files#diff-71215640c5968601ad0a124946241692beb3c931cc450bb43bb7061e8f84c47eL56)  and introduces [`OnMetadataUpdate`](https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/pull/332/files#diff-71215640c5968601ad0a124946241692beb3c931cc450bb43bb7061e8f84c47eR58
) event.

The event can handle multiple Metadata updates coming from the server. Metadata update is raised when a stream is deleted, or a replica is removed. 

The server automatically removes the producers and consumers linked to the connection, here we need to remove these entities from the internal pool to be consistent. 

How to test
---
- You need a cluster 
- Use `RawProducer` and `RawConsumer` bind to one or more streams. Delete the streams and the client has to remove all the connections 
- Use `Producer` and `Consumer` in a cluster remove a replica the `Producer` and `Consumer` should reconnect and continue to work 


Refactor
---

Refactor `RawConsumer` and `RawProducer` in [this commit](https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/pull/332/commits/c5847829ce6d8491fd5f239e016a54376b03818c). Remove duplication code. Move the common code to the `AbstractEntity` Class



