### PR TITLE
Improve Reconnection

### DIFF
--- a/RabbitMQ.Stream.Client/AbstractEntity.cs
+++ b/RabbitMQ.Stream.Client/AbstractEntity.cs
@@ -92,8 +92,7 @@ namespace RabbitMQ.Stream.Client
                 return result;
             }
 
-            var closed = await _client.MaybeClose($"closing: {EntityId}",
-                    GetStream(), config.Pool)
+            var closed = await _client.MaybeClose($"closing: {EntityId}", config.Pool)
                 .ConfigureAwait(false);
             ClientExceptions.MaybeThrowException(closed.ResponseCode, $"_client-close-Entity: {EntityId}");
             Logger.LogDebug("{EntityInfo} is closed", DumpEntityConfiguration());

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -813,7 +813,7 @@ namespace RabbitMQ.Stream.Client
         // Release will decrement the active ids for the connection
         // if the active ids are 0 the connection will be closed
 
-        internal async Task<CloseResponse> MaybeClose(string reason, string stream, ConnectionsPool pool)
+        internal async Task<CloseResponse> MaybeClose(string reason, ConnectionsPool pool)
         {
             await _poolSemaphore.WaitAsync().ConfigureAwait(false);
             try

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -224,7 +224,7 @@ namespace RabbitMQ.Stream.Client
             Parameters.OnMetadataUpdate -= metadataUpdateHandler;
             _attachSemaphore.Release();
         }
-        
+
         public static async Task<Client> Create(ClientParameters parameters, ILogger logger = null)
         {
             var client = new Client(parameters, logger);

--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -205,26 +205,6 @@ namespace RabbitMQ.Stream.Client
             }
         }
 
-        private readonly SemaphoreSlim _attachSemaphore = new(1, 1);
-
-        public void AttachEventsToTheClient(ConnectionCloseHandler connectionCloseHandler,
-            ClientParameters.MetadataUpdateHandler metadataUpdateHandler)
-        {
-            _attachSemaphore.Wait();
-            ConnectionClosed += connectionCloseHandler;
-            Parameters.OnMetadataUpdate += metadataUpdateHandler;
-            _attachSemaphore.Release();
-        }
-
-        public void DetachEventsFromTheClient(ConnectionCloseHandler connectionCloseHandler,
-            ClientParameters.MetadataUpdateHandler metadataUpdateHandler)
-        {
-            _attachSemaphore.Wait();
-            ConnectionClosed -= connectionCloseHandler;
-            Parameters.OnMetadataUpdate -= metadataUpdateHandler;
-            _attachSemaphore.Release();
-        }
-
         public static async Task<Client> Create(ClientParameters parameters, ILogger logger = null)
         {
             var client = new Client(parameters, logger);

--- a/RabbitMQ.Stream.Client/ConnectionsPool.cs
+++ b/RabbitMQ.Stream.Client/ConnectionsPool.cs
@@ -180,7 +180,11 @@ public class ConnectionsPool
         _semaphoreSlim.Wait();
         try
         {
-            Connections.TryRemove(clientId, out _);
+            Connections.TryRemove(clientId, out var connectionItem);
+            if (connectionItem == null)
+                return;
+            connectionItem.Client.Consumers.Clear();
+            connectionItem.Client.Publishers.Clear();
         }
         finally
         {
@@ -231,10 +235,9 @@ public class ConnectionsPool
                 return;
             }
 
-            var l = connectionItem.Client.Consumers.Where(x =>
-                    x.Key == id && x.Value.Item1 == stream).ToList();
-
-            l.ForEach(x => connectionItem.Client.Consumers.Remove(x.Key));
+            connectionItem.Client.Consumers.Where(x =>
+                    x.Key == id && x.Value.Item1 == stream).ToList()
+                .ForEach(x => connectionItem.Client.Consumers.Remove(x.Key));
         }
         finally
         {

--- a/RabbitMQ.Stream.Client/ConnectionsPool.cs
+++ b/RabbitMQ.Stream.Client/ConnectionsPool.cs
@@ -137,7 +137,7 @@ public class ConnectionsPool
     /// The broker info is the string representation of the broker ip and port.
     /// See Metadata.cs Broker.ToString() method, ex: Broker(localhost,5552) is "localhost:5552" 
     /// </summary>
-    internal async Task<IClient> GetOrCreateClient(string brokerInfo, string stream, Func<Task<IClient>> createClient)
+    internal async Task<IClient> GetOrCreateClient(string brokerInfo, Func<Task<IClient>> createClient)
     {
         await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
         try

--- a/RabbitMQ.Stream.Client/IClient.cs
+++ b/RabbitMQ.Stream.Client/IClient.cs
@@ -2,6 +2,7 @@
 // 2.0, and the Mozilla Public License, version 2.0.
 // Copyright (c) 2017-2023 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -23,5 +24,8 @@ namespace RabbitMQ.Stream.Client
         // It is used to identify the client in the ConnectionsPool
         // by default it is a GUID
         string ClientId { get; init; }
+
+        IDictionary<byte, (string, (Action<ReadOnlyMemory<ulong>>, Action<(ulong, ResponseCode)[]>))> Publishers { get; }
+        IDictionary<byte, (string, ConsumerEvents)> Consumers { get; }
     }
 }

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -81,4 +81,9 @@ public class ConsumerInfo : Info
     {
         Reference = reference;
     }
+
+    public override string ToString()
+    {
+        return $"{base.ToString()}, Reference: {Reference}";
+    }
 }

--- a/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
@@ -525,8 +525,6 @@ RabbitMQ.Stream.Client.RawConsumer.StoreOffset(ulong offset) -> System.Threading
 RabbitMQ.Stream.Client.RawConsumerConfig
 RabbitMQ.Stream.Client.RawConsumerConfig.MessageHandler.get -> System.Func<RabbitMQ.Stream.Client.RawConsumer, RabbitMQ.Stream.Client.MessageContext, RabbitMQ.Stream.Client.Message, System.Threading.Tasks.Task>
 RabbitMQ.Stream.Client.RawConsumerConfig.MessageHandler.set -> void
-RabbitMQ.Stream.Client.RawConsumerConfig.MetadataHandler.get -> System.Action<RabbitMQ.Stream.Client.MetaDataUpdate>
-RabbitMQ.Stream.Client.RawConsumerConfig.MetadataHandler.set -> void
 RabbitMQ.Stream.Client.RawConsumerConfig.OffsetSpec.get -> RabbitMQ.Stream.Client.IOffsetType
 RabbitMQ.Stream.Client.RawConsumerConfig.OffsetSpec.set -> void
 RabbitMQ.Stream.Client.RawConsumerConfig.RawConsumerConfig(string stream) -> void
@@ -547,8 +545,6 @@ RabbitMQ.Stream.Client.RawProducerConfig.ConfirmHandler.get -> System.Action<Rab
 RabbitMQ.Stream.Client.RawProducerConfig.ConfirmHandler.set -> void
 RabbitMQ.Stream.Client.RawProducerConfig.ConnectionClosedHandler.get -> System.Func<string, System.Threading.Tasks.Task>
 RabbitMQ.Stream.Client.RawProducerConfig.ConnectionClosedHandler.set -> void
-RabbitMQ.Stream.Client.RawProducerConfig.MetadataHandler.get -> System.Action<RabbitMQ.Stream.Client.MetaDataUpdate>
-RabbitMQ.Stream.Client.RawProducerConfig.MetadataHandler.set -> void
 RabbitMQ.Stream.Client.RawProducerConfig.RawProducerConfig(string stream) -> void
 RabbitMQ.Stream.Client.RawProducerConfig.Stream.get -> string
 RabbitMQ.Stream.Client.RawSuperStreamConsumer
@@ -612,9 +608,6 @@ RabbitMQ.Stream.Client.Reliable.ConsumerFactory
 RabbitMQ.Stream.Client.Reliable.ConsumerFactory.ConsumerFactory() -> void
 RabbitMQ.Stream.Client.Reliable.ConsumerFactory.CreateConsumer(bool boot) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
 RabbitMQ.Stream.Client.Reliable.ConsumerFactory._consumerConfig -> RabbitMQ.Stream.Client.Reliable.ConsumerConfig
-RabbitMQ.Stream.Client.Reliable.IReconnectStrategy
-RabbitMQ.Stream.Client.Reliable.IReconnectStrategy.WhenConnected(string connectionInfo) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Stream.Client.Reliable.IReconnectStrategy.WhenDisconnected(string connectionIdentifier) -> System.Threading.Tasks.ValueTask<bool>
 RabbitMQ.Stream.Client.Reliable.MessagesConfirmation
 RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.InsertDateTime.get -> System.DateTime
 RabbitMQ.Stream.Client.Reliable.MessagesConfirmation.InsertDateTime.init -> void
@@ -650,11 +643,7 @@ RabbitMQ.Stream.Client.Reliable.ProducerFactory._producerConfig -> RabbitMQ.Stre
 RabbitMQ.Stream.Client.Reliable.ReliableBase
 RabbitMQ.Stream.Client.Reliable.ReliableBase.IsOpen() -> bool
 RabbitMQ.Stream.Client.Reliable.ReliableBase.ReliableBase() -> void
-RabbitMQ.Stream.Client.Reliable.ReliableBase.TryToReconnect(RabbitMQ.Stream.Client.Reliable.IReconnectStrategy reconnectStrategy) -> System.Threading.Tasks.Task
-RabbitMQ.Stream.Client.Reliable.ReliableBase._inReconnection -> bool
-RabbitMQ.Stream.Client.Reliable.ReliableBase._isOpen -> bool
 RabbitMQ.Stream.Client.Reliable.ReliableConfig
-RabbitMQ.Stream.Client.Reliable.ReliableConfig.ReconnectStrategy.get -> RabbitMQ.Stream.Client.Reliable.IReconnectStrategy
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.ReconnectStrategy.set -> void
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.ReliableConfig(RabbitMQ.Stream.Client.StreamSystem streamSystem, string stream) -> void
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.Stream.get -> string
@@ -787,8 +776,6 @@ static RabbitMQ.Stream.Client.LeaderLocator.ClientLocal.get -> RabbitMQ.Stream.C
 static RabbitMQ.Stream.Client.LeaderLocator.LeastLeaders.get -> RabbitMQ.Stream.Client.LeaderLocator
 static RabbitMQ.Stream.Client.LeaderLocator.Random.get -> RabbitMQ.Stream.Client.LeaderLocator
 static RabbitMQ.Stream.Client.Message.From(ref System.Buffers.SequenceReader<byte> reader, uint len) -> RabbitMQ.Stream.Client.Message
