### PR TITLE
Improve the rawProducer and rawSuperStreamProducer status

### DIFF
--- a/RabbitMQ.Stream.Client/AbstractEntity.cs
+++ b/RabbitMQ.Stream.Client/AbstractEntity.cs
@@ -38,6 +38,14 @@ namespace RabbitMQ.Stream.Client
         protected abstract string GetStream();
         protected abstract string DumpEntityConfiguration();
 
+        protected void ThrowIfClosed()
+        {
+            if (!IsOpen())
+            {
+                throw new AlreadyClosedException($"{DumpEntityConfiguration()} is closed.");
+            }
+        }
+
         // here the _cancelTokenSource is disposed and the token is cancelled
         // in producer is used to cancel the send task
         // in consumer is used to cancel the receive task

--- a/RabbitMQ.Stream.Client/ClientExceptions.cs
+++ b/RabbitMQ.Stream.Client/ClientExceptions.cs
@@ -21,7 +21,7 @@ namespace RabbitMQ.Stream.Client
         ///   Client is trying to connect in a not ready endpoint.
         ///   It is usually a temporary situation.
         /// -  TimeoutException
-        ///    Some call went in timeout. Maybe a temporary DNS problem.
+        ///    Network call timed out. It is often a temporary situation and we should retry.
         ///    In this case we can try to reconnect.
         ///
         ///  For the other kind of exception, we just throw back the exception.

--- a/RabbitMQ.Stream.Client/ClientExceptions.cs
+++ b/RabbitMQ.Stream.Client/ClientExceptions.cs
@@ -3,11 +3,42 @@
 // Copyright (c) 2007-2023 VMware, Inc.
 
 using System;
