### PR TITLE
Handle cancellation token during the consumer close

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -396,7 +396,8 @@ namespace RabbitMQ.Stream.Client
                 if (response.ResponseCode == ResponseCode.Ok)
                     return (subscriptionId, response);
 
-                ClientExceptions.MaybeThrowException(response.ResponseCode, $"Error while creating consumer for stream {config.Stream}");
+                ClientExceptions.MaybeThrowException(response.ResponseCode,
+                    $"Error while creating consumer for stream {config.Stream}");
             }
             catch (Exception e)
             {
@@ -404,7 +405,8 @@ namespace RabbitMQ.Stream.Client
                 // and close the connection if necessary. 
                 consumers.Remove(subscriptionId);
                 await MaybeClose("Create Consumer Exception", config.Stream, config.Pool).ConfigureAwait(false);
-                throw new CreateConsumerException($"Error while creating consumer for stream {config.Stream}, error: {e.Message}");
+                throw new CreateConsumerException(
+                    $"Error while creating consumer for stream {config.Stream}, error: {e.Message}");
             }
 
             return (subscriptionId, new SubscribeResponse(subscriptionId, ResponseCode.InternalError));
@@ -724,7 +726,7 @@ namespace RabbitMQ.Stream.Client
         private void InternalClose()
         {
             _heartBeatHandler.Close();
-            // IsClosed = true;
+            IsClosed = true;
         }
 
         private bool HasEntities()
@@ -747,6 +749,7 @@ namespace RabbitMQ.Stream.Client
                 return new CloseResponse(0, ResponseCode.Ok);
             }
 
+            InternalClose();
             try
             {
                 var result =
@@ -768,8 +771,6 @@ namespace RabbitMQ.Stream.Client
             {
                 connection.Dispose();
             }
-
-            InternalClose();
 
             return new CloseResponse(0, ResponseCode.Ok);
         }

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -207,6 +207,7 @@ namespace RabbitMQ.Stream.Client
             client.connection = await Connection
                 .Create(parameters.Endpoint, client.HandleIncoming, client.HandleClosed, parameters.Ssl, logger)
                 .ConfigureAwait(false);
+            client.connection.ClientId = client.ClientId;
             // exchange properties
             var peerPropertiesResponse = await client.Request<PeerPropertiesRequest, PeerPropertiesResponse>(corr =>
                 new PeerPropertiesRequest(corr, parameters.Properties)).ConfigureAwait(false);
@@ -306,7 +307,7 @@ namespace RabbitMQ.Stream.Client
             Action<(ulong, ResponseCode)[]> errorCallback, ConnectionsPool pool = null)
         {
             await _poolSemaphore.WaitAsync().ConfigureAwait(false);
-            var publisherId = ConnectionsPool.FindNextValidId(publishers.Keys.ToList());
+            var publisherId = ConnectionsPool.FindNextValidId(publishers.Keys.ToList(), IncrementEntityId());
             DeclarePublisherResponse response;
 
             try
@@ -320,7 +321,7 @@ namespace RabbitMQ.Stream.Client
                 _poolSemaphore.Release();
             }
 
-            if (response.ResponseCode == ResponseCode.Ok || pool == null)
+            if (response.ResponseCode == ResponseCode.Ok)
                 return (publisherId, response);
 
             // if the response code is not ok we need to remove the subscription