-static RabbitMQ.Stream.Client.RawConsumer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.RawConsumerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
-static RabbitMQ.Stream.Client.RawProducer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.RawProducerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 static RabbitMQ.Stream.Client.RawSuperStreamConsumer.Create(RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig rawSuperStreamConsumerConfig, System.Collections.Generic.IDictionary<string, RabbitMQ.Stream.Client.StreamInfo> streamInfos, RabbitMQ.Stream.Client.ClientParameters clientParameters, Microsoft.Extensions.Logging.ILogger logger = null) -> RabbitMQ.Stream.Client.IConsumer
 static RabbitMQ.Stream.Client.RawSuperStreamProducer.Create(RabbitMQ.Stream.Client.RawSuperStreamProducerConfig rawSuperStreamProducerConfig, System.Collections.Generic.IDictionary<string, RabbitMQ.Stream.Client.StreamInfo> streamInfos, RabbitMQ.Stream.Client.ClientParameters clientParameters, Microsoft.Extensions.Logging.ILogger logger = null) -> RabbitMQ.Stream.Client.IProducer
 static RabbitMQ.Stream.Client.Reliable.Consumer.Create(RabbitMQ.Stream.Client.Reliable.ConsumerConfig consumerConfig, Microsoft.Extensions.Logging.ILogger<RabbitMQ.Stream.Client.Reliable.Consumer> logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.Consumer>

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -28,13 +28,11 @@ RabbitMQ.Stream.Client.AuthMechanismNotSupportedException.AuthMechanismNotSuppor
 RabbitMQ.Stream.Client.Chunk.Crc.get -> uint
 RabbitMQ.Stream.Client.Chunk.Data.get -> System.ReadOnlyMemory<byte>
 RabbitMQ.Stream.Client.Chunk.MagicVersion.get -> byte
-RabbitMQ.Stream.Client.Client.AttachEventsToTheClient(RabbitMQ.Stream.Client.Client.ConnectionCloseHandler connectionCloseHandler, RabbitMQ.Stream.Client.ClientParameters.MetadataUpdateHandler metadataUpdateHandler) -> void
 RabbitMQ.Stream.Client.Client.ClientId.get -> string
 RabbitMQ.Stream.Client.Client.ClientId.init -> void
 RabbitMQ.Stream.Client.Client.Consumers.get -> System.Collections.Generic.IDictionary<byte, (string, RabbitMQ.Stream.Client.ConsumerEvents)>
 RabbitMQ.Stream.Client.Client.DeclarePublisher(string publisherRef, string stream, System.Action<System.ReadOnlyMemory<ulong>> confirmCallback, System.Action<(ulong, RabbitMQ.Stream.Client.ResponseCode)[]> errorCallback, RabbitMQ.Stream.Client.ConnectionsPool pool = null) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.DeclarePublisherResponse)>
 RabbitMQ.Stream.Client.Client.DeletePublisher(byte publisherId, bool ignoreIfAlreadyRemoved = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.DeletePublisherResponse>
-RabbitMQ.Stream.Client.Client.DetachEventsFromTheClient(RabbitMQ.Stream.Client.Client.ConnectionCloseHandler connectionCloseHandler, RabbitMQ.Stream.Client.ClientParameters.MetadataUpdateHandler metadataUpdateHandler) -> void
 RabbitMQ.Stream.Client.Client.ExchangeVersions() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.CommandVersionsResponse>
 RabbitMQ.Stream.Client.Client.Publishers.get -> System.Collections.Generic.IDictionary<byte, (string, (System.Action<System.ReadOnlyMemory<ulong>>, System.Action<(ulong, RabbitMQ.Stream.Client.ResponseCode)[]>))>
 RabbitMQ.Stream.Client.Client.QueryRoute(string superStream, string routingKey) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.RouteQueryResponse>

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ abstract RabbitMQ.Stream.Client.AbstractEntity.GetStream() -> string
 const RabbitMQ.Stream.Client.RouteQueryResponse.Key = 24 -> ushort
 const RabbitMQ.Stream.Client.StreamStatsResponse.Key = 28 -> ushort
 override RabbitMQ.Stream.Client.Broker.ToString() -> string
+override RabbitMQ.Stream.Client.ConsumerInfo.ToString() -> string
 override RabbitMQ.Stream.Client.RawConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 override RabbitMQ.Stream.Client.RawProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.AbstractEntity.Dispose(bool disposing) -> void
@@ -16,6 +17,7 @@ RabbitMQ.Stream.Client.AbstractEntity.Logger.init -> void
 RabbitMQ.Stream.Client.AbstractEntity.Shutdown(RabbitMQ.Stream.Client.EntityCommonConfig config, bool ignoreIfAlreadyDeleted = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.AbstractEntity.ThrowIfClosed() -> void
 RabbitMQ.Stream.Client.AbstractEntity.Token.get -> System.Threading.CancellationToken
+RabbitMQ.Stream.Client.AbstractEntity.UpdateStatusToClosed() -> void
 RabbitMQ.Stream.Client.AlreadyClosedException
 RabbitMQ.Stream.Client.AlreadyClosedException.AlreadyClosedException(string s) -> void
 RabbitMQ.Stream.Client.AuthMechanism
@@ -26,11 +28,15 @@ RabbitMQ.Stream.Client.AuthMechanismNotSupportedException.AuthMechanismNotSuppor
 RabbitMQ.Stream.Client.Chunk.Crc.get -> uint
 RabbitMQ.Stream.Client.Chunk.Data.get -> System.ReadOnlyMemory<byte>
 RabbitMQ.Stream.Client.Chunk.MagicVersion.get -> byte
+RabbitMQ.Stream.Client.Client.AttachEventsToTheClient(RabbitMQ.Stream.Client.Client.ConnectionCloseHandler connectionCloseHandler, RabbitMQ.Stream.Client.ClientParameters.MetadataUpdateHandler metadataUpdateHandler) -> void
 RabbitMQ.Stream.Client.Client.ClientId.get -> string
 RabbitMQ.Stream.Client.Client.ClientId.init -> void
+RabbitMQ.Stream.Client.Client.Consumers.get -> System.Collections.Generic.IDictionary<byte, (string, RabbitMQ.Stream.Client.ConsumerEvents)>
 RabbitMQ.Stream.Client.Client.DeclarePublisher(string publisherRef, string stream, System.Action<System.ReadOnlyMemory<ulong>> confirmCallback, System.Action<(ulong, RabbitMQ.Stream.Client.ResponseCode)[]> errorCallback, RabbitMQ.Stream.Client.ConnectionsPool pool = null) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.DeclarePublisherResponse)>
 RabbitMQ.Stream.Client.Client.DeletePublisher(byte publisherId, bool ignoreIfAlreadyRemoved = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.DeletePublisherResponse>
+RabbitMQ.Stream.Client.Client.DetachEventsFromTheClient(RabbitMQ.Stream.Client.Client.ConnectionCloseHandler connectionCloseHandler, RabbitMQ.Stream.Client.ClientParameters.MetadataUpdateHandler metadataUpdateHandler) -> void
 RabbitMQ.Stream.Client.Client.ExchangeVersions() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.CommandVersionsResponse>
+RabbitMQ.Stream.Client.Client.Publishers.get -> System.Collections.Generic.IDictionary<byte, (string, (System.Action<System.ReadOnlyMemory<ulong>>, System.Action<(ulong, RabbitMQ.Stream.Client.ResponseCode)[]>))>
 RabbitMQ.Stream.Client.Client.QueryRoute(string superStream, string routingKey) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.RouteQueryResponse>
 RabbitMQ.Stream.Client.Client.StreamStats(string stream) -> System.Threading.Tasks.ValueTask<RabbitMQ.Stream.Client.StreamStatsResponse>
 RabbitMQ.Stream.Client.Client.Subscribe(string stream, RabbitMQ.Stream.Client.IOffsetType offsetType, ushort initialCredit, System.Collections.Generic.Dictionary<string, string> properties, System.Func<RabbitMQ.Stream.Client.Deliver, System.Threading.Tasks.Task> deliverHandler, System.Func<bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>> consumerUpdateHandler = null, RabbitMQ.Stream.Client.ConnectionsPool pool = null) -> System.Threading.Tasks.Task<(byte, RabbitMQ.Stream.Client.SubscribeResponse)>
@@ -39,15 +45,16 @@ RabbitMQ.Stream.Client.ClientParameters.AuthMechanism.get -> RabbitMQ.Stream.Cli
 RabbitMQ.Stream.Client.ClientParameters.AuthMechanism.set -> void
 RabbitMQ.Stream.Client.ClientParameters.MetadataUpdateHandler
 RabbitMQ.Stream.Client.ClientParameters.OnMetadataUpdate -> RabbitMQ.Stream.Client.ClientParameters.MetadataUpdateHandler
+RabbitMQ.Stream.Client.Connection.UpdateCloseStatus(string reason) -> void
 RabbitMQ.Stream.Client.ConnectionItem
 RabbitMQ.Stream.Client.ConnectionItem.Available.get -> bool
 RabbitMQ.Stream.Client.ConnectionItem.BrokerInfo.get -> string
 RabbitMQ.Stream.Client.ConnectionItem.Client.get -> RabbitMQ.Stream.Client.IClient
 RabbitMQ.Stream.Client.ConnectionItem.ConnectionItem(string brokerInfo, byte idsPerConnection, RabbitMQ.Stream.Client.IClient client) -> void
+RabbitMQ.Stream.Client.ConnectionItem.EntitiesCount.get -> int
 RabbitMQ.Stream.Client.ConnectionItem.IdsPerConnection.get -> byte
 RabbitMQ.Stream.Client.ConnectionItem.LastUsed.get -> System.DateTime
 RabbitMQ.Stream.Client.ConnectionItem.LastUsed.set -> void
-RabbitMQ.Stream.Client.ConnectionItem.StreamIds.get -> System.Collections.Generic.Dictionary<string, RabbitMQ.Stream.Client.StreamIds>
 RabbitMQ.Stream.Client.ConnectionPoolConfig
 RabbitMQ.Stream.Client.ConnectionPoolConfig.ConnectionPoolConfig() -> void
 RabbitMQ.Stream.Client.ConnectionPoolConfig.ConsumersPerConnection.get -> byte
@@ -55,14 +62,17 @@ RabbitMQ.Stream.Client.ConnectionPoolConfig.ConsumersPerConnection.set -> void
 RabbitMQ.Stream.Client.ConnectionPoolConfig.ProducersPerConnection.get -> byte
 RabbitMQ.Stream.Client.ConnectionPoolConfig.ProducersPerConnection.set -> void
 RabbitMQ.Stream.Client.ConnectionsPool
-RabbitMQ.Stream.Client.ConnectionsPool.ActiveIdsCount.get -> int
-RabbitMQ.Stream.Client.ConnectionsPool.ActiveIdsCountForClient(string clientId) -> int
-RabbitMQ.Stream.Client.ConnectionsPool.ActiveIdsCountForClientAndStream(string clientId, string stream) -> int
-RabbitMQ.Stream.Client.ConnectionsPool.ActiveIdsCountForStream(string stream) -> int
 RabbitMQ.Stream.Client.ConnectionsPool.ConnectionsCount.get -> int
 RabbitMQ.Stream.Client.ConnectionsPool.ConnectionsPool(int maxConnections, byte idsPerConnection) -> void
-RabbitMQ.Stream.Client.ConnectionsPool.Release(string clientId, string stream) -> void
+RabbitMQ.Stream.Client.ConnectionsPool.MaybeClose(string clientId, string reason) -> void
 RabbitMQ.Stream.Client.ConnectionsPool.Remove(string clientId) -> void
+RabbitMQ.Stream.Client.ConnectionsPool.RemoveConsumerEntityFromStream(string clientId, byte id, string stream) -> void
+RabbitMQ.Stream.Client.ConnectionsPool.RemoveProducerEntityFromStream(string clientId, byte id, string stream) -> void
+RabbitMQ.Stream.Client.ConsumerEvents
+RabbitMQ.Stream.Client.ConsumerEvents.ConsumerEvents() -> void
+RabbitMQ.Stream.Client.ConsumerEvents.ConsumerEvents(System.Func<RabbitMQ.Stream.Client.Deliver, System.Threading.Tasks.Task> deliverHandler, System.Func<bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>> consumerUpdateHandler) -> void
+RabbitMQ.Stream.Client.ConsumerEvents.ConsumerUpdateHandler.get -> System.Func<bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>>
+RabbitMQ.Stream.Client.ConsumerEvents.DeliverHandler.get -> System.Func<RabbitMQ.Stream.Client.Deliver, System.Threading.Tasks.Task>
 RabbitMQ.Stream.Client.ConsumerFilter
 RabbitMQ.Stream.Client.ConsumerFilter.MatchUnfiltered.get -> bool
 RabbitMQ.Stream.Client.ConsumerFilter.MatchUnfiltered.set -> void
@@ -75,10 +85,21 @@ RabbitMQ.Stream.Client.ConsumerInfo.ConsumerInfo(string stream, string reference
 RabbitMQ.Stream.Client.ConsumerInfo.Reference.get -> string
 RabbitMQ.Stream.Client.CrcException
 RabbitMQ.Stream.Client.CrcException.CrcException(string s) -> void
+RabbitMQ.Stream.Client.CreateConsumerException.CreateConsumerException(string s, RabbitMQ.Stream.Client.ResponseCode responseCode) -> void
+RabbitMQ.Stream.Client.CreateException
+RabbitMQ.Stream.Client.CreateException.CreateException(string s) -> void
+RabbitMQ.Stream.Client.CreateException.CreateException(string s, RabbitMQ.Stream.Client.ResponseCode responseCode) -> void
+RabbitMQ.Stream.Client.CreateException.ResponseCode.get -> RabbitMQ.Stream.Client.ResponseCode
+RabbitMQ.Stream.Client.CreateException.ResponseCode.init -> void
+RabbitMQ.Stream.Client.CreateProducerException.CreateProducerException(string s, RabbitMQ.Stream.Client.ResponseCode responseCode) -> void
 RabbitMQ.Stream.Client.EntityCommonConfig
+RabbitMQ.Stream.Client.EntityCommonConfig.MetadataHandler.get -> System.Func<RabbitMQ.Stream.Client.MetaDataUpdate, System.Threading.Tasks.Task>
+RabbitMQ.Stream.Client.EntityCommonConfig.MetadataHandler.set -> void
 RabbitMQ.Stream.Client.HashRoutingMurmurStrategy.Route(RabbitMQ.Stream.Client.Message message, System.Collections.Generic.List<string> partitions) -> System.Threading.Tasks.Task<System.Collections.Generic.List<string>>
 RabbitMQ.Stream.Client.IClient.ClientId.get -> string
 RabbitMQ.Stream.Client.IClient.ClientId.init -> void
+RabbitMQ.Stream.Client.IClient.Consumers.get -> System.Collections.Generic.IDictionary<byte, (string, RabbitMQ.Stream.Client.ConsumerEvents)>
+RabbitMQ.Stream.Client.IClient.Publishers.get -> System.Collections.Generic.IDictionary<byte, (string, (System.Action<System.ReadOnlyMemory<ulong>>, System.Action<(ulong, RabbitMQ.Stream.Client.ResponseCode)[]>))>
 RabbitMQ.Stream.Client.IClosable
 RabbitMQ.Stream.Client.IClosable.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.IConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
@@ -147,6 +168,9 @@ RabbitMQ.Stream.Client.RawSuperStreamProducer.Close() -> System.Threading.Tasks.
 RabbitMQ.Stream.Client.RawSuperStreamProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.get -> RabbitMQ.Stream.Client.RoutingStrategyType
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.set -> void
+RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy
+RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy.WhenConnected(string itemIdentifier) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy.WhenDisconnected(string itemIdentifier) -> System.Threading.Tasks.ValueTask<bool>
 RabbitMQ.Stream.Client.Reliable.Consumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
 RabbitMQ.Stream.Client.Reliable.ConsumerConfig.Crc32.get -> RabbitMQ.Stream.Client.ICrc32
 RabbitMQ.Stream.Client.Reliable.ConsumerConfig.Crc32.set -> void
@@ -154,6 +178,7 @@ RabbitMQ.Stream.Client.Reliable.ConsumerConfig.Filter.get -> RabbitMQ.Stream.Cli
 RabbitMQ.Stream.Client.Reliable.ConsumerConfig.Filter.set -> void
 RabbitMQ.Stream.Client.Reliable.ConsumerConfig.InitialCredits.get -> ushort
 RabbitMQ.Stream.Client.Reliable.ConsumerConfig.InitialCredits.set -> void
+RabbitMQ.Stream.Client.Reliable.ConsumerFactory._consumer -> RabbitMQ.Stream.Client.IConsumer
 RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer
 RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.Close() -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.GetLastPublishedId() -> System.Threading.Tasks.Task<ulong>
@@ -166,6 +191,20 @@ RabbitMQ.Stream.Client.Reliable.Producer.Info.get -> RabbitMQ.Stream.Client.Prod
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Filter.get -> RabbitMQ.Stream.Client.ProducerFilter
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Filter.set -> void
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.set -> void
+RabbitMQ.Stream.Client.Reliable.ReliableBase.CheckIfStreamIsAvailable(string stream, RabbitMQ.Stream.Client.StreamSystem system) -> System.Threading.Tasks.Task<bool>
+RabbitMQ.Stream.Client.Reliable.ReliableBase.CompareStatus(RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus toTest) -> bool
+RabbitMQ.Stream.Client.Reliable.ReliableBase.IsValidStatus() -> bool
+RabbitMQ.Stream.Client.Reliable.ReliableBase.MaybeReconnect() -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.Reliable.ReliableBase.UpdateStatus(RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus status) -> void
+RabbitMQ.Stream.Client.Reliable.ReliableBase._status -> RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus
+RabbitMQ.Stream.Client.Reliable.ReliableConfig.ReconnectStrategy.get -> RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy
+RabbitMQ.Stream.Client.Reliable.ReliableConfig.ResourceAvailableReconnectStrategy.get -> RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy
+RabbitMQ.Stream.Client.Reliable.ReliableConfig.ResourceAvailableReconnectStrategy.set -> void
+RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus
+RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus.Closed = 3 -> RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus
+RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus.Initialization = 0 -> RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus
+RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus.Open = 1 -> RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus
+RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus.Reconnecting = 2 -> RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus
 RabbitMQ.Stream.Client.Reliable.SuperStreamConfig.RoutingStrategyType.get -> RabbitMQ.Stream.Client.RoutingStrategyType
 RabbitMQ.Stream.Client.Reliable.SuperStreamConfig.RoutingStrategyType.set -> void
 RabbitMQ.Stream.Client.RouteNotFoundException
@@ -181,10 +220,6 @@ RabbitMQ.Stream.Client.RouteQueryResponse.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.RoutingStrategyType
 RabbitMQ.Stream.Client.RoutingStrategyType.Hash = 0 -> RabbitMQ.Stream.Client.RoutingStrategyType
 RabbitMQ.Stream.Client.RoutingStrategyType.Key = 1 -> RabbitMQ.Stream.Client.RoutingStrategyType
-RabbitMQ.Stream.Client.StreamIds
-RabbitMQ.Stream.Client.StreamIds.Count.get -> int
-RabbitMQ.Stream.Client.StreamIds.Stream.get -> string
-RabbitMQ.Stream.Client.StreamIds.StreamIds(string stream) -> void
 RabbitMQ.Stream.Client.StreamStats
 RabbitMQ.Stream.Client.StreamStats.CommittedChunkId() -> ulong
 RabbitMQ.Stream.Client.StreamStats.FirstOffset() -> ulong
@@ -210,6 +245,8 @@ RabbitMQ.Stream.Client.UnsupportedOperationException
 RabbitMQ.Stream.Client.UnsupportedOperationException.UnsupportedOperationException(string s) -> void
 static RabbitMQ.Stream.Client.Connection.Create(System.Net.EndPoint endpoint, System.Func<System.Memory<byte>, System.Threading.Tasks.Task> commandCallback, System.Func<string, System.Threading.Tasks.Task> closedCallBack, RabbitMQ.Stream.Client.SslOption sslOption, Microsoft.Extensions.Logging.ILogger logger) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Connection>
 static RabbitMQ.Stream.Client.Message.From(ref System.Buffers.ReadOnlySequence<byte> seq, uint len) -> RabbitMQ.Stream.Client.Message
+static RabbitMQ.Stream.Client.RawConsumer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.RawConsumerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
+static RabbitMQ.Stream.Client.RawProducer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.RawProducerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 static RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.Create(RabbitMQ.Stream.Client.Reliable.DeduplicatingProducerConfig producerConfig, Microsoft.Extensions.Logging.ILogger<RabbitMQ.Stream.Client.Reliable.Producer> logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer>
 static RabbitMQ.Stream.Client.RoutingHelper<T>.LookupLeaderConnection(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.StreamInfo metaDataInfo, RabbitMQ.Stream.Client.ConnectionsPool pool, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IClient>
 static RabbitMQ.Stream.Client.RoutingHelper<T>.LookupRandomConnection(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.StreamInfo metaDataInfo, RabbitMQ.Stream.Client.ConnectionsPool pool, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IClient>

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -5,14 +5,6 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-
-/* Unmerged change from project 'RabbitMQ.Stream.Client(net7.0)'
-Before:
-using System.Data;
-using System.Diagnostics;
-After:
-using System.Diagnostics;
-*/
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
@@ -626,7 +618,6 @@ namespace RabbitMQ.Stream.Client
                 _config.Pool.RemoveConsumerEntityFromStream(_client.ClientId, EntityId, _config.Stream);
                 _config.MetadataHandler?.Invoke(metaDataUpdate);
                 await Close().ConfigureAwait(false);
-                return;
             };
 
         private Client.ConnectionCloseHandler OnConnectionClosed() =>

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -34,7 +34,6 @@ namespace RabbitMQ.Stream.Client
         public string Stream { get; }
         public Func<string, Task> ConnectionClosedHandler { get; set; }
         public Action<Confirmation> ConfirmHandler { get; set; } = _ => { };
-        public Action<MetaDataUpdate> MetadataHandler { get; set; } = _ => { };
 
         public RawProducerConfig(string stream)
         {
@@ -81,7 +80,9 @@ namespace RabbitMQ.Stream.Client
         )
         {
             var client = await RoutingHelper<Routing>
-                .LookupLeaderConnection(clientParameters, metaStreamInfo, config.Pool, logger)
+                .LookupLeaderConnection(
+                    clientParameters,
+                    metaStreamInfo, config.Pool, logger)
                 .ConfigureAwait(false);
 
             var producer = new RawProducer((Client)client, config, logger);
@@ -114,9 +115,6 @@ namespace RabbitMQ.Stream.Client
         private async Task Init()
         {
             _config.Validate();
-
-            _client.ConnectionClosed += OnConnectionClosed();
-            _client.Parameters.OnMetadataUpdate += OnMetadataUpdate();
 
             (EntityId, var response) = await _client.DeclarePublisher(
                 _config.Reference,
@@ -160,15 +158,17 @@ namespace RabbitMQ.Stream.Client
 
             if (response.ResponseCode == ResponseCode.Ok)
             {
+                _client.AttachEventsToTheClient(OnConnectionClosed(), OnMetadataUpdate());
                 _status = EntityStatus.Open;
                 return;
             }
 
-            throw new CreateProducerException($"producer could not be created code: {response.ResponseCode}");
+            throw new CreateProducerException($"producer could not be created code: {response.ResponseCode}",
+                response.ResponseCode);
         }
 
         private Client.ConnectionCloseHandler OnConnectionClosed() =>
-            async reason =>
+            async (reason) =>
             {
                 _config.Pool.Remove(_client.ClientId);
                 await Shutdown(_config, true).ConfigureAwait(false);
@@ -182,23 +182,25 @@ namespace RabbitMQ.Stream.Client
             };
 
         private ClientParameters.MetadataUpdateHandler OnMetadataUpdate() =>
-            metaDataUpdate =>
+            async metaDataUpdate =>
             {
                 // the connection can handle different streams
                 // we need to check if the metadata update is for the stream
                 // where the producer is sending the messages else can ignore the update
                 if (metaDataUpdate.Stream != _config.Stream)
                     return;
+
+                _client.DetachEventsFromTheClient(OnConnectionClosed(), OnMetadataUpdate());
+
+                _config.Pool.RemoveProducerEntityFromStream(_client.ClientId, EntityId, _config.Stream);
+
                 // at this point the server has removed the producer from the list 
                 // and the DeletePublisher producer is not needed anymore (ignoreIfClosed = true)
                 // we call the Close to re-enter to the standard behavior
                 // ignoreIfClosed is an optimization to avoid to send the DeletePublisher
                 _config.MetadataHandler?.Invoke(metaDataUpdate);
-                Shutdown(_config, true).ConfigureAwait(false);
+                await Shutdown(_config, true).ConfigureAwait(false);
 
-                // remove the event since the producer is closed
-                // only if the stream is the valid
-                _client.Parameters.OnMetadataUpdate -= OnMetadataUpdate();
             };
 
         private bool IsFilteringEnabled => _config.Filter is { FilterValue: not null };
@@ -385,9 +387,8 @@ namespace RabbitMQ.Stream.Client
                 // in this case we reduce the waiting time
                 // the producer could be removed because of stream deleted 
                 // so it is not necessary to wait.
-                var closeResponse = await _client.DeletePublisher(EntityId, ignoreIfAlreadyDeleted)
-                    .WaitAsync(TimeSpan.FromSeconds(3))
-                    .ConfigureAwait(false);
+                var closeResponse =
+                    await _client.DeletePublisher(EntityId, ignoreIfAlreadyDeleted).ConfigureAwait(false);
                 return closeResponse.ResponseCode;
             }
             catch (Exception e)

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -4,13 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-/* Unmerged change from project 'RabbitMQ.Stream.Client(net7.0)'
-Before:
-using System.Diagnostics;
-using System.Linq;
-After:
-using System.Linq;
-*/
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -200,7 +193,6 @@ namespace RabbitMQ.Stream.Client
                 // ignoreIfClosed is an optimization to avoid to send the DeletePublisher
                 _config.MetadataHandler?.Invoke(metaDataUpdate);
                 await Shutdown(_config, true).ConfigureAwait(false);
-
             };
 
         private bool IsFilteringEnabled => _config.Filter is { FilterValue: not null };

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -151,7 +151,8 @@ namespace RabbitMQ.Stream.Client
 
             if (response.ResponseCode == ResponseCode.Ok)
             {
-                _client.AttachEventsToTheClient(OnConnectionClosed(), OnMetadataUpdate());
+                _client.ConnectionClosed += OnConnectionClosed();
+                _client.Parameters.OnMetadataUpdate += OnMetadataUpdate();
                 _status = EntityStatus.Open;
                 return;
             }
@@ -183,7 +184,8 @@ namespace RabbitMQ.Stream.Client
                 if (metaDataUpdate.Stream != _config.Stream)
                     return;
 
-                _client.DetachEventsFromTheClient(OnConnectionClosed(), OnMetadataUpdate());
+                _client.ConnectionClosed -= OnConnectionClosed();
+                _client.Parameters.OnMetadataUpdate -= OnMetadataUpdate();
 
                 _config.Pool.RemoveProducerEntityFromStream(_client.ClientId, EntityId, _config.Stream);
 

--- a/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
@@ -3,14 +3,6 @@
 // Copyright (c) 2017-2023 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
 using System.Collections.Concurrent;
-
-/* Unmerged change from project 'RabbitMQ.Stream.Client(net7.0)'
-Before:
-using System.Threading;
-using System.Threading.Tasks;
-After:
-using System.Threading.Tasks;
-*/
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -51,7 +43,7 @@ public abstract class ConsumerFactory : ReliableBase
             offsetSpec = new OffsetTypeOffset(_lastOffsetConsumed[_consumerConfig.Stream] + 1);
         }
 
-        var x = await _consumerConfig.StreamSystem.CreateRawConsumer(new RawConsumerConfig(_consumerConfig.Stream)
+        return await _consumerConfig.StreamSystem.CreateRawConsumer(new RawConsumerConfig(_consumerConfig.Stream)
         {
             ClientProvidedName = _consumerConfig.ClientProvidedName,
             Reference = _consumerConfig.Reference,
@@ -86,8 +78,6 @@ public abstract class ConsumerFactory : ReliableBase
                 }
             },
         }, BaseLogger).ConfigureAwait(false);
-
-        return x;
     }
 
     private async Task<IConsumer> SuperConsumer(bool boot)

--- a/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
@@ -57,7 +57,7 @@ public abstract class ConsumerFactory : ReliableBase
             {
                 if (closeReason == ConnectionClosedReason.Normal)
                 {
-                    BaseLogger.LogInformation("Reconnect is skipped. {Identity} is closed normally", ToString());
+                    BaseLogger.LogInformation("{Identity} is closed normally", ToString());
                     return;
                 }
 

--- a/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
+++ b/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace RabbitMQ.Stream.Client.Reliable;
+namespace RabbitMQ.Stream.Client.Reconnect;
 
 /// <summary>
 /// IReconnectStrategy is the interface to reconnect the TCP client
@@ -18,15 +18,15 @@ public interface IReconnectStrategy
     /// WhenDisconnected is raised when the TPC client
     /// is disconnected for some reason. 
     /// </summary>
-    /// <param name="connectionIdentifier">Additional connection info. Just for logging</param>
+    /// <param name="itemIdentifier">Additional connection info. Just for logging</param>
     /// <returns>if True the client will be reconnected else closed</returns>
-    ValueTask<bool> WhenDisconnected(string connectionIdentifier);
+    ValueTask<bool> WhenDisconnected(string itemIdentifier);
 
     /// <summary>
     /// It is raised when the TCP client is connected successfully 
     /// </summary>
-    /// <param name="connectionInfo">Additional connection info. Just for logging</param>
-    ValueTask WhenConnected(string connectionInfo);
+    /// <param name="itemIdentifier">Additional info. Just for logging</param>
+    ValueTask WhenConnected(string itemIdentifier);
 }
 
 /// <summary>
@@ -71,6 +71,47 @@ internal class BackOffReconnectStrategy : IReconnectStrategy
     {
         Tentatives = 1;
         _logger.LogInformation("{ConnectionIdentifier} reconnected successfully", connectionIdentifier);
+        return ValueTask.CompletedTask;
+    }
+}
+
+internal class ResourceAvailableBackOffReconnectStrategy : IReconnectStrategy
+{
+    private int Tentatives { get; set; } = 1;
+    private readonly ILogger _logger;
+
+    public ResourceAvailableBackOffReconnectStrategy(ILogger logger = null)
+    {
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    // reset the tentatives after a while 
+    // else the backoff will be too long
+    private void MaybeResetTentatives()
+    {
+        if (Tentatives > 4)
+        {
+            Tentatives = 1;
+        }
+    }
+
+    public async ValueTask<bool> WhenDisconnected(string resourceIdentifier)
+    {
+        Tentatives <<= 1;
+        _logger.LogInformation(
+            "{ConnectionIdentifier} resource not available, retry in {ReconnectionDelayMs} seconds",
+            resourceIdentifier,
+            Tentatives
+        );
+        await Task.Delay(TimeSpan.FromSeconds(Tentatives)).ConfigureAwait(false);
+        MaybeResetTentatives();
+        return Tentatives < 4;
+    }
+
+    public ValueTask WhenConnected(string resourceIdentifier)
+    {
+        Tentatives = 1;
+        _logger.LogInformation("{ResourceIdentifier} created successfully", resourceIdentifier);
         return ValueTask.CompletedTask;
     }
 }

--- a/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
+++ b/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
@@ -70,7 +70,7 @@ internal class BackOffReconnectStrategy : IReconnectStrategy
     public ValueTask WhenConnected(string connectionIdentifier)
     {
         Tentatives = 1;
-        _logger.LogInformation("{ConnectionIdentifier} reconnected successfully", connectionIdentifier);
+        _logger.LogInformation("{ConnectionIdentifier} connected successfully", connectionIdentifier);
         return ValueTask.CompletedTask;
     }
 }
@@ -111,7 +111,7 @@ internal class ResourceAvailableBackOffReconnectStrategy : IReconnectStrategy
     public ValueTask WhenConnected(string resourceIdentifier)
     {
         Tentatives = 1;
-        _logger.LogInformation("{ResourceIdentifier} created successfully", resourceIdentifier);
+        _logger.LogInformation("{ResourceIdentifier} is available", resourceIdentifier);
         return ValueTask.CompletedTask;
     }
 }