+using System.Linq;
+using System.Net.Sockets;
 
 namespace RabbitMQ.Stream.Client
 {
     internal static class ClientExceptions
     {
+
+        // <summary>
+        /// IsAKnownException returns true if the exception is a known exception
+        /// We need it to reconnect when the producer/consumer.
+        /// - LeaderNotFoundException is a temporary exception
+        ///   It means that the leader is not available and the client can't reconnect.
+        ///   Especially the Producer that needs to know the leader.
+        /// - SocketException
+        ///   Client is trying to connect in a not ready endpoint.
+        ///   It is usually a temporary situation.
+        /// -  TimeoutException
+        ///    Some call went in timeout. Maybe a temporary DNS problem.
+        ///    In this case we can try to reconnect.
+        ///
+        ///  For the other kind of exception, we just throw back the exception.
+        //</summary>
+        internal static bool IsAKnownException(Exception exception)
+        {
+            if (exception is AggregateException aggregateException)
+            {
+                var x = aggregateException.InnerExceptions.Select(x =>
+                    x.GetType() == typeof(SocketException) || x.GetType() == typeof(TimeoutException) ||
+                    x.GetType() == typeof(LeaderNotFoundException));
+                return x.Any();
+            }
+
+            return exception is (SocketException or TimeoutException or LeaderNotFoundException);
+        }
+
         public static void MaybeThrowException(ResponseCode responseCode, string message)
         {
             if (responseCode is ResponseCode.Ok)
@@ -24,6 +55,14 @@ namespace RabbitMQ.Stream.Client
                 //TODO Implement for all the response code
                 _ => new GenericProtocolException(responseCode, message)
             };
+        }
+    }
+
+    public class AlreadyClosedException : Exception
+    {
+        public AlreadyClosedException(string s)
+            : base(s)
+        {
         }
     }
 

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -14,7 +14,10 @@ RabbitMQ.Stream.Client.AbstractEntity.IsOpen() -> bool
 RabbitMQ.Stream.Client.AbstractEntity.Logger.get -> Microsoft.Extensions.Logging.ILogger
 RabbitMQ.Stream.Client.AbstractEntity.Logger.init -> void
 RabbitMQ.Stream.Client.AbstractEntity.Shutdown(RabbitMQ.Stream.Client.EntityCommonConfig config, bool ignoreIfAlreadyDeleted = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
+RabbitMQ.Stream.Client.AbstractEntity.ThrowIfClosed() -> void
 RabbitMQ.Stream.Client.AbstractEntity.Token.get -> System.Threading.CancellationToken
+RabbitMQ.Stream.Client.AlreadyClosedException
+RabbitMQ.Stream.Client.AlreadyClosedException.AlreadyClosedException(string s) -> void
 RabbitMQ.Stream.Client.AuthMechanism
 RabbitMQ.Stream.Client.AuthMechanism.External = 1 -> RabbitMQ.Stream.Client.AuthMechanism
 RabbitMQ.Stream.Client.AuthMechanism.Plain = 0 -> RabbitMQ.Stream.Client.AuthMechanism

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -215,6 +215,7 @@ namespace RabbitMQ.Stream.Client
         /// <param name="compressionType">No Compression, Gzip Compression. Other types are not provided by default</param>
         public async ValueTask Send(ulong publishingId, List<Message> subEntryMessages, CompressionType compressionType)
         {
+            ThrowIfClosed();
             if (subEntryMessages.Count != 0)
             {
                 await SemaphoreAwaitAsync().ConfigureAwait(false);
@@ -239,6 +240,7 @@ namespace RabbitMQ.Stream.Client
         /// <param name="messages"></param>
         public async ValueTask Send(List<(ulong, Message)> messages)
         {
+            ThrowIfClosed();
             PreValidateBatch(messages);
             await InternalBatchSend(messages).ConfigureAwait(false);
         }
@@ -275,6 +277,7 @@ namespace RabbitMQ.Stream.Client
 
         private async Task SendMessages(List<(ulong, Message)> messages, bool clearMessagesList = true)
         {
+            ThrowIfClosed();
             if (IsFilteringEnabled)
             {
                 await _client.Publish(new PublishFilter(EntityId, messages, _config.Filter.FilterValue,
@@ -322,6 +325,7 @@ namespace RabbitMQ.Stream.Client
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public async ValueTask Send(ulong publishingId, Message message)
         {
+            ThrowIfClosed();
             if (message.Size > _client.MaxFrameSize)
             {
                 throw new InvalidOperationException($"Message size is to big. " +

--- a/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
@@ -136,6 +136,14 @@ public class RawSuperStreamProducer : IProducer, IDisposable
         return p;
     }
 
+    protected void ThrowIfClosed()
+    {
+        if (!IsOpen())
+        {
+            throw new AlreadyClosedException($"Super stream {_config.SuperStream} is closed.");
+        }
+    }
+
     private async Task<IProducer> GetProducer(string stream)
     {
         if (!_producers.ContainsKey(stream))
@@ -170,12 +178,14 @@ public class RawSuperStreamProducer : IProducer, IDisposable
 
     public async ValueTask Send(ulong publishingId, Message message)
     {
+        ThrowIfClosed();
         var producer = await GetProducerForMessage(message).ConfigureAwait(false);
         await producer.Send(publishingId, message).ConfigureAwait(false);
     }
 
     public async ValueTask Send(List<(ulong, Message)> messages)
     {
+        ThrowIfClosed();
         var aggregate = new List<(IProducer, List<(ulong, Message)>)>();
 
         // this part is not super-optimized
@@ -203,6 +213,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
 
     public async ValueTask Send(ulong publishingId, List<Message> subEntryMessages, CompressionType compressionType)
     {
+        ThrowIfClosed();
         var aggregate = new List<(IProducer, List<Message>)>();
 
         // this part is not super-optimized

--- a/RabbitMQ.Stream.Client/Reliable/ConfirmationPipe.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConfirmationPipe.cs
@@ -113,6 +113,7 @@ public class ConfirmationPipe
 
     internal void Stop()
     {
+        FlushPendingMessages();
         _invalidateTimer.Enabled = false;
         _waitForConfirmationActionBlock.Complete();
     }
@@ -123,6 +124,15 @@ public class ConfirmationPipe
             (DateTime.Now - pair.Value.InsertDateTime).TotalSeconds > _messageTimeout.TotalSeconds);
 
         foreach (var pair in timedOutMessages)
+        {
+            await RemoveUnConfirmedMessage(ConfirmationStatus.ClientTimeoutError, pair.Value.PublishingId, null)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private async void FlushPendingMessages()
+    {
+        foreach (var pair in _waitForConfirmation)
         {
             await RemoveUnConfirmedMessage(ConfirmationStatus.ClientTimeoutError, pair.Value.PublishingId, null)
                 .ConfigureAwait(false);

--- a/Tests/EntitiesStateTests.cs
+++ b/Tests/EntitiesStateTests.cs
@@ -1,0 +1,108 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2007-2023 VMware, Inc.
+
+using System.Collections.Generic;
+using System.Text;
+using RabbitMQ.Stream.Client;
+using RabbitMQ.Stream.Client.AMQP;
+using RabbitMQ.Stream.Client.Reliable;
+using Xunit;
+
+namespace Tests
+{
+    public class EntitiesStateTests
+    {
+        [Fact]
+        public async void RawProducersShouldRaiseErrorWhenClosed()
+        {
+            SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
+            var rawProducer = await system.CreateRawProducer(new RawProducerConfig(stream));
+
+            Assert.True(rawProducer.IsOpen());
+            await rawProducer.Send(1, new Message(new byte[] { 1 }));
+            await rawProducer.Close();
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await rawProducer.Send(1, new Message(new byte[] { 1 })));
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await rawProducer.Send(new List<(ulong, Message)>()));
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await rawProducer.Send(1, new List<Message>(), CompressionType.Gzip));
+
+            var producer = await Producer.Create(new ProducerConfig(system, stream));
+            Assert.True(producer.IsOpen());
+            await producer.Send(new Message(new byte[] { 1 }));
+            await producer.Close();
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await producer.Send(new Message(new byte[] { 1 })));
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await producer.Send(new List<Message>()));
+
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await producer.Send(new List<Message>(), CompressionType.Gzip));
+
+            await SystemUtils.CleanUpStreamSystem(system, stream);
+        }
+
+        [Fact]
+        public async void RawSuperStreamProducersShouldRaiseErrorWhenClosed()
+        {
+            SystemUtils.ResetSuperStreams();
+            // Simple send message to super stream
+            // We should not have any errors and according to the routing strategy
+            // the message should be routed to the correct stream
+            var system = await StreamSystem.Create(new StreamSystemConfig());
+            var rawSuperStreamProducer =
+                await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+                {
+                    Routing = message1 => message1.Properties.MessageId.ToString(),
+                });
+
+            Assert.True(rawSuperStreamProducer.IsOpen());
+            for (ulong i = 0; i < 20; i++)
+            {
+                var message = new Message(Encoding.Default.GetBytes("hello"))
+                {
+                    Properties = new Properties() { MessageId = $"hello{i}" }
+                };
+                await rawSuperStreamProducer.Send(i, message);
+            }
+
+            await rawSuperStreamProducer.Close();
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await rawSuperStreamProducer.Send(1, new Message(new byte[] { 1 })));
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await rawSuperStreamProducer.Send(new List<(ulong, Message)>()));
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await rawSuperStreamProducer.Send(1, new List<Message>(), CompressionType.Gzip));
+
+            var producer = await Producer.Create(new ProducerConfig(system, SystemUtils.InvoicesExchange)
+            {
+                SuperStreamConfig = new SuperStreamConfig()
+                {
+                    Routing = message1 => message1.Properties.MessageId.ToString(),
+                }
+            });
+
+            Assert.True(producer.IsOpen());
+            for (ulong i = 0; i < 20; i++)
+            {
+                var message = new Message(Encoding.Default.GetBytes("hello"))
+                {
+                    Properties = new Properties() { MessageId = $"hello{i}" }
+                };
+                await producer.Send(message);
+            }
+
+            await producer.Close();
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await producer.Send(new Message(new byte[] { 1 })));
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await producer.Send(new List<Message>()));
+            await Assert.ThrowsAsync<AlreadyClosedException>(async () =>
+                await producer.Send(new List<Message>(), CompressionType.Gzip));
+
+            await system.Close();
+        }
+    }
+}

--- a/Tests/MultiThreadTests.cs
+++ b/Tests/MultiThreadTests.cs
@@ -2,6 +2,7 @@
 // 2.0, and the Mozilla Public License, version 2.0.
 // Copyright (c) 2007-2023 VMware, Inc.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -104,7 +105,14 @@ public class MultiThreadTests
             });
             for (var j = 0; j < 10000; j++)
             {
-                await producer.Send(new Message(new byte[3]));
+                try
+                {
+                    await producer.Send(new Message(new byte[3]));
+                }
+                catch (Exception e)
+                {
+                    Assert.True(e is AlreadyClosedException);
+                }
             }
 
             SystemUtils.WaitUntil(() => producers.TrueForAll(c => !c.IsOpen()));