@@ -357,13 +358,31 @@ namespace RabbitMQ.Stream.Client
         public async Task<(byte, SubscribeResponse)> Subscribe(string stream, IOffsetType offsetType,
             ushort initialCredit,
             Dictionary<string, string> properties, Func<Deliver, Task> deliverHandler,
-            Func<bool, Task<IOffsetType>> consumerUpdateHandler = null)
+            Func<bool, Task<IOffsetType>> consumerUpdateHandler = null, ConnectionsPool pool = null)
         {
-            return await Subscribe(new RawConsumerConfig(stream) { OffsetSpec = offsetType },
+            return await Subscribe(new RawConsumerConfig(stream) { OffsetSpec = offsetType, Pool = pool },
                 initialCredit,
                 properties,
                 deliverHandler,
                 consumerUpdateHandler).ConfigureAwait(false);
+        }
+
+        private byte _nextEntityId = 0;
+
+        // the entity id is a byte so we need to increment it and reset it when it reaches the max value
+        // to avoid to use always the same ids when producers and consumers are created 
+        // so even there is a connection with one producer or consumer we need to increment the id 
+        private byte IncrementEntityId()
+        {
+            lock (Obj)
+            {
+                var current = _nextEntityId;
+                _nextEntityId++;
+                if (_nextEntityId != byte.MaxValue)
+                    return current;
+                _nextEntityId = 0;
+                return _nextEntityId;
+            }
         }
 
         public async Task<(byte, SubscribeResponse)> Subscribe(RawConsumerConfig config,
@@ -372,44 +391,32 @@ namespace RabbitMQ.Stream.Client
             Func<bool, Task<IOffsetType>> consumerUpdateHandler)
         {
             await _poolSemaphore.WaitAsync().ConfigureAwait(false);
-            var subscriptionId = ConnectionsPool.FindNextValidId(consumers.Keys.ToList());
-
+            var subscriptionId = ConnectionsPool.FindNextValidId(consumers.Keys.ToList(), IncrementEntityId());
+            SubscribeResponse response;
             try
             {
-                SubscribeResponse response;
-                try
-                {
-                    consumers.Add(subscriptionId,
-                        new ConsumerEvents(
-                            deliverHandler,
-                            consumerUpdateHandler));
+                consumers.Add(subscriptionId,
+                    new ConsumerEvents(
+                        deliverHandler,
+                        consumerUpdateHandler));
 
-                    response = await Request<SubscribeRequest, SubscribeResponse>(corr =>
-                        new SubscribeRequest(corr, subscriptionId, config.Stream, config.OffsetSpec, initialCredit,
-                            properties)).ConfigureAwait(false);
-                }
-                finally
-                {
-                    _poolSemaphore.Release();
-                }
-
-                if (response.ResponseCode == ResponseCode.Ok)
-                    return (subscriptionId, response);
-
-                ClientExceptions.MaybeThrowException(response.ResponseCode,
-                    $"Error while creating consumer for stream {config.Stream}");
+                response = await Request<SubscribeRequest, SubscribeResponse>(corr =>
+                    new SubscribeRequest(corr, subscriptionId, config.Stream, config.OffsetSpec, initialCredit,
+                        properties)).ConfigureAwait(false);
             }
-            catch (Exception e)
+            finally
             {
-                // if the response code is not ok we need to remove the subscription
-                // and close the connection if necessary. 
-                consumers.Remove(subscriptionId);
-                await MaybeClose("Create Consumer Exception", config.Stream, config.Pool).ConfigureAwait(false);
-                throw new CreateConsumerException(
-                    $"Error while creating consumer for stream {config.Stream}, error: {e.Message}");
+                _poolSemaphore.Release();
             }
 
-            return (subscriptionId, new SubscribeResponse(subscriptionId, ResponseCode.InternalError));
+            if (response.ResponseCode == ResponseCode.Ok)
+                return (subscriptionId, response);
+
+            // if the response code is not ok we need to remove the subscription
+            // and close the connection if necessary. 
+            consumers.Remove(subscriptionId);
+            await MaybeClose("Create Consumer Exception", config.Stream, config.Pool).ConfigureAwait(false);
+            return (subscriptionId, response);
         }
 
         public async Task<UnsubscribeResponse> Unsubscribe(byte subscriptionId, bool ignoreIfAlreadyRemoved = false)
@@ -799,7 +806,6 @@ namespace RabbitMQ.Stream.Client
                         _logger.LogInformation("Close connection for the {ClientId}", ClientId);
                         // the client can be closed in an unexpected way so we need to remove it from the pool
                         // so you will find pool.remove(ClientId) also to the disconnect event
-                        // pool.remove(ClientId) is a duplicate call here but it is ok. The pool is idempotent 
                         pool.Remove(ClientId);
                         await Close(reason).ConfigureAwait(false);
                     }

--- a/RabbitMQ.Stream.Client/Connection.cs
+++ b/RabbitMQ.Stream.Client/Connection.cs
@@ -33,7 +33,7 @@ namespace RabbitMQ.Stream.Client
         private CancellationToken Token => _cancelTokenSource.Token;
 
         internal int NumFrames => numFrames;
-
+        internal string ClientId { get; set; }
         public bool IsClosed => isClosed;
 
         private static System.IO.Stream MaybeTcpUpgrade(NetworkStream networkStream, SslOption sslOption)