--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -343,7 +343,7 @@ public class Producer : ProducerFactory
 
     public override string ToString()
     {
-        return $"Producer reference: {_producerConfig.Reference}, stream: {_producerConfig.Stream} ";
+        return $"Producer stream: {_producerConfig.Stream}, client name: {_producerConfig.ClientProvidedName}";
     }
 
     /// <summary>

--- a/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
@@ -1,15 +1,6 @@
 ﻿// This source code is dual-licensed under the Apache License, version
 // 2.0, and the Mozilla Public License, version 2.0.
 // Copyright (c) 2017-2023 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
-
-
-/* Unmerged change from project 'RabbitMQ.Stream.Client(net7.0)'
-Before:
-using System.Threading;
-using System.Threading.Tasks;
-After:
-using System.Threading.Tasks;
-*/
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 

--- a/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
@@ -75,7 +75,7 @@ public abstract class ProducerFactory : ReliableBase
             {
                 if (closeReason == ConnectionClosedReason.Normal)
                 {
-                    BaseLogger.LogInformation("Reconnect is skipped. {Identity} is closed normally", ToString());
+                    BaseLogger.LogInformation("{Identity} is closed normally", ToString());
                     return;
                 }
 

--- a/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
@@ -6,12 +6,15 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using RabbitMQ.Stream.Client.Reconnect;
 
 namespace RabbitMQ.Stream.Client.Reliable;
 
 public record ReliableConfig
 {
     public IReconnectStrategy ReconnectStrategy { get; set; }
+    public IReconnectStrategy ResourceAvailableReconnectStrategy { get; set; }
+
     public StreamSystem StreamSystem { get; }
     public string Stream { get; }
 
@@ -29,69 +32,127 @@ public record ReliableConfig
     }
 }
 