--- a/Tests/ReliableTests.cs
+++ b/Tests/ReliableTests.cs
@@ -557,7 +557,7 @@ public class ReliableTests
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
         var c = new FakeThrowExceptionConsumer(new ConsumerConfig(system, stream),
             exception);
-        Assert.True(ReliableBase.IsAKnownException(exception));
+        Assert.True(ClientExceptions.IsAKnownException(exception));
         await c.Init(new BackOffReconnectStrategy());
         // Here the Consumer should be open
         // The exception is raised only the first time

--- a/Tests/SuperStreamProducerTests.cs
+++ b/Tests/SuperStreamProducerTests.cs
@@ -459,50 +459,6 @@ public class SuperStreamProducerTests
     }
 
     [Fact]
-    public async void ShouldRaiseAObjectDisposedExceptionWhenClose()
-    {
-        SystemUtils.ResetSuperStreams();
-
-        // This test is for OpenClose Status 
-        // When the producer is closed it should raise ObjectDisposedException
-        var system = await StreamSystem.Create(new StreamSystemConfig());
-        var streamProducer =
-            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
-            {
-                Routing = message1 => message1.Properties.MessageId.ToString()
-            });
-        Assert.True(streamProducer.IsOpen());
-        Assert.True(await streamProducer.Close() == ResponseCode.Ok);
-        Assert.False(streamProducer.IsOpen());
-        await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
-        {
-            await streamProducer.Send(1, new Message(Encoding.Default.GetBytes("hello")));
-        });
-    }
-
-    [Fact]
-    public async void ShouldRaiseAObjectDisposedExceptionWhenCloseWhitDispose()
-    {
-        SystemUtils.ResetSuperStreams();
-
-        // This test is for using and Dispose  
-        var system = await StreamSystem.Create(new StreamSystemConfig());
-        var streamProducer =
-            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
-            {
-                Routing = message1 => message1.Properties.MessageId.ToString()
-            });
-        Assert.True(streamProducer.IsOpen());
-        streamProducer.Dispose();
-        Assert.True(await streamProducer.Close() == ResponseCode.Ok);
-        Assert.False(streamProducer.IsOpen());
-        await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
-        {
-            await streamProducer.Send(1, new Message(Encoding.Default.GetBytes("hello")));
-        });
-    }
-
-    [Fact]
     public async void HandleConfirmationToSuperStream()
     {
         SystemUtils.ResetSuperStreams();


### PR DESCRIPTION
The pr is part of https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/336 the aim is to standardise the behaviour.

- Add AlreadyClosedException when a producer or super stream producer is closed In the same way like AMQP does with channels

- Producer: Flush the pending messages when closed.
- Producer: Add AlreadyClosedException when closed. So it is the same like: AMQP and RawProducer and RawSuperStreamProducer

- Improve IsAKnownException function with the AggregateException that can contains known exceptions needed for reconnect the client

- Add EntitiesStateTests to test all the status and verify that all the entities have the same behaviour