@@ -191,6 +191,8 @@ namespace RabbitMQ.Stream.Client
             finally
             {
                 isClosed = true;
+                _logger?.LogDebug("TCP Connection Closed ClientId: {ClientId} is IsCancellationRequested {Token} ",
+                    ClientId, Token.IsCancellationRequested);
                 // Mark the PipeReader as complete
                 await reader.CompleteAsync(caught).ConfigureAwait(false);
                 var t = closedCallback?.Invoke("TCP Connection Closed")!;

--- a/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
@@ -186,7 +186,6 @@ RabbitMQ.Stream.Client.Client.QueryPublisherSequence(string publisherRef, string
 RabbitMQ.Stream.Client.Client.StoreOffset(string reference, string stream, ulong offsetValue) -> System.Threading.Tasks.ValueTask<bool>
 RabbitMQ.Stream.Client.Client.StreamExists(string stream) -> System.Threading.Tasks.Task<bool>
 RabbitMQ.Stream.Client.Client.Subscribe(RabbitMQ.Stream.Client.RawConsumerConfig config, ushort initialCredit, System.Collections.Generic.Dictionary<string, string> properties, System.Func<RabbitMQ.Stream.Client.Deliver, System.Threading.Tasks.Task> deliverHandler, System.Func<bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>> consumerUpdateHandler) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.SubscribeResponse)>
-RabbitMQ.Stream.Client.Client.Subscribe(string stream, RabbitMQ.Stream.Client.IOffsetType offsetType, ushort initialCredit, System.Collections.Generic.Dictionary<string, string> properties, System.Func<RabbitMQ.Stream.Client.Deliver, System.Threading.Tasks.Task> deliverHandler, System.Func<bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>> consumerUpdateHandler = null) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.SubscribeResponse)>
 RabbitMQ.Stream.Client.ClientParameters
 RabbitMQ.Stream.Client.ClientParameters.AddressResolver.get -> RabbitMQ.Stream.Client.AddressResolver
 RabbitMQ.Stream.Client.ClientParameters.AddressResolver.set -> void

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -33,6 +33,7 @@ RabbitMQ.Stream.Client.Client.DeletePublisher(byte publisherId, bool ignoreIfAlr
 RabbitMQ.Stream.Client.Client.ExchangeVersions() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.CommandVersionsResponse>
 RabbitMQ.Stream.Client.Client.QueryRoute(string superStream, string routingKey) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.RouteQueryResponse>
 RabbitMQ.Stream.Client.Client.StreamStats(string stream) -> System.Threading.Tasks.ValueTask<RabbitMQ.Stream.Client.StreamStatsResponse>
+RabbitMQ.Stream.Client.Client.Subscribe(string stream, RabbitMQ.Stream.Client.IOffsetType offsetType, ushort initialCredit, System.Collections.Generic.Dictionary<string, string> properties, System.Func<RabbitMQ.Stream.Client.Deliver, System.Threading.Tasks.Task> deliverHandler, System.Func<bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>> consumerUpdateHandler = null, RabbitMQ.Stream.Client.ConnectionsPool pool = null) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.SubscribeResponse)>
 RabbitMQ.Stream.Client.Client.Unsubscribe(byte subscriptionId, bool ignoreIfAlreadyRemoved = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.UnsubscribeResponse>
 RabbitMQ.Stream.Client.ClientParameters.AuthMechanism.get -> RabbitMQ.Stream.Client.AuthMechanism
 RabbitMQ.Stream.Client.ClientParameters.AuthMechanism.set -> void

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -211,7 +211,8 @@ public class Consumer : ConsumerFactory
 
     public override string ToString()
     {
-        return $"Consumer reference: {_consumerConfig.Reference}, stream: {_consumerConfig.Stream} ";
+        return $"Consumer reference: {_consumerConfig.Reference}, stream: {_consumerConfig.Stream}, " +
+               $"client name: {_consumerConfig.ClientProvidedName} ";
     }
 
     public ConsumerInfo Info { get; }

--- a/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
@@ -60,11 +60,12 @@ public abstract class ReliableBase
         await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
         try
         {
-            await CreateNewEntity(boot).ConfigureAwait(false);
             lock (_lock)
             {
                 _isOpen = true;
             }
+
+            await CreateNewEntity(boot).ConfigureAwait(false);
         }
 
         catch (Exception e)

--- a/RabbitMQ.Stream.Client/Subscribe.cs
+++ b/RabbitMQ.Stream.Client/Subscribe.cs
@@ -134,7 +134,7 @@ namespace RabbitMQ.Stream.Client
         private readonly uint correlationId;
         private readonly ResponseCode responseCode;
 
-        private SubscribeResponse(uint correlationId, ResponseCode responseCode)
+        internal SubscribeResponse(uint correlationId, ResponseCode responseCode)
         {
             this.correlationId = correlationId;
             this.responseCode = responseCode;


### PR DESCRIPTION
* During the handle delivery, the consumer could receive a Token cancellation
  In this commit, the consumer handles it with a log and exit. It will avoid
  propagating the error and close the TCP connection

* Add a lock around the IsOpen() function to make it thread-safe.
  In normal situations, it does not matter. It is useful when a consumer is
  created and destroyed in a short time

* Handle the Subscribe error. In case there is an error during the init.
  The error will be raised to the caller, but the pool must be consistent.


Found the issue with a caos test like:
```csharp
for (var z = 0; z < 800; z++)
        {
            Console.WriteLine($"Starting consumer test {z}");
            await Task.Delay(new Random().Next(100, 200));
            try
            {
                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

                var consumer = await _streamSystem.CreateConsumer($"consumer-thread-force-test_{z}",
                    async (_, consumer, arg3, arg4) =>
                    {
                        tcs.TrySetResult();
                        await Task.CompletedTask;
                    }
                        
                );

                await tcs.Task.ConfigureAwait(false);
                _ = Task.Run(async () =>
                {
                    await Task.Delay(new Random().Next(500, 800));
                    await consumer.Close();
                });
            }
            catch (Exception e)
            {
                Console.WriteLine($"Error creating consumer {e.Message}");
            }
        }
```