+public enum ReliableEntityStatus
+{
+    Initialization,
+    Open,
+    Reconnecting,
+    Closed,
+}
+
 /// <summary>
 /// Base class for Reliable producer/ consumer
 /// With the term Entity we mean a Producer or a Consumer
 /// </summary>
 public abstract class ReliableBase
 {
-    protected readonly SemaphoreSlim SemaphoreSlim = new(1);
+    protected readonly SemaphoreSlim SemaphoreSlim = new(1, 1);
     private readonly object _lock = new();
-    protected bool _isOpen;
-    protected bool _inReconnection;
+    protected ReliableEntityStatus _status = ReliableEntityStatus.Initialization;
 
-    protected abstract ILogger BaseLogger { get; }
-
-    internal async Task Init(IReconnectStrategy reconnectStrategy)
+    protected void UpdateStatus(ReliableEntityStatus status)
     {
-        await Init(true, reconnectStrategy).ConfigureAwait(false);
+        lock (_lock)
+        {
+            _status = status;
+        }
     }
 
-    // <summary>
-    /// Init the reliable client
-    /// <param name="boot"> If it is the First boot for the reliable P/C </param>
-    /// <param name="reconnectStrategy">IReconnectStrategy</param>
-    /// Try to Init the Entity, if it fails, it will try to reconnect
-    /// only if the exception is a known exception
-    // </summary>
-    private async Task Init(bool boot, IReconnectStrategy reconnectStrategy)
+    protected bool CompareStatus(ReliableEntityStatus toTest)
+    {
+        lock (_lock)
+        {
+            return _status == toTest;
+        }
+    }
+
+    protected bool IsValidStatus()
+    {
+        lock (_lock)
+        {
+            return _status is ReliableEntityStatus.Open or ReliableEntityStatus.Reconnecting
+                or ReliableEntityStatus.Initialization;
+        }
+    }
+
+    protected abstract ILogger BaseLogger { get; }
+    private IReconnectStrategy _reconnectStrategy;
+    private IReconnectStrategy _resourceAvailableReconnectStrategy;
+
+    internal async Task Init(IReconnectStrategy reconnectStrategy,
+        IReconnectStrategy resourceAvailableReconnectStrategy)
+    {
+        _reconnectStrategy = reconnectStrategy;
+        _resourceAvailableReconnectStrategy = resourceAvailableReconnectStrategy;
+        await Init(true).ConfigureAwait(false);
+    }
+
+    private async Task MaybeInit(bool boot)
     {
         var reconnect = false;
-        await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
         try
         {
-            lock (_lock)
-            {
-                _isOpen = true;
-            }
-
             await CreateNewEntity(boot).ConfigureAwait(false);
+            // if the createNewEntity is successful we can set the status to Open
+            // else there are two ways:
+            // - the exception is a known exception and the client will try to reconnect
+            // - the exception is not a known exception and the client will throw the exception
+            UpdateStatus(ReliableEntityStatus.Open);
         }
-
         catch (Exception e)
         {
+            if (boot)
+            {
+                // if it is the first boot we don't need to reconnect
+                UpdateStatus(ReliableEntityStatus.Closed);
+                throw;
+            }
+
             reconnect = ClientExceptions.IsAKnownException(e);
+            if (e is CreateException { ResponseCode: ResponseCode.StreamNotAvailable })
+                BaseLogger.LogInformation("streamNotAvailable {Identity}", ToString());
+
             LogException(e);
             if (!reconnect)
             {
                 // We consider the client as closed
                 // since the exception is raised to the caller
-                lock (_lock)
-                {
-                    _isOpen = false;
-                }
-
+                UpdateStatus(ReliableEntityStatus.Closed);
                 throw;
             }
-        }
-        finally
-        {
-            SemaphoreSlim.Release();
         }
 
         if (reconnect)
         {
-            await TryToReconnect(reconnectStrategy).ConfigureAwait(false);
+            await MaybeReconnect().ConfigureAwait(false);
+        }
+    }
+
+    // <summary>
+    /// Init the reliable client
+    /// <param name="boot"> If it is the First boot for the reliable P/C </param>
+    // </summary>
+    private async Task Init(bool boot)
+    {
+        if (!boot && !IsValidStatus())
+        {
+            BaseLogger.LogInformation("{Identity} is already closed", ToString());
+            return;
+        }
+
+        // each time that the client is initialized, we need to reset the status
+        // if we hare here it means that the entity is not open for some reason like:
+        // first time initialization or reconnect due of a IsAKnownException
+        UpdateStatus(ReliableEntityStatus.Initialization);
+
+        await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await MaybeInit(boot).ConfigureAwait(false);
+        }
+        finally
+        {
+            SemaphoreSlim.Release();
         }
     }
 
@@ -102,34 +163,77 @@ public abstract class ReliableBase
     /// </summary>
     internal abstract Task CreateNewEntity(bool boot);
 
+    protected async Task<bool> CheckIfStreamIsAvailable(string stream, StreamSystem system)
+    {
+
+        await Task.Delay(Consts.RandomMid()).ConfigureAwait(false);
+        var exists = false;
+        var tryAgain = true;
+        while (tryAgain)
+        {
+            try
+            {
+                exists = await system.StreamExists(stream).ConfigureAwait(false);
+                await _resourceAvailableReconnectStrategy.WhenConnected(ToString()).ConfigureAwait(false);
+                break;
+            }
+            catch (Exception e)
+            {
+                tryAgain = await _resourceAvailableReconnectStrategy
+                    .WhenDisconnected($"Stream {stream} for {ToString()}. Error: {e.Message} ").ConfigureAwait(false);
+            }
+        }
+
+        if (!exists)
+        {
+            // In this case the stream doesn't exist anymore
+            // the  Entity is just closed.
+            BaseLogger.LogInformation(
+                "Meta data update stream: {StreamIdentifier}. The stream doesn't exist anymore {Identity} will be closed",
+                stream,
+                ToString()
+            );
+        }
+
+        return exists;
+    }
+
     // <summary>
     /// Try to reconnect to the broker
     /// Based on the retry strategy
-    /// <param name="reconnectStrategy"> The Strategy for the reconnection
-    /// by default it is exponential backoff.
-    /// It it possible to change implementing the IReconnectStrategy interface </param>
-    // </summary>
-    protected async Task TryToReconnect(IReconnectStrategy reconnectStrategy)
+// </summary>
+    protected async Task MaybeReconnect()
     {
-        _inReconnection = true;
-        try
+        var reconnect = await _reconnectStrategy.WhenDisconnected(ToString()).ConfigureAwait(false);
+        if (!reconnect)
         {
-            switch (await reconnectStrategy.WhenDisconnected(ToString()).ConfigureAwait(false) && IsOpen())
-            {
-                case true:
-                    BaseLogger.LogInformation("{Identity} is disconnected. Client will try reconnect", ToString());
-                    await Init(false, reconnectStrategy).ConfigureAwait(false);
-                    break;
-                case false:
-                    BaseLogger.LogInformation("{Identity} is asked to be closed", ToString());
-                    await Close().ConfigureAwait(false);
-                    break;
-            }
+            UpdateStatus(ReliableEntityStatus.Closed);
+            return;
         }
-        finally
+
+        switch (IsOpen())
         {
-            _inReconnection = false;
+            case true:
+                await TryToReconnect().ConfigureAwait(false);
+                break;
+            case false:
+                if (CompareStatus(ReliableEntityStatus.Reconnecting))
+                {
+                    BaseLogger.LogInformation("{Identity} is in Reconnecting", ToString());
+                }
+
+                break;
         }
+    }
+
+    /// <summary>
+    ///  Try to reconnect to the broker
+    /// </summary>
+    private async Task TryToReconnect()
+    {
+        UpdateStatus(ReliableEntityStatus.Reconnecting);
+        BaseLogger.LogInformation("{Identity} is disconnected. Client will try reconnect", ToString());
+        await MaybeInit(false).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -143,42 +247,13 @@ public abstract class ReliableBase
     /// and try to reconnect.
     /// (internal because it is needed for tests)
     /// </summary>
-    internal async Task HandleMetaDataMaybeReconnect(string stream, StreamSystem system)
-    {
-        // This sleep is needed. When a stream is deleted it takes sometime.
-        // The StreamExists/1 could return true even the stream doesn't exist anymore.
-        await Task.Delay(500).ConfigureAwait(false);
-        if (await system.StreamExists(stream).ConfigureAwait(false))
-        {
-            BaseLogger.LogInformation(
-                "Meta data update stream: {StreamIdentifier}. The stream still exists. Client: {Identity}",
-                stream,
-                ToString()
-            );
-            // Here we just close the producer connection
-            // the func TryToReconnect/0 will be called. 
-
-            await CloseEntity().ConfigureAwait(false);
-        }
-        else
-        {
-            // In this case the stream doesn't exist anymore
-            // the ReliableProducer is just closed.
-            BaseLogger.LogInformation("Meta data update stream: {StreamIdentifier}. {Identity} will be closed",
-                stream,
-                ToString()
-            );
-            await Close().ConfigureAwait(false);
-        }
-    }
-
     private void LogException(Exception exception)
     {
-        const string KnownExceptionTemplate = "{Identity} trying to reconnect due to exception";
+        const string KnownExceptionTemplate = "{Identity} trying to reconnect due to exception {Err}";
         const string UnknownExceptionTemplate = "{Identity} received an exception during initialization";
         if (ClientExceptions.IsAKnownException(exception))
         {
-            BaseLogger.LogError(exception, KnownExceptionTemplate, ToString());
+            BaseLogger.LogError(KnownExceptionTemplate, ToString(), exception.Message);
         }
         else
         {
@@ -195,6 +270,30 @@ public abstract class ReliableBase
     /// </summary>
     protected abstract Task CloseEntity();
 
+    internal async Task OnEntityClosed(StreamSystem system, string stream)
+    {
+        var streamExists = false;
+        await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            streamExists = await CheckIfStreamIsAvailable(stream, system)
+                .ConfigureAwait(false);
+            if (streamExists)
+            {
+                await MaybeReconnect().ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            SemaphoreSlim.Release();
+        }
+
+        if (!streamExists)
+        {
+            await Close().ConfigureAwait(false);
+        }
+    }
+
     // <summary>
     /// Close the Reliable(Producer/Consumer) instance.
     // </summary>
@@ -204,7 +303,8 @@ public abstract class ReliableBase
     {
         lock (_lock)
         {
-            return _isOpen;
+            return _status is ReliableEntityStatus.Open or ReliableEntityStatus.Reconnecting
+                or ReliableEntityStatus.Initialization;
         }
     }
 }

--- a/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
@@ -109,8 +109,6 @@ public abstract class ReliableBase
             }
 
             reconnect = ClientExceptions.IsAKnownException(e);
-            if (e is CreateException { ResponseCode: ResponseCode.StreamNotAvailable })
-                BaseLogger.LogInformation("streamNotAvailable {Identity}", ToString());
 
             LogException(e);
             if (!reconnect)
@@ -174,7 +172,7 @@ public abstract class ReliableBase
             try
             {
                 exists = await system.StreamExists(stream).ConfigureAwait(false);
-                await _resourceAvailableReconnectStrategy.WhenConnected(ToString()).ConfigureAwait(false);
+                await _resourceAvailableReconnectStrategy.WhenConnected(stream).ConfigureAwait(false);
                 break;
             }
             catch (Exception e)
@@ -232,7 +230,6 @@ public abstract class ReliableBase
     private async Task TryToReconnect()
     {
         UpdateStatus(ReliableEntityStatus.Reconnecting);
-        BaseLogger.LogInformation("{Identity} is disconnected. Client will try reconnect", ToString());
         await MaybeInit(false).ConfigureAwait(false);
     }
 

--- a/RabbitMQ.Stream.Client/RoutingClient.cs
+++ b/RabbitMQ.Stream.Client/RoutingClient.cs
@@ -156,7 +156,7 @@ namespace RabbitMQ.Stream.Client
         public static async Task<IClient> LookupLeaderConnection(ClientParameters clientParameters,
             StreamInfo metaDataInfo, ConnectionsPool pool, ILogger logger = null)
         {
-            return await pool.GetOrCreateClient(metaDataInfo.Leader.ToString(), metaDataInfo.Stream,
+            return await pool.GetOrCreateClient(metaDataInfo.Leader.ToString(),
                 async () =>
                     await LookupConnection(clientParameters, metaDataInfo.Leader, MaxAttempts(metaDataInfo), logger)
                         .ConfigureAwait(false)).ConfigureAwait(false);
@@ -177,7 +177,7 @@ namespace RabbitMQ.Stream.Client
             {
                 try
                 {
-                    return await pool.GetOrCreateClient(broker.ToString(), metaDataInfo.Stream,
+                    return await pool.GetOrCreateClient(broker.ToString(),
                         async () =>
                             await LookupConnection(clientParameters, broker, MaxAttempts(metaDataInfo), logger)
                                 .ConfigureAwait(false)).ConfigureAwait(false);

--- a/Tests/ClientTests.cs
+++ b/Tests/ClientTests.cs
@@ -78,7 +78,11 @@ namespace Tests
             var stream = Guid.NewGuid().ToString();
             var testPassed = new TaskCompletionSource<MetaDataUpdate>();
             var clientParameters = new ClientParameters();
-            clientParameters.OnMetadataUpdate += (update) => { testPassed.SetResult(update); };
+            clientParameters.OnMetadataUpdate += async (update) =>
+            {
+                testPassed.SetResult(update);
+                await Task.CompletedTask;
+            };
 
             var client = await Client.Create(clientParameters);
             await client.CreateStream(stream, new Dictionary<string, string>());

--- a/Tests/ConnectionsPoolTests.cs
+++ b/Tests/ConnectionsPoolTests.cs
@@ -279,10 +279,10 @@ namespace Tests
             var pool = new ConnectionsPool(0, 2);
             var metaDataInfo = await client.QueryMetadata(new[] { Stream1, Stream2 });
             var p1 = await RawProducer.Create(client.Parameters, new RawProducerConfig(Stream1) { Pool = pool },
-            metaDataInfo.StreamInfos[Stream1]);
+                metaDataInfo.StreamInfos[Stream1]);
 
             var p2 = await RawProducer.Create(client.Parameters, new RawProducerConfig(Stream2) { Pool = pool },
-            metaDataInfo.StreamInfos[Stream2]);
+                metaDataInfo.StreamInfos[Stream2]);
 
             Assert.Equal(1, pool.ConnectionsCount);
 
@@ -323,7 +323,7 @@ namespace Tests
                 metaDataInfo.StreamInfos[Stream1]);
 
             var p2 = await RawProducer.Create(client.Parameters, new RawProducerConfig(Stream2) { Pool = pool },
-            metaDataInfo.StreamInfos[Stream2]);
+                metaDataInfo.StreamInfos[Stream2]);
             // one for the producer and one for the consumer
             Assert.Equal(2, pool.ConnectionsCount);
 
@@ -599,110 +599,53 @@ namespace Tests
         }
 
         /// <summary>
-        /// In this test we create and destroy producers and consumers in multi thread
-        /// The pool should be consistent at the end
-        /// </summary>
-        // [Fact]
-        // public async void TheProducerConsumerPoolShouldBeConsistentInMultiThreadCreateDestroy()
-        // {
-        //     var client = await Client.Create(new ClientParameters() { });
-        //     const string Stream1 = "pool_test_stream_1_multi_thread_producer_consumer_cd";
-        //     await client.CreateStream(Stream1, new Dictionary<string, string>());
-        //     const int IdsPerConnection = 17;
-        //     var pool = new ConnectionsPool(0, IdsPerConnection);
-        //     var metaDataInfo = await client.QueryMetadata(new[] { Stream1 });
-        //
-        //     var tasksP = new List<Task>();
-        //     for (var i = 0; i < (IdsPerConnection * 2); i++)
-        //     {
-        //         tasksP.Add(Task.Run(async () =>
-        //         {
-        //             var p = await RawProducer.Create(client.Parameters, new RawProducerConfig(Stream1) { Pool = pool },
-        //                 metaDataInfo.StreamInfos[Stream1]);
-        //             await p.Close();
-        //         }));
-        //     }
-        //
-        //     for (var i = 0; i < (IdsPerConnection * 2); i++)
-        //     {
-        //         tasksP.Add(Task.Run(async () =>
-        //         {
-        //             var c = await RawConsumer.Create(client.Parameters, new RawConsumerConfig(Stream1) { Pool = pool },
-        //                 metaDataInfo.StreamInfos[Stream1]);
-        //             await c.Close();
-        //         }));
-        //     }
-        //
-        //     await Task.WhenAll(tasksP);
-        //
-        //     SystemUtils.WaitUntil(() => pool.ConnectionsCount == 0);
-        //     Assert.Equal(0, pool.ConnectionsCount);
-        //     Assert.Equal(0, pool.ActiveIdsCount);
-        //     await client.DeleteStream(Stream1);
-        //     await client.Close("byte");
-        // }
-
-        /// <summary>
         /// The pool has 3 ids per connection.
         /// Here we test the metadata update event. One connection can handle different
         /// Streams so we need to be sure the pool is consistent when the metadata update handler is raised.
         /// By default the metadata update removes the consumer from the server so we need to remove the consumers
         /// from the pool.
         /// </summary>
-        // [Fact]
-        // public async void TheConsumersPoolShouldBeConsistentWhenAStreamIsDeleted()
-        // {
-        //     var client = await Client.Create(new ClientParameters() { });
-        //     const string Stream1 = "pool_test_stream_1_delete_consumer";
-        //     const string Stream2 = "pool_test_stream_2_delete_consumer";
-        //     await client.CreateStream(Stream1, new Dictionary<string, string>());
-        //     await client.CreateStream(Stream2, new Dictionary<string, string>());
-        //     const int IdsPerConnection = 3;
-        //     var pool = new ConnectionsPool(0, IdsPerConnection);
-        //     var metaDataInfo = await client.QueryMetadata(new[] { Stream1, Stream2 });
-        //     var iConsumers = new ConcurrentDictionary<string, IConsumer>();
-        //
-        //     var tasksP = new List<Task>();
-        //     for (var i = 0; i < (IdsPerConnection * 2); i++)
-        //     {
-        //         tasksP.Add(Task.Run(async () =>
-        //         {
-        //             var p = await RawConsumer.Create(client.Parameters, new RawConsumerConfig(Stream1) { Pool = pool, },
-        //                 metaDataInfo.StreamInfos[Stream1]);
-        //             iConsumers.TryAdd(Guid.NewGuid().ToString(), p);
-        //         }));
-        //
-        //         tasksP.Add(Task.Run(async () =>
-        //         {
-        //             var p2 = await RawConsumer.Create(client.Parameters, new RawConsumerConfig(Stream2) { Pool = pool, },
-        //                 metaDataInfo.StreamInfos[Stream2]);
-        //             iConsumers.TryAdd(Guid.NewGuid().ToString(), p2);
-        //         }));
-        //     }
-        //
-        //     await Task.WhenAll(tasksP);
-        //
-        //     // Here we have 4 connections ( IdsPerConnection * 2)
-        //     // one per stream
-        //     Assert.Equal(4, pool.ConnectionsCount);
-        //     await client.DeleteStream(Stream1);
-        //     // removed one stream so we should not have active ids for this stream
-        //     // we don't check the connection pool since the connections can be random 
-        //     // so not sure how many connection can we have here. But it doesn't matter since we check the active ids
-        //     SystemUtils.WaitUntil(() => pool.ActiveIdsCountForStream(Stream1) == 0);
-        //     Assert.Equal(IdsPerConnection * 2, pool.ActiveIdsCount);
-        //
-        //     await client.DeleteStream(Stream2);
-        //     // here we can check the pool. however the connections  are distributed here must be 0
-        //     SystemUtils.WaitUntil(() => pool.ConnectionsCount == 0);
-        //     // no active ids for the stream2 since we removed the stream
-        //     Assert.Equal(0, pool.ActiveIdsCountForStream(Stream2));
-        //     Assert.Equal(0, pool.ActiveIdsCount);
-        //
-        //     // no active consumers to the internal consumers list
-        //     iConsumers.Values.ToList().ForEach(
-        //         x => Assert.Empty(ConsumersIdsPerConnection(x)));
-        // }
+        [Fact]
+        public async void TheConsumersPoolShouldBeConsistentWhenAStreamIsDeleted()
+        {
+            var client = await Client.Create(new ClientParameters() { });
+            const string Stream1 = "pool_test_stream_1_delete_consumer";
+            const string Stream2 = "pool_test_stream_2_delete_consumer";
+            await client.CreateStream(Stream1, new Dictionary<string, string>());
+            await client.CreateStream(Stream2, new Dictionary<string, string>());
+            const int IdsPerConnection = 3;
+            var pool = new ConnectionsPool(0, IdsPerConnection);
+            var metaDataInfo = await client.QueryMetadata(new[] { Stream1, Stream2 });
+            var iConsumers = new ConcurrentDictionary<string, IConsumer>();
+
+            for (var i = 0; i < (IdsPerConnection * 2); i++)
+            {
+                var p = await RawConsumer.Create(client.Parameters, new RawConsumerConfig(Stream1) { Pool = pool, },
+                    metaDataInfo.StreamInfos[Stream1]);
+                iConsumers.TryAdd(Guid.NewGuid().ToString(), p);
+
+                var p2 = await RawConsumer.Create(client.Parameters, new RawConsumerConfig(Stream2) { Pool = pool, },
+                    metaDataInfo.StreamInfos[Stream2]);
+                iConsumers.TryAdd(Guid.NewGuid().ToString(), p2);
+            }
+
+            // Here we have 4 connections ( IdsPerConnection * 2)
+            // one per stream
+            Assert.Equal(4, pool.ConnectionsCount);
+            await client.DeleteStream(Stream1);
+            // removed one stream so we should not have active ids for this stream
+            // we don't check the connection pool since the connections can be random 
+            // so not sure how many connection can we have here. But it doesn't matter since we check the active ids
+
+            await client.DeleteStream(Stream2);
+            // here we can check the pool. however the connections  are distributed here must be 0
+            SystemUtils.WaitUntil(() => pool.ConnectionsCount == 0);
+            // no active ids for the stream2 since we removed the stream
+
+            // no active consumers to the internal consumers list
+            iConsumers.Values.ToList().ForEach(
+                x => Assert.Empty(ConsumersIdsPerConnection(x)));
+        }
 
         /// <summary>
         /// The pool has 3 ids per connection.
@@ -741,113 +684,59 @@ namespace Tests
             // removed one stream so we should not have active ids for this stream
             // we don't check the connection pool since the connections can be random 
             // so not sure how many connection can we have here. But it doesn't matter since we check the active ids
-            // SystemUtils.WaitUntil(() => pool.ActiveIdsCountForStream(Stream1) == 0);
-            // Assert.Equal(IdsPerConnection * 2, pool.ActiveIdsCount);
 
             await client.DeleteStream(Stream2);
             // here we can check the pool. however the connections  are distributed here must be 0
             SystemUtils.WaitUntil(() => pool.ConnectionsCount == 0);
             // no active ids for the stream2 since we removed the stream
-            // Assert.Equal(0, pool.ActiveIdsCountForStream(Stream2));
-            // Assert.Equal(0, pool.ActiveIdsCount);
 
             // no active consumers to the internal producers list
             iProducers.Values.ToList().ForEach(
                 x => Assert.Empty(ProducersIdsPerConnection(x)));
         }
 
-        //
-        /// <summary>
-        /// The pool has 13 ids per connection.
-        /// The pool should be consistent in multi thread
-        /// Id we create (13* 2) consumers in multi thread
-        /// the pool must contain only two connections
-        /// Same when we close the consumers in multi thread the pool must be empty at the end
-        /// </summary>
-        // [Fact]
-        // public async void TheConsumerPoolShouldBeConsistentInMultiThread()
-        // {
-        //     var client = await Client.Create(new ClientParameters() { });
-        //     const string Stream1 = "pool_test_stream_1_multi_thread_consumer";
-        //     await client.CreateStream(Stream1, new Dictionary<string, string>());
-        //     const int IdsPerConnection = 13;
-        //     var pool = new ConnectionsPool(0, IdsPerConnection);
-        //     var metaDataInfo = await client.QueryMetadata(new[] { Stream1 });
-        //     var consumersList = new ConcurrentDictionary<string, IConsumer>();
-        //
-        //     var tasksP = new List<Task>();
-        //     for (var i = 0; i < (IdsPerConnection * 4); i++)
-        //     {
-        //         tasksP.Add(Task.Run(async () =>
-        //         {
-        //             consumersList.TryAdd(Guid.NewGuid().ToString(),
-        //                 await RawConsumer.Create(client.Parameters,
-        //                     new RawConsumerConfig(Stream1) { Pool = pool },
-        //                     metaDataInfo.StreamInfos[Stream1]));
-        //         }));
-        //     }
-        //
-        //     await Task.WhenAll(tasksP);
-        //
-        //     Assert.Equal(4, pool.ConnectionsCount);
-        //     Assert.Equal(IdsPerConnection * 4, pool.ActiveIdsCountForStream(Stream1));
-        //     Assert.Equal(IdsPerConnection * 4, pool.ActiveIdsCount);
-        //
-        //     var tasksC = new List<Task>();
-        //     consumersList.Values.ToList().ForEach(c => tasksC.Add(Task.Run(async () => { await c.Close(); })));
-        //
-        //     // called twice should not raise any error due of the _poolSemaphoreSlim in the client
-        //     consumersList.Values.ToList().ForEach(c => tasksC.Add(Task.Run(async () => { await c.Close(); })));
-        //     await Task.WhenAll(tasksC);
-        //
-        //     SystemUtils.WaitUntil(() => pool.ConnectionsCount == 0);
-        //     Assert.Equal(0, pool.ActiveIdsCount);
-        //     Assert.Equal(0, pool.ConnectionsCount);
-        //     await client.DeleteStream(Stream1);
-        //     await client.Close("byte");
-        // }
-
         /// <summary>
         /// Validate the consistency of the client lists consumers and publishers with
         /// the pool elements.
         /// </summary>
-        // [Fact]
-        // public async void TheConsumerPoolShouldBeConsistentWhenTheConnectionIsClosed()
-        // {
-        //     var clientProvidedName = Guid.NewGuid().ToString();
-        //     var client = await Client.Create(new ClientParameters() { ClientProvidedName = clientProvidedName });
-        //     const string Stream1 = "pool_test_stream_1_test_connection_closed";
-        //     const string Stream2 = "pool_test_stream_2_test_connection_closed";
-        //     await client.CreateStream(Stream1, new Dictionary<string, string>());
-        //     await client.CreateStream(Stream2, new Dictionary<string, string>());
-        //     const int IdsPerConnection = 2;
-        //     var pool = new ConnectionsPool(0, IdsPerConnection);
-        //     var metaDataInfo = await client.QueryMetadata(new[] { Stream1, Stream2 });
-        //
-        //     var c1 = await RawConsumer.Create(client.Parameters,
-        //         new RawConsumerConfig(Stream1) { Pool = pool },
-        //         metaDataInfo.StreamInfos[Stream1]);
-        //
-        //     var c2 = await RawConsumer.Create(client.Parameters,
-        //         new RawConsumerConfig(Stream2) { Pool = pool },
-        //         metaDataInfo.StreamInfos[Stream2]);
-        //
-        //     Assert.Equal(1, pool.ConnectionsCount);
-        //     SystemUtils.WaitUntil(() => SystemUtils.HttpKillConnections(clientProvidedName).Result == 2);
-        //     SystemUtils.WaitUntil(() => pool.ConnectionsCount == 0);
-        //     Assert.Equal(0, pool.ConnectionsCount);
-        //     Assert.Equal(0, pool.ActiveIdsCount);
-        //     Assert.Equal(0, pool.ActiveIdsCountForStream(Stream1));
-        //     Assert.Equal(0, pool.ActiveIdsCountForStream(Stream2));
-        //     SystemUtils.Wait(); // the event close is raised in another thread so we need to wait a bit to be sure the event is raised
-        //     Assert.Empty(ConsumersIdsPerConnection(c1).ToList());
-        //     Assert.Empty(ConsumersIdsPerConnection(c2).ToList());
-        //
-        //     client = await Client.Create(new ClientParameters());
-        //     await client.DeleteStream(Stream1);
-        //     await client.DeleteStream(Stream2);
-        //     await client.Close("bye");
-        // }
+        [Fact]
+        public async void ThePoolShouldBeConsistentWhenTheConnectionIsClosed()
+        {
+            var clientProvidedName = Guid.NewGuid().ToString();
+            var client = await Client.Create(new ClientParameters() { ClientProvidedName = clientProvidedName });
+            const string Stream1 = "pool_test_stream_1_test_connection_closed";
+            const string Stream2 = "pool_test_stream_2_test_connection_closed";
+            await client.CreateStream(Stream1, new Dictionary<string, string>());
+            await client.CreateStream(Stream2, new Dictionary<string, string>());
+            const int IdsPerConnection = 3;
+            var pool = new ConnectionsPool(0, IdsPerConnection);
+            var metaDataInfo = await client.QueryMetadata(new[] { Stream1, Stream2 });
+
+            var c1 = await RawConsumer.Create(client.Parameters,
+                new RawConsumerConfig(Stream1) { Pool = pool },
+                metaDataInfo.StreamInfos[Stream1]);
+
+            var c2 = await RawConsumer.Create(client.Parameters,
+                new RawConsumerConfig(Stream2) { Pool = pool },
+                metaDataInfo.StreamInfos[Stream2]);
+
+            var p1 = await RawProducer.Create(client.Parameters, new RawProducerConfig(Stream2) { Pool = pool },
+                metaDataInfo.StreamInfos[Stream2]);
+
+            Assert.Equal(1, pool.ConnectionsCount);
+            SystemUtils.WaitUntil(() => SystemUtils.HttpKillConnections(clientProvidedName).Result == 2);
+            SystemUtils.WaitUntil(() => pool.ConnectionsCount == 0);
+            Assert.Equal(0, pool.ConnectionsCount);
+            SystemUtils.WaitUntil(() => ConsumersIdsPerConnection(c1).ToList().Count == 0);
+            SystemUtils.WaitUntil(() => ConsumersIdsPerConnection(c2).ToList().Count == 0);
+            SystemUtils.WaitUntil(() => ProducersIdsPerConnection(p1).ToList().Count == 0);
+
+            client = await Client.Create(new ClientParameters());
+            await client.DeleteStream(Stream1);
+            await client.DeleteStream(Stream2);
+            await client.Close("bye");
+        }
+
         [Fact]
         public async void ValidatePool()
         {

--- a/Tests/PermissionTests.cs
+++ b/Tests/PermissionTests.cs
@@ -40,6 +40,14 @@ namespace Tests
                 }
             );
 
+            await Assert.ThrowsAsync<CreateProducerException>(
+                async () =>
+                {
+                    await Producer.Create(
+                        new ProducerConfig(system, stream));
+                }
+            );
+
             Producer producer = null;
             try
             {

--- a/Tests/RawConsumerSystemTests.cs
+++ b/Tests/RawConsumerSystemTests.cs
@@ -603,6 +603,7 @@ namespace Tests
             var system = await StreamSystem.Create(config);
             await system.CreateStream(new StreamSpec(stream));
             var testPassed = new TaskCompletionSource<bool>();
+
             var rawConsumer = await system.CreateRawConsumer(
                 new RawConsumerConfig(stream)
                 {
@@ -613,11 +614,14 @@ namespace Tests
                         {
                             testPassed.SetResult(true);
                         }
+
+                        return Task.CompletedTask;
                     }
                 });
             SystemUtils.Wait();
             await system.DeleteStream(stream);
             new Utils<bool>(testOutputHelper).WaitUntilTaskCompletes(testPassed);
+            Assert.False(((RawConsumer)rawConsumer).IsOpen());
             await rawConsumer.Close();
             await system.Close();
         }

--- a/Tests/RawProducerSystemTests.cs
+++ b/Tests/RawProducerSystemTests.cs
@@ -246,11 +246,14 @@ namespace Tests
                         {
                             testPassed.SetResult(true);
                         }
+
+                        return Task.CompletedTask;
                     }
                 });
             SystemUtils.Wait();
             await system.DeleteStream(stream);
             new Utils<bool>(testOutputHelper).WaitUntilTaskCompletes(testPassed);
+            Assert.False(((RawProducer)rawProducer).IsOpen());
             await rawProducer.Close();
             await system.Close();
         }

--- a/Tests/UnitTests.cs
+++ b/Tests/UnitTests.cs
@@ -26,9 +26,19 @@ namespace Tests
 
         public string ClientId { get; init; }
 
+        public IDictionary<byte, (string, (Action<ReadOnlyMemory<ulong>>, Action<(ulong, ResponseCode)[]>))> Publishers
+        {
+            get;
+        }
+
+        public IDictionary<byte, (string, ConsumerEvents)> Consumers { get; }
+
         public FakeClient(ClientParameters clientParameters)
         {
             Parameters = clientParameters;
+            Publishers =
+                new Dictionary<byte, (string, (Action<ReadOnlyMemory<ulong>>, Action<(ulong, ResponseCode)[]>))>();
+            Consumers = new Dictionary<byte, (string, ConsumerEvents)>();
             ClientId = Guid.NewGuid().ToString();
         }
     }
@@ -154,7 +164,8 @@ namespace Tests
             // run more than one time just to be sure to use all the IP with random
             for (var i = 0; i < 4; i++)
             {
-                var client = RoutingHelper<LoadBalancerRouting>.LookupLeaderConnection(clientParameters, metaDataInfo, new ConnectionsPool(1, 1));
+                var client = RoutingHelper<LoadBalancerRouting>.LookupLeaderConnection(clientParameters, metaDataInfo,
+                    new ConnectionsPool(1, 1));
                 Assert.Equal("node2", client.Result.ConnectionProperties["advertised_host"]);
                 Assert.Equal("5552", client.Result.ConnectionProperties["advertised_port"]);
             }
@@ -170,7 +181,8 @@ namespace Tests
             // run more than one time just to be sure to use all the IP with random
             for (var i = 0; i < 4; i++)
             {
-                var client = RoutingHelper<LoadBalancerRouting>.LookupLeaderConnection(clientParameters, metaDataInfo, new ConnectionsPool(1, 1));
+                var client = RoutingHelper<LoadBalancerRouting>.LookupLeaderConnection(clientParameters, metaDataInfo,
+                    new ConnectionsPool(1, 1));
                 Assert.Equal("node2", client.Result.ConnectionProperties["advertised_host"]);
                 Assert.Equal("5552", client.Result.ConnectionProperties["advertised_port"]);
             }

--- a/docs/Documentation/RawClasses.cs
+++ b/docs/Documentation/RawClasses.cs
@@ -25,6 +25,7 @@ public class RawClasses
                 MetadataHandler = update => // <3>
                 {
                     Console.WriteLine($"Metadata Stream updated: {update.Stream}");
+                    return Task.CompletedTask;
                 },
                 ConfirmHandler = confirmation => // <4>
                 {

--- a/kubernetes/stream_cluster.yaml
+++ b/kubernetes/stream_cluster.yaml
@@ -7,10 +7,10 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: tls
-  namespace: stream-clients-test
+  namespace: stream-clients-test-1
 spec:
   replicas: 3
-  image: rabbitmq:3.12.6-management
+  image: rabbitmq:3.13-rc-management
   service:
     type: LoadBalancer
   tls:


### PR DESCRIPTION
* Part of https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/336

* Improve the disconnection message. It is possible to understand if it is a normal disconnection or an unexpected.
* Remove the Active Items from the connection pool and use the Publishers and Consumers client list directly to check the pool size
* Refactor the Factory Classes. Remove code duplication in case of metadata update and connection closed. See ReliableBase.OnEntityClosed
* Handle streamNotAvailable error. In this case the client will try to reconnect the entity
* Fix the events attach to the RawConsumer and RawProducer. The events are attached only if the ResponseCode is OK
* Detach the events once the entity receives the disconnection or metadata update. In that case, the entity is closed
* Introduce ReliableEntityStatus like a state machine to understand the status of Producer and Consumer classes
* Add ResourceAvailableReconnectStrategy interface to Handle the retry in case testing in a stream exists. See ReliableBase CheckIfStreamIsAvailable
* Change the  MetadataHandler to Func<MetaDataUpdate, Task> to be like the other methods
* Producer and Consumer classes fail fast during the first initialization. The user is aware of what is happening. The reconnect part occurs only after the first boot.



How to test
----
- Setup a cluster. I use:
```
git clone git@github.com:rabbitmq/rabbitmq-stream-go-client.git .
make rabbitmq-ha-proxy 
```

```
/etc/hosts
127.0.0.1 node0
127.0.0.1 node1
127.0.0.1 node2
```

- execute a script with multiple consumers and producers:
I use https://gist.github.com/Gsantomaggio/f6a091076e498d88ecfe827c2b165dad


- restart the docker nodes and see if the client will survive to the restart