### PR TITLE
Improve the super stream reconnection

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -843,6 +843,13 @@ namespace RabbitMQ.Stream.Client
         {
             var streams = new[] { stream };
             var response = await QueryMetadata(streams).ConfigureAwait(false);
+            if (response.StreamInfos is { Count: >= 1 } &&
+                response.StreamInfos[stream].ResponseCode == ResponseCode.StreamNotAvailable)
+            {
+
+                ClientExceptions.MaybeThrowException(ResponseCode.StreamNotAvailable, stream);
+            }
+
             return response.StreamInfos is { Count: >= 1 } &&
                    response.StreamInfos[stream].ResponseCode == ResponseCode.Ok;
         }

--- a/RabbitMQ.Stream.Client/ClientExceptions.cs
+++ b/RabbitMQ.Stream.Client/ClientExceptions.cs
@@ -30,12 +30,15 @@ namespace RabbitMQ.Stream.Client
             if (exception is AggregateException aggregateException)
             {
                 var x = aggregateException.InnerExceptions.Select(x =>
-                    x.GetType() == typeof(SocketException) || x.GetType() == typeof(TimeoutException) ||
-                    x.GetType() == typeof(LeaderNotFoundException) || x.GetType() == typeof(InvalidOperationException));
+                    x.GetType() == typeof(SocketException) ||
+                    x.GetType() == typeof(TimeoutException) ||
+                    x.GetType() == typeof(LeaderNotFoundException) ||
+                    x.GetType() == typeof(OperationCanceledException) ||
+                    x.GetType() == typeof(InvalidOperationException));
                 return x.Any();
             }
 
-            return exception is (SocketException or TimeoutException or LeaderNotFoundException or InvalidOperationException) ||
+            return exception is (SocketException or TimeoutException or LeaderNotFoundException or InvalidOperationException or OperationCanceledException) ||
                    IsStreamNotAvailable(exception);
         }
 

--- a/RabbitMQ.Stream.Client/ConnectionsPool.cs
+++ b/RabbitMQ.Stream.Client/ConnectionsPool.cs
@@ -154,6 +154,16 @@ public class ConnectionsPool
                 // TODO: we can improve this by getting the connection with the less active items
                 var connectionItem = Connections.Values.First(x => x.BrokerInfo == brokerInfo && x.Available);
                 connectionItem.LastUsed = DateTime.UtcNow;
+                if ((Client)(connectionItem.Client) is not {IsClosed: true}) return connectionItem.Client;
+              
+                // the connection is closed
+                // let's remove it from the pool
+                Connections.TryRemove(connectionItem.Client.ClientId, out _);
+                // let's create a new one
+                connectionItem = new ConnectionItem(brokerInfo, _idsPerConnection, await createClient().ConfigureAwait(false));
+                Connections.TryAdd(connectionItem.Client.ClientId, connectionItem);
+
+
                 return connectionItem.Client;
             }
 

--- a/RabbitMQ.Stream.Client/ConnectionsPool.cs
+++ b/RabbitMQ.Stream.Client/ConnectionsPool.cs
@@ -154,15 +154,16 @@ public class ConnectionsPool
                 // TODO: we can improve this by getting the connection with the less active items
                 var connectionItem = Connections.Values.First(x => x.BrokerInfo == brokerInfo && x.Available);
                 connectionItem.LastUsed = DateTime.UtcNow;
-                if ((Client)(connectionItem.Client) is not {IsClosed: true}) return connectionItem.Client;
-              
+
+                if (connectionItem.Client is not { IsClosed: true })
+                    return connectionItem.Client;
+
                 // the connection is closed
                 // let's remove it from the pool
                 Connections.TryRemove(connectionItem.Client.ClientId, out _);
                 // let's create a new one
                 connectionItem = new ConnectionItem(brokerInfo, _idsPerConnection, await createClient().ConfigureAwait(false));
                 Connections.TryAdd(connectionItem.Client.ClientId, connectionItem);
-
 
                 return connectionItem.Client;
             }
@@ -184,7 +185,6 @@ public class ConnectionsPool
             _semaphoreSlim.Release();
         }
     }
-
     public void Remove(string clientId)
     {
         _semaphoreSlim.Wait();

--- a/RabbitMQ.Stream.Client/IClient.cs
+++ b/RabbitMQ.Stream.Client/IClient.cs
@@ -27,5 +27,7 @@ namespace RabbitMQ.Stream.Client
 
         IDictionary<byte, (string, (Action<ReadOnlyMemory<ulong>>, Action<(ulong, ResponseCode)[]>))> Publishers { get; }
         IDictionary<byte, (string, ConsumerEvents)> Consumers { get; }
+
+        public bool IsClosed { get; }
     }
 }

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -42,8 +42,6 @@ public record IConsumerConfig : EntityCommonConfig, INamedEntity
 
     public string Reference { get; set; }
 
-    public Func<string, Task> ConnectionClosedHandler { get; set; }
-
     public ConsumerFilter ConsumerFilter { get; set; } = null;
 
     // InitialCredits is the initial credits to be used for the consumer.

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -7,6 +7,11 @@ using System.Threading.Tasks;
 
 namespace RabbitMQ.Stream.Client;
 
+public interface ISuperStreamConsumer : IConsumer
+{
+    public Task ReconnectPartition(StreamInfo streamInfo);
+}
+
 public interface IConsumer : IClosable
 {
     public Task StoreOffset(ulong offset);

--- a/RabbitMQ.Stream.Client/IProducer.cs
+++ b/RabbitMQ.Stream.Client/IProducer.cs
@@ -8,6 +8,10 @@ using System.Threading.Tasks;
 
 namespace RabbitMQ.Stream.Client;
 
+public interface ISuperStreamProducer : IProducer
+{
+    public Task ReconnectPartition(StreamInfo streamInfo);
+}
 // <summary>
 // Producer interface for sending messages to a stream.
 // There are different types of producers:
@@ -83,7 +87,6 @@ public record ProducerFilter
 
 public record IProducerConfig : EntityCommonConfig, INamedEntity
 {
-
     public string Reference { get; set; }
     public int MaxInFlight { get; set; } = 1_000;
     public string ClientProvidedName { get; set; } = "dotnet-stream-raw-producer";

--- a/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
@@ -335,8 +335,6 @@ RabbitMQ.Stream.Client.IConsumer.StoreOffset(ulong offset) -> System.Threading.T
 RabbitMQ.Stream.Client.IConsumerConfig
 RabbitMQ.Stream.Client.IConsumerConfig.ClientProvidedName.get -> string
 RabbitMQ.Stream.Client.IConsumerConfig.ClientProvidedName.set -> void
-RabbitMQ.Stream.Client.IConsumerConfig.ConnectionClosedHandler.get -> System.Func<string, System.Threading.Tasks.Task>
-RabbitMQ.Stream.Client.IConsumerConfig.ConnectionClosedHandler.set -> void
 RabbitMQ.Stream.Client.IConsumerConfig.ConsumerUpdateListener.get -> System.Func<string, string, bool, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IOffsetType>>
 RabbitMQ.Stream.Client.IConsumerConfig.ConsumerUpdateListener.set -> void
 RabbitMQ.Stream.Client.IConsumerConfig.IsSingleActiveConsumer.get -> bool

--- a/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
@@ -720,9 +720,7 @@ RabbitMQ.Stream.Client.StreamSystem
 RabbitMQ.Stream.Client.StreamSystem.Close() -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.StreamSystem.CreateRawConsumer(RabbitMQ.Stream.Client.RawConsumerConfig rawConsumerConfig, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
 RabbitMQ.Stream.Client.StreamSystem.CreateRawProducer(RabbitMQ.Stream.Client.RawProducerConfig rawProducerConfig, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
-RabbitMQ.Stream.Client.StreamSystem.CreateRawSuperStreamProducer(RabbitMQ.Stream.Client.RawSuperStreamProducerConfig rawSuperStreamProducerConfig, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 RabbitMQ.Stream.Client.StreamSystem.CreateStream(RabbitMQ.Stream.Client.StreamSpec spec) -> System.Threading.Tasks.Task
-RabbitMQ.Stream.Client.StreamSystem.CreateSuperStreamConsumer(RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig rawSuperStreamConsumerConfig, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
 RabbitMQ.Stream.Client.StreamSystem.DeleteStream(string stream) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.StreamSystem.IsClosed.get -> bool
 RabbitMQ.Stream.Client.StreamSystem.QueryOffset(string reference, string stream) -> System.Threading.Tasks.Task<ulong>
@@ -773,8 +771,6 @@ static RabbitMQ.Stream.Client.LeaderLocator.ClientLocal.get -> RabbitMQ.Stream.C
 static RabbitMQ.Stream.Client.LeaderLocator.LeastLeaders.get -> RabbitMQ.Stream.Client.LeaderLocator
 static RabbitMQ.Stream.Client.LeaderLocator.Random.get -> RabbitMQ.Stream.Client.LeaderLocator
 static RabbitMQ.Stream.Client.Message.From(ref System.Buffers.SequenceReader<byte> reader, uint len) -> RabbitMQ.Stream.Client.Message
-static RabbitMQ.Stream.Client.RawSuperStreamConsumer.Create(RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig rawSuperStreamConsumerConfig, System.Collections.Generic.IDictionary<string, RabbitMQ.Stream.Client.StreamInfo> streamInfos, RabbitMQ.Stream.Client.ClientParameters clientParameters, Microsoft.Extensions.Logging.ILogger logger = null) -> RabbitMQ.Stream.Client.IConsumer
-static RabbitMQ.Stream.Client.RawSuperStreamProducer.Create(RabbitMQ.Stream.Client.RawSuperStreamProducerConfig rawSuperStreamProducerConfig, System.Collections.Generic.IDictionary<string, RabbitMQ.Stream.Client.StreamInfo> streamInfos, RabbitMQ.Stream.Client.ClientParameters clientParameters, Microsoft.Extensions.Logging.ILogger logger = null) -> RabbitMQ.Stream.Client.IProducer
 static RabbitMQ.Stream.Client.Reliable.Consumer.Create(RabbitMQ.Stream.Client.Reliable.ConsumerConfig consumerConfig, Microsoft.Extensions.Logging.ILogger<RabbitMQ.Stream.Client.Reliable.Consumer> logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.Consumer>
 static RabbitMQ.Stream.Client.Reliable.Producer.Create(RabbitMQ.Stream.Client.Reliable.ProducerConfig producerConfig, Microsoft.Extensions.Logging.ILogger<RabbitMQ.Stream.Client.Reliable.Producer> logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.Producer>
 static RabbitMQ.Stream.Client.StreamCompressionCodecs.GetCompressionCodec(RabbitMQ.Stream.Client.CompressionType compressionType) -> RabbitMQ.Stream.Client.ICompressionCodec

--- a/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
@@ -634,7 +634,6 @@ RabbitMQ.Stream.Client.Reliable.ProducerConfig.SuperStreamConfig.set -> void
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.TimeoutMessageAfter.get -> System.TimeSpan
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.TimeoutMessageAfter.init -> void
 RabbitMQ.Stream.Client.Reliable.ProducerFactory
-RabbitMQ.Stream.Client.Reliable.ProducerFactory.CreateProducer() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 RabbitMQ.Stream.Client.Reliable.ProducerFactory.ProducerFactory() -> void
 RabbitMQ.Stream.Client.Reliable.ProducerFactory._confirmationPipe -> RabbitMQ.Stream.Client.Reliable.ConfirmationPipe
 RabbitMQ.Stream.Client.Reliable.ProducerFactory._producerConfig -> RabbitMQ.Stream.Client.Reliable.ProducerConfig

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -170,6 +170,9 @@ RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig.ConnectionClosedHandler.get 
 RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig.ConnectionClosedHandler.set -> void
 RabbitMQ.Stream.Client.RawSuperStreamProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
+RabbitMQ.Stream.Client.RawSuperStreamProducer.ReconnectPartition(string stream) -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.ConnectionClosedHandler.get -> System.Func<string, string, System.Threading.Tasks.Task>
+RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.ConnectionClosedHandler.set -> void
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.get -> RabbitMQ.Stream.Client.RoutingStrategyType
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.set -> void
 RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy
@@ -195,9 +198,12 @@ RabbitMQ.Stream.Client.Reliable.Producer.Info.get -> RabbitMQ.Stream.Client.Prod
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Filter.get -> RabbitMQ.Stream.Client.ProducerFilter
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Filter.set -> void
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.set -> void
+RabbitMQ.Stream.Client.Reliable.ProducerFactory.CreateProducer(bool boot) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
+RabbitMQ.Stream.Client.Reliable.ProducerFactory._producer -> RabbitMQ.Stream.Client.IProducer
 RabbitMQ.Stream.Client.Reliable.ReliableBase.CompareStatus(RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus toTest) -> bool
 RabbitMQ.Stream.Client.Reliable.ReliableBase.IsValidStatus() -> bool
 RabbitMQ.Stream.Client.Reliable.ReliableBase.LogException(System.Exception exception) -> void
+RabbitMQ.Stream.Client.Reliable.ReliableBase.MaybeReconnectPartition(string stream, string info, System.Func<string, System.Threading.Tasks.Task> reconnectPartitionFunc) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.Reliable.ReliableBase.UpdateStatus(RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus status) -> void
 RabbitMQ.Stream.Client.Reliable.ReliableBase._reconnectStrategy -> RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy
 RabbitMQ.Stream.Client.Reliable.ReliableBase._status -> RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -141,6 +141,10 @@ RabbitMQ.Stream.Client.IProducerConfig.Filter.set -> void
 RabbitMQ.Stream.Client.IRouting
 RabbitMQ.Stream.Client.IRouting.CreateClient(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.Broker metaInfoBroker, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IClient>
 RabbitMQ.Stream.Client.IRoutingStrategy.Route(RabbitMQ.Stream.Client.Message message, System.Collections.Generic.List<string> partitions) -> System.Threading.Tasks.Task<System.Collections.Generic.List<string>>
+RabbitMQ.Stream.Client.ISuperStreamConsumer
+RabbitMQ.Stream.Client.ISuperStreamConsumer.ReconnectPartition(RabbitMQ.Stream.Client.StreamInfo streamInfo) -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.ISuperStreamProducer
+RabbitMQ.Stream.Client.ISuperStreamProducer.ReconnectPartition(RabbitMQ.Stream.Client.StreamInfo streamInfo) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.KeyRoutingStrategy
 RabbitMQ.Stream.Client.KeyRoutingStrategy.KeyRoutingStrategy(System.Func<RabbitMQ.Stream.Client.Message, string> routingKeyExtractor, System.Func<string, string, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.RouteQueryResponse>> routingKeyQFunc, string superStream) -> void
 RabbitMQ.Stream.Client.KeyRoutingStrategy.Route(RabbitMQ.Stream.Client.Message message, System.Collections.Generic.List<string> partitions) -> System.Threading.Tasks.Task<System.Collections.Generic.List<string>>
@@ -239,6 +243,8 @@ RabbitMQ.Stream.Client.StreamStatsResponse.Statistic.get -> System.Collections.G
 RabbitMQ.Stream.Client.StreamStatsResponse.StreamStatsResponse() -> void
 RabbitMQ.Stream.Client.StreamStatsResponse.StreamStatsResponse(uint correlationId, RabbitMQ.Stream.Client.ResponseCode responseCode, System.Collections.Generic.IDictionary<string, long> statistic) -> void
 RabbitMQ.Stream.Client.StreamStatsResponse.Write(System.Span<byte> span) -> int
+RabbitMQ.Stream.Client.StreamSystem.CreateRawSuperStreamProducer(RabbitMQ.Stream.Client.RawSuperStreamProducerConfig rawSuperStreamProducerConfig, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ISuperStreamProducer>
+RabbitMQ.Stream.Client.StreamSystem.CreateSuperStreamConsumer(RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig rawSuperStreamConsumerConfig, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ISuperStreamConsumer>
 RabbitMQ.Stream.Client.StreamSystem.StreamInfo(string streamName) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.StreamInfo>
 RabbitMQ.Stream.Client.StreamSystem.StreamStats(string stream) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.StreamStats>
 RabbitMQ.Stream.Client.StreamSystemConfig.AuthMechanism.get -> RabbitMQ.Stream.Client.AuthMechanism
@@ -255,6 +261,8 @@ static RabbitMQ.Stream.Client.Connection.Create(System.Net.EndPoint endpoint, Sy
 static RabbitMQ.Stream.Client.Message.From(ref System.Buffers.ReadOnlySequence<byte> seq, uint len) -> RabbitMQ.Stream.Client.Message
 static RabbitMQ.Stream.Client.RawConsumer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.RawConsumerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IConsumer>
 static RabbitMQ.Stream.Client.RawProducer.Create(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.RawProducerConfig config, RabbitMQ.Stream.Client.StreamInfo metaStreamInfo, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
+static RabbitMQ.Stream.Client.RawSuperStreamConsumer.Create(RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig rawSuperStreamConsumerConfig, System.Collections.Generic.IDictionary<string, RabbitMQ.Stream.Client.StreamInfo> streamInfos, RabbitMQ.Stream.Client.ClientParameters clientParameters, Microsoft.Extensions.Logging.ILogger logger = null) -> RabbitMQ.Stream.Client.ISuperStreamConsumer
+static RabbitMQ.Stream.Client.RawSuperStreamProducer.Create(RabbitMQ.Stream.Client.RawSuperStreamProducerConfig rawSuperStreamProducerConfig, System.Collections.Generic.IDictionary<string, RabbitMQ.Stream.Client.StreamInfo> streamInfos, RabbitMQ.Stream.Client.ClientParameters clientParameters, Microsoft.Extensions.Logging.ILogger logger = null) -> RabbitMQ.Stream.Client.ISuperStreamProducer
 static RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer.Create(RabbitMQ.Stream.Client.Reliable.DeduplicatingProducerConfig producerConfig, Microsoft.Extensions.Logging.ILogger<RabbitMQ.Stream.Client.Reliable.Producer> logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.Reliable.DeduplicatingProducer>
 static RabbitMQ.Stream.Client.RoutingHelper<T>.LookupLeaderConnection(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.StreamInfo metaDataInfo, RabbitMQ.Stream.Client.ConnectionsPool pool, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IClient>
 static RabbitMQ.Stream.Client.RoutingHelper<T>.LookupRandomConnection(RabbitMQ.Stream.Client.ClientParameters clientParameters, RabbitMQ.Stream.Client.StreamInfo metaDataInfo, RabbitMQ.Stream.Client.ConnectionsPool pool, Microsoft.Extensions.Logging.ILogger logger = null) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IClient>

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@ abstract RabbitMQ.Stream.Client.AbstractEntity.Close() -> System.Threading.Tasks
 abstract RabbitMQ.Stream.Client.AbstractEntity.DeleteEntityFromTheServer(bool ignoreIfAlreadyDeleted = false) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 abstract RabbitMQ.Stream.Client.AbstractEntity.DumpEntityConfiguration() -> string
 abstract RabbitMQ.Stream.Client.AbstractEntity.GetStream() -> string
+abstract RabbitMQ.Stream.Client.Reliable.ReliableBase.CreateNewEntity(bool boot) -> System.Threading.Tasks.Task
 const RabbitMQ.Stream.Client.RouteQueryResponse.Key = 24 -> ushort
 const RabbitMQ.Stream.Client.StreamStatsResponse.Key = 28 -> ushort
 override RabbitMQ.Stream.Client.Broker.ToString() -> string
@@ -159,9 +160,14 @@ RabbitMQ.Stream.Client.PublishFilter.PublishFilter(byte publisherId, System.Coll
 RabbitMQ.Stream.Client.PublishFilter.SizeNeeded.get -> int
 RabbitMQ.Stream.Client.PublishFilter.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.RawConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
+RabbitMQ.Stream.Client.RawConsumerConfig.ConnectionClosedHandler.get -> System.Func<string, System.Threading.Tasks.Task>
+RabbitMQ.Stream.Client.RawConsumerConfig.ConnectionClosedHandler.set -> void
 RabbitMQ.Stream.Client.RawProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
 RabbitMQ.Stream.Client.RawSuperStreamConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
+RabbitMQ.Stream.Client.RawSuperStreamConsumer.ReconnectPartition(string stream) -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig.ConnectionClosedHandler.get -> System.Func<string, string, System.Threading.Tasks.Task>
+RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig.ConnectionClosedHandler.set -> void
 RabbitMQ.Stream.Client.RawSuperStreamProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.get -> RabbitMQ.Stream.Client.RoutingStrategyType
@@ -189,11 +195,11 @@ RabbitMQ.Stream.Client.Reliable.Producer.Info.get -> RabbitMQ.Stream.Client.Prod
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Filter.get -> RabbitMQ.Stream.Client.ProducerFilter
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Filter.set -> void
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.set -> void
-RabbitMQ.Stream.Client.Reliable.ReliableBase.CheckIfStreamIsAvailable(string stream, RabbitMQ.Stream.Client.StreamSystem system) -> System.Threading.Tasks.Task<bool>
 RabbitMQ.Stream.Client.Reliable.ReliableBase.CompareStatus(RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus toTest) -> bool
 RabbitMQ.Stream.Client.Reliable.ReliableBase.IsValidStatus() -> bool
-RabbitMQ.Stream.Client.Reliable.ReliableBase.MaybeReconnect() -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.Reliable.ReliableBase.LogException(System.Exception exception) -> void
 RabbitMQ.Stream.Client.Reliable.ReliableBase.UpdateStatus(RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus status) -> void
+RabbitMQ.Stream.Client.Reliable.ReliableBase._reconnectStrategy -> RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy
 RabbitMQ.Stream.Client.Reliable.ReliableBase._status -> RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.ReconnectStrategy.get -> RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.ResourceAvailableReconnectStrategy.get -> RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -98,6 +98,7 @@ RabbitMQ.Stream.Client.HashRoutingMurmurStrategy.Route(RabbitMQ.Stream.Client.Me
 RabbitMQ.Stream.Client.IClient.ClientId.get -> string
 RabbitMQ.Stream.Client.IClient.ClientId.init -> void
 RabbitMQ.Stream.Client.IClient.Consumers.get -> System.Collections.Generic.IDictionary<byte, (string, RabbitMQ.Stream.Client.ConsumerEvents)>
+RabbitMQ.Stream.Client.IClient.IsClosed.get -> bool
 RabbitMQ.Stream.Client.IClient.Publishers.get -> System.Collections.Generic.IDictionary<byte, (string, (System.Action<System.ReadOnlyMemory<ulong>>, System.Action<(ulong, RabbitMQ.Stream.Client.ResponseCode)[]>))>
 RabbitMQ.Stream.Client.IClosable
 RabbitMQ.Stream.Client.IClosable.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
@@ -165,12 +166,12 @@ RabbitMQ.Stream.Client.RawConsumerConfig.ConnectionClosedHandler.set -> void
 RabbitMQ.Stream.Client.RawProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
 RabbitMQ.Stream.Client.RawSuperStreamConsumer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
-RabbitMQ.Stream.Client.RawSuperStreamConsumer.ReconnectPartition(string stream) -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.RawSuperStreamConsumer.ReconnectPartition(RabbitMQ.Stream.Client.StreamInfo streamInfo) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig.ConnectionClosedHandler.get -> System.Func<string, string, System.Threading.Tasks.Task>
 RabbitMQ.Stream.Client.RawSuperStreamConsumerConfig.ConnectionClosedHandler.set -> void
 RabbitMQ.Stream.Client.RawSuperStreamProducer.Close() -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.ResponseCode>
 RabbitMQ.Stream.Client.RawSuperStreamProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo
-RabbitMQ.Stream.Client.RawSuperStreamProducer.ReconnectPartition(string stream) -> System.Threading.Tasks.Task
+RabbitMQ.Stream.Client.RawSuperStreamProducer.ReconnectPartition(RabbitMQ.Stream.Client.StreamInfo streamInfo) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.ConnectionClosedHandler.get -> System.Func<string, string, System.Threading.Tasks.Task>
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.ConnectionClosedHandler.set -> void
 RabbitMQ.Stream.Client.RawSuperStreamProducerConfig.RoutingStrategyType.get -> RabbitMQ.Stream.Client.RoutingStrategyType
@@ -201,11 +202,7 @@ RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.set -> void
 RabbitMQ.Stream.Client.Reliable.ProducerFactory.CreateProducer(bool boot) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 RabbitMQ.Stream.Client.Reliable.ProducerFactory._producer -> RabbitMQ.Stream.Client.IProducer
 RabbitMQ.Stream.Client.Reliable.ReliableBase.CompareStatus(RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus toTest) -> bool
-RabbitMQ.Stream.Client.Reliable.ReliableBase.IsValidStatus() -> bool
-RabbitMQ.Stream.Client.Reliable.ReliableBase.LogException(System.Exception exception) -> void
-RabbitMQ.Stream.Client.Reliable.ReliableBase.MaybeReconnectPartition(string stream, string info, System.Func<string, System.Threading.Tasks.Task> reconnectPartitionFunc) -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.Reliable.ReliableBase.UpdateStatus(RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus status) -> void
-RabbitMQ.Stream.Client.Reliable.ReliableBase._reconnectStrategy -> RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy
 RabbitMQ.Stream.Client.Reliable.ReliableBase._status -> RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.ReconnectStrategy.get -> RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.ResourceAvailableReconnectStrategy.get -> RabbitMQ.Stream.Client.Reconnect.IReconnectStrategy
@@ -242,6 +239,7 @@ RabbitMQ.Stream.Client.StreamStatsResponse.Statistic.get -> System.Collections.G
 RabbitMQ.Stream.Client.StreamStatsResponse.StreamStatsResponse() -> void
 RabbitMQ.Stream.Client.StreamStatsResponse.StreamStatsResponse(uint correlationId, RabbitMQ.Stream.Client.ResponseCode responseCode, System.Collections.Generic.IDictionary<string, long> statistic) -> void
 RabbitMQ.Stream.Client.StreamStatsResponse.Write(System.Span<byte> span) -> int
+RabbitMQ.Stream.Client.StreamSystem.StreamInfo(string streamName) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.StreamInfo>
 RabbitMQ.Stream.Client.StreamSystem.StreamStats(string stream) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.StreamStats>
 RabbitMQ.Stream.Client.StreamSystemConfig.AuthMechanism.get -> RabbitMQ.Stream.Client.AuthMechanism
 RabbitMQ.Stream.Client.StreamSystemConfig.AuthMechanism.set -> void

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -109,6 +109,8 @@ namespace RabbitMQ.Stream.Client
         public string Stream { get; }
 
         public Func<RawConsumer, MessageContext, Message, Task> MessageHandler { get; set; }
+
+        public Func<string, Task> ConnectionClosedHandler { get; set; }
     }
 
     public class RawConsumer : AbstractEntity, IConsumer, IDisposable
@@ -619,8 +621,9 @@ namespace RabbitMQ.Stream.Client
                 // we call the Close to re-enter to the standard behavior
                 // ignoreIfClosed is an optimization to avoid to send the unsubscribe
                 _config.Pool.RemoveConsumerEntityFromStream(_client.ClientId, EntityId, _config.Stream);
-                _config.MetadataHandler?.Invoke(metaDataUpdate);
                 await Close().ConfigureAwait(false);
+
+                _config.MetadataHandler?.Invoke(metaDataUpdate);
             };
 
         private Client.ConnectionCloseHandler OnConnectionClosed() =>

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -621,8 +621,7 @@ namespace RabbitMQ.Stream.Client
                 // we call the Close to re-enter to the standard behavior
                 // ignoreIfClosed is an optimization to avoid to send the unsubscribe
                 _config.Pool.RemoveConsumerEntityFromStream(_client.ClientId, EntityId, _config.Stream);
-                await Close().ConfigureAwait(false);
-
+                await Shutdown(_config, true).ConfigureAwait(false);
                 _config.MetadataHandler?.Invoke(metaDataUpdate);
             };
 

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -143,7 +143,7 @@ namespace RabbitMQ.Stream.Client
             Logger = logger ?? NullLogger.Instance;
             _initialCredits = config.InitialCredits;
             _config = config;
-            Logger.LogDebug("Creating... {ConsumerInfo}", DumpEntityConfiguration());
+            Logger.LogDebug("Creating... {DumpEntityConfiguration}", DumpEntityConfiguration());
             Info = new ConsumerInfo(_config.Stream, _config.Reference);
             // _chunksBuffer is a channel that is used to buffer the chunks
             _chunksBuffer = Channel.CreateBounded<Chunk>(new BoundedChannelOptions(_initialCredits)
@@ -472,7 +472,7 @@ namespace RabbitMQ.Stream.Client
             }, Token);
         }
 
-        internal async Task Init()
+        private async Task Init()
         {
             _config.Validate();
 

--- a/RabbitMQ.Stream.Client/RawProducer.cs
+++ b/RabbitMQ.Stream.Client/RawProducer.cs
@@ -57,7 +57,7 @@ namespace RabbitMQ.Stream.Client
 
         protected override string GetStream() => _config.Stream;
 
-        protected override string DumpEntityConfiguration()
+        protected sealed override string DumpEntityConfiguration()
         {
             return
                 $"Producer id {EntityId} for stream: {_config.Stream}, reference: {_config.Reference}," +
@@ -88,6 +88,8 @@ namespace RabbitMQ.Stream.Client
             _client = client;
             _config = config;
             Info = new ProducerInfo(_config.Stream, _config.Reference);
+            Logger = logger ?? NullLogger.Instance;
+            Logger.LogDebug("Creating... {DumpEntityConfiguration}", DumpEntityConfiguration());
             _messageBuffer = Channel.CreateBounded<OutgoingMsg>(new BoundedChannelOptions(10000)
             {
                 AllowSynchronousContinuations = false,
@@ -95,7 +97,6 @@ namespace RabbitMQ.Stream.Client
                 SingleWriter = false,
                 FullMode = BoundedChannelFullMode.Wait
             });
-            Logger = logger ?? NullLogger.Instance;
             Task.Run(ProcessBuffer);
             _semaphore = new SemaphoreSlim(config.MaxInFlight, config.MaxInFlight);
         }
@@ -167,12 +168,11 @@ namespace RabbitMQ.Stream.Client
                 _client.ConnectionClosed -= OnConnectionClosed();
                 _client.Parameters.OnMetadataUpdate -= OnMetadataUpdate();
                 _config.Pool.Remove(_client.ClientId);
-                await Shutdown(_config, true).ConfigureAwait(false);
+                UpdateStatusToClosed();
                 if (_config.ConnectionClosedHandler != null)
                 {
                     await _config.ConnectionClosedHandler(reason).ConfigureAwait(false);
                 }
-
             };
 
         private ClientParameters.MetadataUpdateHandler OnMetadataUpdate() =>
@@ -187,12 +187,11 @@ namespace RabbitMQ.Stream.Client
                 _client.ConnectionClosed -= OnConnectionClosed();
                 _client.Parameters.OnMetadataUpdate -= OnMetadataUpdate();
 
-                _config.Pool.RemoveProducerEntityFromStream(_client.ClientId, EntityId, _config.Stream);
-
                 // at this point the server has removed the producer from the list 
                 // and the DeletePublisher producer is not needed anymore (ignoreIfClosed = true)
                 // we call the Close to re-enter to the standard behavior
                 // ignoreIfClosed is an optimization to avoid to send the DeletePublisher
+                _config.Pool.RemoveProducerEntityFromStream(_client.ClientId, EntityId, _config.Stream);
                 await Shutdown(_config, true).ConfigureAwait(false);
                 _config.MetadataHandler?.Invoke(metaDataUpdate);
             };
@@ -364,7 +363,7 @@ namespace RabbitMQ.Stream.Client
             }
             catch (Exception e)
             {
-                Logger.LogError(e, "error while Process Buffer");
+                Logger.LogError(e, "{DumpEntityConfiguration} Error while Process Buffer", DumpEntityConfiguration());
             }
         }
 

--- a/RabbitMQ.Stream.Client/RawSuperStreamConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamConsumer.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace RabbitMQ.Stream.Client;
 
-public class RawSuperStreamConsumer : IConsumer, IDisposable
+public class RawSuperStreamConsumer : ISuperStreamConsumer, IDisposable
 {
     // ConcurrentDictionary because the consumer can be closed from another thread
     // The send operations will check if the producer exists and if not it will be created
@@ -36,7 +36,7 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
     /// <param name="clientParameters"></param>
     /// <param name="logger"></param>
     /// <returns></returns>
-    public static IConsumer Create(
+    public static ISuperStreamConsumer Create(
         RawSuperStreamConsumerConfig rawSuperStreamConsumerConfig,
         IDictionary<string, StreamInfo> streamInfos,
         ClientParameters clientParameters,
@@ -129,11 +129,11 @@ public class RawSuperStreamConsumer : IConsumer, IDisposable
 
     private async Task<IConsumer> InitConsumer(string stream)
     {
-        var index = _streamInfos.Keys.Select((item, index) => new {Item = item, Index = index})
+        var index = _streamInfos.Keys.Select((item, index) => new { Item = item, Index = index })
             .First(i => i.Item == stream).Index;
 
         var c = await RawConsumer.Create(
-            _clientParameters with {ClientProvidedName = $"{_clientParameters.ClientProvidedName}_{index}"},
+            _clientParameters with { ClientProvidedName = $"{_clientParameters.ClientProvidedName}_{index}" },
             FromStreamConfig(stream), _streamInfos[stream], _logger).ConfigureAwait(false);
         _logger?.LogDebug("Super stream consumer {ConsumerReference} created for Stream {StreamIdentifier}", c.Info,
             stream);

--- a/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
@@ -129,10 +129,10 @@ public class RawSuperStreamProducer : ISuperStreamProducer, IDisposable
     // The producer is created on demand when a message is sent to a stream
     private async Task<IProducer> InitProducer(string stream)
     {
-        var index = _streamInfos.Keys.Select((item, index) => new {Item = item, Index = index})
+        var index = _streamInfos.Keys.Select((item, index) => new { Item = item, Index = index })
             .First(i => i.Item == stream).Index;
         var p = await RawProducer.Create(
-                _clientParameters with {ClientProvidedName = $"{_config.ClientProvidedName}_{index}"},
+                _clientParameters with { ClientProvidedName = $"{_config.ClientProvidedName}_{index}" },
                 FromStreamConfig(stream),
                 _streamInfos[stream],
                 _logger)
@@ -190,7 +190,7 @@ public class RawSuperStreamProducer : ISuperStreamProducer, IDisposable
 
         // we should always have a route
         // but in case of stream KEY the routing could not exist
-        if (routes is not {Count: > 0})
+        if (routes is not { Count: > 0 })
         {
             throw new RouteNotFoundException("No route found for the message to any stream");
         }
@@ -239,7 +239,7 @@ public class RawSuperStreamProducer : ISuperStreamProducer, IDisposable
             }
             else
             {
-                aggregate.Add((p, new List<(ulong, Message)>() {(subMessage.Item1, subMessage.Item2)}));
+                aggregate.Add((p, new List<(ulong, Message)>() { (subMessage.Item1, subMessage.Item2) }));
             }
         }
 
@@ -274,7 +274,7 @@ public class RawSuperStreamProducer : ISuperStreamProducer, IDisposable
             }
             else
             {
-                aggregate.Add((p, new List<Message>() {subMessage}));
+                aggregate.Add((p, new List<Message>() { subMessage }));
             }
         }
 
@@ -419,7 +419,7 @@ public class HashRoutingMurmurStrategy : IRoutingStrategy
         var key = _routingKeyExtractor(message);
         var hash = new Murmur32ManagedX86(Seed).ComputeHash(Encoding.UTF8.GetBytes(key));
         var index = BitConverter.ToUInt32(hash, 0) % (uint)partitions.Count;
-        var r = new List<string>() {partitions[(int)index]};
+        var r = new List<string>() { partitions[(int)index] };
         return Task.FromResult(r);
     }
 
@@ -452,8 +452,8 @@ public class KeyRoutingStrategy : IRoutingStrategy
         var c = await _routingKeyQFunc(_superStream, key).ConfigureAwait(false);
         _cacheStream[key] = c.Streams;
         return (from resultStream in c.Streams
-            where partitions.Contains(resultStream)
-            select new List<string>() {resultStream}).FirstOrDefault();
+                where partitions.Contains(resultStream)
+                select new List<string>() { resultStream }).FirstOrDefault();
     }
 
     public KeyRoutingStrategy(Func<Message, string> routingKeyExtractor,

--- a/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
+++ b/RabbitMQ.Stream.Client/RawSuperStreamProducer.cs
@@ -129,10 +129,10 @@ public class RawSuperStreamProducer : IProducer, IDisposable
     // The producer is created on demand when a message is sent to a stream
     private async Task<IProducer> InitProducer(string stream)
     {
-        var index = _streamInfos.Keys.Select((item, index) => new {Item = item, Index = index})
+        var index = _streamInfos.Keys.Select((item, index) => new { Item = item, Index = index })
             .First(i => i.Item == stream).Index;
         var p = await RawProducer.Create(
-                _clientParameters with {ClientProvidedName = $"{_config.ClientProvidedName}_{index}"},
+                _clientParameters with { ClientProvidedName = $"{_config.ClientProvidedName}_{index}" },
                 FromStreamConfig(stream),
                 _streamInfos[stream],
                 _logger)
@@ -190,7 +190,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
 
         // we should always have a route
         // but in case of stream KEY the routing could not exist
-        if (routes is not {Count: > 0})
+        if (routes is not { Count: > 0 })
         {
             throw new RouteNotFoundException("No route found for the message to any stream");
         }
@@ -239,7 +239,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
             }
             else
             {
-                aggregate.Add((p, new List<(ulong, Message)>() {(subMessage.Item1, subMessage.Item2)}));
+                aggregate.Add((p, new List<(ulong, Message)>() { (subMessage.Item1, subMessage.Item2) }));
             }
         }
 
@@ -266,7 +266,7 @@ public class RawSuperStreamProducer : IProducer, IDisposable
             }
             else
             {
-                aggregate.Add((p, new List<Message>() {subMessage}));
+                aggregate.Add((p, new List<Message>() { subMessage }));
             }
         }
 
@@ -403,7 +403,7 @@ public class HashRoutingMurmurStrategy : IRoutingStrategy
         var key = _routingKeyExtractor(message);
         var hash = new Murmur32ManagedX86(Seed).ComputeHash(Encoding.UTF8.GetBytes(key));
         var index = BitConverter.ToUInt32(hash, 0) % (uint)partitions.Count;
-        var r = new List<string>() {partitions[(int)index]};
+        var r = new List<string>() { partitions[(int)index] };
         return Task.FromResult(r);
     }
 
@@ -436,8 +436,8 @@ public class KeyRoutingStrategy : IRoutingStrategy
         var c = await _routingKeyQFunc(_superStream, key).ConfigureAwait(false);
         _cacheStream[key] = c.Streams;
         return (from resultStream in c.Streams
-            where partitions.Contains(resultStream)
-            select new List<string>() {resultStream}).FirstOrDefault();
+                where partitions.Contains(resultStream)
+                select new List<string>() { resultStream }).FirstOrDefault();
     }
 
     public KeyRoutingStrategy(Func<Message, string> routingKeyExtractor,

--- a/RabbitMQ.Stream.Client/Reliable/ConfirmationPipe.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConfirmationPipe.cs
@@ -125,7 +125,7 @@ public class ConfirmationPipe
 
         foreach (var pair in timedOutMessages)
         {
-            await RemoveUnConfirmedMessage(ConfirmationStatus.ClientTimeoutError, pair.Value.PublishingId, null)
+            await RemoveUnConfirmedMessage(ConfirmationStatus.ClientTimeoutError, pair.Value.PublishingId, pair.Value.Stream)
                 .ConfigureAwait(false);
         }
     }

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -189,7 +189,7 @@ public class Consumer : ConsumerFactory
     // just close the consumer. See base/metadataupdate
     protected override async Task CloseEntity()
     {
-        await SemaphoreSlim.WaitAsync(Consts.LongWait).ConfigureAwait(false);
+        await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
         try
         {
             if (_consumer != null)

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -157,7 +157,6 @@ public record ConsumerConfig : ReliableConfig
 /// </summary>
 public class Consumer : ConsumerFactory
 {
-
     private readonly ILogger<Consumer> _logger;
 
     protected override ILogger BaseLogger => _logger;
@@ -174,13 +173,14 @@ public class Consumer : ConsumerFactory
         consumerConfig.ReconnectStrategy ??= new BackOffReconnectStrategy(logger);
         consumerConfig.ResourceAvailableReconnectStrategy ??= new ResourceAvailableBackOffReconnectStrategy(logger);
         var rConsumer = new Consumer(consumerConfig, logger);
-        await rConsumer.Init(consumerConfig.ReconnectStrategy, consumerConfig.ResourceAvailableReconnectStrategy).ConfigureAwait(false);
+        await rConsumer.Init(consumerConfig.ReconnectStrategy, consumerConfig.ResourceAvailableReconnectStrategy)
+            .ConfigureAwait(false);
         logger?.LogDebug("Consumer: {Reference} created for Stream: {Stream}",
             consumerConfig.Reference, consumerConfig.Stream);
         return rConsumer;
     }
 
-    internal override async Task CreateNewEntity(bool boot)
+    protected override async Task CreateNewEntity(bool boot)
     {
         _consumer = await CreateConsumer(boot).ConfigureAwait(false);
         await _consumerConfig.ReconnectStrategy.WhenConnected(ToString()).ConfigureAwait(false);

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -175,8 +175,6 @@ public class Consumer : ConsumerFactory
         var rConsumer = new Consumer(consumerConfig, logger);
         await rConsumer.Init(consumerConfig.ReconnectStrategy, consumerConfig.ResourceAvailableReconnectStrategy)
             .ConfigureAwait(false);
-        logger?.LogDebug("Consumer: {Reference} created for Stream: {Stream}",
-            consumerConfig.Reference, consumerConfig.Stream);
         return rConsumer;
     }
 

--- a/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
+++ b/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
@@ -48,7 +48,7 @@ internal class BackOffReconnectStrategy : IReconnectStrategy
     // else the backoff will be too long
     private void MaybeResetTentatives()
     {
-        if (Tentatives > 1000)
+        if (Tentatives > 5)
         {
             Tentatives = 1;
         }
@@ -57,12 +57,14 @@ internal class BackOffReconnectStrategy : IReconnectStrategy
     public async ValueTask<bool> WhenDisconnected(string connectionIdentifier)
     {
         Tentatives <<= 1;
+        var next = Random.Shared.Next(Tentatives * 1000, Tentatives * 2000);
         _logger.LogInformation(
             "{ConnectionIdentifier} disconnected, check if reconnection needed in {ReconnectionDelayMs} ms",
             connectionIdentifier,
-            Tentatives * 100
+            next
         );
-        await Task.Delay(TimeSpan.FromMilliseconds(Tentatives * 100)).ConfigureAwait(false);
+        
+        await Task.Delay(TimeSpan.FromMilliseconds(next)).ConfigureAwait(false);
         MaybeResetTentatives();
         return true;
     }

--- a/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
+++ b/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
@@ -56,17 +56,28 @@ internal class BackOffReconnectStrategy : IReconnectStrategy
 
     public async ValueTask<bool> WhenDisconnected(string connectionIdentifier)
     {
+
         Tentatives <<= 1;
-        var next = Random.Shared.Next(Tentatives * 1000, Tentatives * 2000);
         _logger.LogInformation(
             "{ConnectionIdentifier} disconnected, check if reconnection needed in {ReconnectionDelayMs} ms",
             connectionIdentifier,
-            next
+            Tentatives * 100
         );
-        
-        await Task.Delay(TimeSpan.FromMilliseconds(next)).ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromMilliseconds(Tentatives * 100)).ConfigureAwait(false);
         MaybeResetTentatives();
         return true;
+        // this will be in another commit
+        // Tentatives <<= 1;
+        // var next = Random.Shared.Next(Tentatives * 1000, Tentatives * 2000);
+        // _logger.LogInformation(
+        //     "{ConnectionIdentifier} disconnected, check if reconnection needed in {ReconnectionDelayMs} ms",
+        //     connectionIdentifier,
+        //     next
+        // );
+        //
+        // await Task.Delay(TimeSpan.FromMilliseconds(next)).ConfigureAwait(false);
+        // MaybeResetTentatives();
+        // return true;
     }
 
     public ValueTask WhenConnected(string connectionIdentifier)

--- a/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
+++ b/RabbitMQ.Stream.Client/Reliable/IReconnectStrategy.cs
@@ -105,13 +105,13 @@ internal class ResourceAvailableBackOffReconnectStrategy : IReconnectStrategy
         );
         await Task.Delay(TimeSpan.FromSeconds(Tentatives)).ConfigureAwait(false);
         MaybeResetTentatives();
-        return Tentatives < 4;
+        return Tentatives < 5;
     }
 
     public ValueTask WhenConnected(string resourceIdentifier)
     {
         Tentatives = 1;
-        _logger.LogInformation("{ResourceIdentifier} is available", resourceIdentifier);
+        _logger.LogInformation("{ResourceIdentifier}", resourceIdentifier);
         return ValueTask.CompletedTask;
     }
 }

--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -172,7 +172,7 @@ public class Producer : ProducerFactory
         return rProducer;
     }
 
-    internal override async Task CreateNewEntity(bool boot)
+    protected override async Task CreateNewEntity(bool boot)
     {
         _producer = await CreateProducer().ConfigureAwait(false);
 

--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -125,7 +125,7 @@ public record ProducerConfig : ReliableConfig
 /// </summary>
 public class Producer : ProducerFactory
 {
-    private IProducer _producer;
+
     private ulong _publishingId;
     private readonly ILogger<Producer> _logger;
 
@@ -174,7 +174,7 @@ public class Producer : ProducerFactory
 
     protected override async Task CreateNewEntity(bool boot)
     {
-        _producer = await CreateProducer().ConfigureAwait(false);
+        _producer = await CreateProducer(boot).ConfigureAwait(false);
 
         await _producerConfig.ReconnectStrategy.WhenConnected(ToString()).ConfigureAwait(false);
 
@@ -191,7 +191,7 @@ public class Producer : ProducerFactory
 
     protected override async Task CloseEntity()
     {
-        await SemaphoreSlim.WaitAsync(Consts.LongWait).ConfigureAwait(false);
+        await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
         try
         {
             if (_producer != null)
@@ -214,7 +214,7 @@ public class Producer : ProducerFactory
         }
 
         UpdateStatus(ReliableEntityStatus.Closed);
-        await SemaphoreSlim.WaitAsync(Consts.ShortWait).ConfigureAwait(false);
+        await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
         try
         {
             _confirmationPipe.Stop();

--- a/RabbitMQ.Stream.Client/Reliable/Producer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Producer.cs
@@ -163,12 +163,6 @@ public class Producer : ProducerFactory
         var rProducer = new Producer(producerConfig, logger);
         await rProducer.Init(producerConfig.ReconnectStrategy, producerConfig.ResourceAvailableReconnectStrategy)
             .ConfigureAwait(false);
-        logger?.LogDebug(
-            "Producer: {Reference} created for Stream: {Stream}",
-            producerConfig.Reference,
-            producerConfig.Stream
-        );
-
         return rProducer;
     }
 

--- a/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
@@ -15,48 +15,75 @@ namespace RabbitMQ.Stream.Client.Reliable;
 
 public abstract class ProducerFactory : ReliableBase
 {
+    protected IProducer _producer;
     protected ProducerConfig _producerConfig;
     protected ConfirmationPipe _confirmationPipe;
 
-    protected async Task<IProducer> CreateProducer()
+    protected async Task<IProducer> CreateProducer(bool boot)
     {
         if (_producerConfig.SuperStreamConfig is { Enabled: true })
         {
-            return await SuperStreamProducer().ConfigureAwait(false);
+            return await SuperStreamProducer(boot).ConfigureAwait(false);
         }
 
         return await StandardProducer().ConfigureAwait(false);
     }
 
-    private async Task<IProducer> SuperStreamProducer()
+    private async Task<IProducer> SuperStreamProducer(bool boot)
     {
-        return await _producerConfig.StreamSystem.CreateRawSuperStreamProducer(
-            new RawSuperStreamProducerConfig(_producerConfig.Stream)
-            {
-                ClientProvidedName = _producerConfig.ClientProvidedName,
-                Reference = _producerConfig.Reference,
-                MessagesBufferSize = _producerConfig.MessagesBufferSize,
-                MaxInFlight = _producerConfig.MaxInFlight,
-                Routing = _producerConfig.SuperStreamConfig.Routing,
-                RoutingStrategyType = _producerConfig.SuperStreamConfig.RoutingStrategyType,
-                Filter = _producerConfig.Filter,
-                ConfirmHandler = confirmationHandler =>
+        if (boot)
+        {
+
+            
+
+            return await _producerConfig.StreamSystem.CreateRawSuperStreamProducer(
+                new RawSuperStreamProducerConfig(_producerConfig.Stream)
                 {
-                    var (stream, confirmation) = confirmationHandler;
-                    var confirmationStatus = confirmation.Code switch
+                    ClientProvidedName = _producerConfig.ClientProvidedName,
+                    Reference = _producerConfig.Reference,
+                    MessagesBufferSize = _producerConfig.MessagesBufferSize,
+                    MaxInFlight = _producerConfig.MaxInFlight,
+                    Routing = _producerConfig.SuperStreamConfig.Routing,
+                    RoutingStrategyType = _producerConfig.SuperStreamConfig.RoutingStrategyType,
+                    Filter = _producerConfig.Filter,
+                    ConnectionClosedHandler = async (closeReason, partitionStream) =>
                     {
-                        ResponseCode.PublisherDoesNotExist => ConfirmationStatus.PublisherDoesNotExist,
-                        ResponseCode.AccessRefused => ConfirmationStatus.AccessRefused,
-                        ResponseCode.InternalError => ConfirmationStatus.InternalError,
-                        ResponseCode.PreconditionFailed => ConfirmationStatus.PreconditionFailed,
-                        ResponseCode.StreamNotAvailable => ConfirmationStatus.StreamNotAvailable,
-                        ResponseCode.Ok => ConfirmationStatus.Confirmed,
-                        _ => ConfirmationStatus.UndefinedError
-                    };
-                    _confirmationPipe.RemoveUnConfirmedMessage(confirmationStatus, confirmation.PublishingId,
-                        stream).ConfigureAwait(false);
-                }
-            }, BaseLogger).ConfigureAwait(false);
+                        if (closeReason == ConnectionClosedReason.Normal)
+                        {
+                            BaseLogger.LogInformation("{Identity} is closed normally", ToString());
+                            return;
+                        }
+
+                        var r = ((RawSuperStreamProducer)(_producer)).ReconnectPartition;
+                        await OnEntityClosed(_producerConfig.StreamSystem, partitionStream, r)
+                            .ConfigureAwait(false);
+
+                    },
+                    MetadataHandler = async update =>
+                    {
+                        var r = ((RawSuperStreamProducer)(_producer)).ReconnectPartition;
+                        await OnEntityClosed(_producerConfig.StreamSystem, update.Stream, r)
+                            .ConfigureAwait(false);
+                    },
+                    ConfirmHandler = confirmationHandler =>
+                    {
+                        var (stream, confirmation) = confirmationHandler;
+                        var confirmationStatus = confirmation.Code switch
+                        {
+                            ResponseCode.PublisherDoesNotExist => ConfirmationStatus.PublisherDoesNotExist,
+                            ResponseCode.AccessRefused => ConfirmationStatus.AccessRefused,
+                            ResponseCode.InternalError => ConfirmationStatus.InternalError,
+                            ResponseCode.PreconditionFailed => ConfirmationStatus.PreconditionFailed,
+                            ResponseCode.StreamNotAvailable => ConfirmationStatus.StreamNotAvailable,
+                            ResponseCode.Ok => ConfirmationStatus.Confirmed,
+                            _ => ConfirmationStatus.UndefinedError
+                        };
+                        _confirmationPipe.RemoveUnConfirmedMessage(confirmationStatus, confirmation.PublishingId,
+                            stream).ConfigureAwait(false);
+                    }
+                }, BaseLogger).ConfigureAwait(false);
+        }
+        return _producer;
     }
 
     private async Task<IProducer> StandardProducer()

--- a/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
@@ -34,8 +34,6 @@ public abstract class ProducerFactory : ReliableBase
         if (boot)
         {
 
-            
-
             return await _producerConfig.StreamSystem.CreateRawSuperStreamProducer(
                 new RawSuperStreamProducerConfig(_producerConfig.Stream)
                 {
@@ -50,7 +48,7 @@ public abstract class ProducerFactory : ReliableBase
                     {
                         if (closeReason == ConnectionClosedReason.Normal)
                         {
-                            BaseLogger.LogInformation("{Identity} is closed normally", ToString());
+                            BaseLogger.LogDebug("{Identity} is closed normally", ToString());
                             return;
                         }
 
@@ -83,11 +81,16 @@ public abstract class ProducerFactory : ReliableBase
                     }
                 }, BaseLogger).ConfigureAwait(false);
         }
+
         return _producer;
     }
 
     private async Task<IProducer> StandardProducer()
     {
+        // before creating a new producer, the old one is disposed
+        // This is just a safety check, the producer should be already disposed
+        _producer?.Dispose();
+
         return await _producerConfig.StreamSystem.CreateRawProducer(new RawProducerConfig(_producerConfig.Stream)
         {
             ClientProvidedName = _producerConfig.ClientProvidedName,
@@ -102,7 +105,7 @@ public abstract class ProducerFactory : ReliableBase
             {
                 if (closeReason == ConnectionClosedReason.Normal)
                 {
-                    BaseLogger.LogInformation("{Identity} is closed normally", ToString());
+                    BaseLogger.LogDebug("{Identity} is closed normally", ToString());
                     return;
                 }
 

--- a/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ProducerFactory.cs
@@ -2,8 +2,6 @@
 // 2.0, and the Mozilla Public License, version 2.0.
 // Copyright (c) 2017-2023 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
-using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -21,7 +19,6 @@ public abstract class ProducerFactory : ReliableBase
     protected IProducer _producer;
     protected ProducerConfig _producerConfig;
     protected ConfirmationPipe _confirmationPipe;
-    private static readonly ManualResetEvent s_reconnect = new ManualResetEvent(false);
 
     protected async Task<IProducer> CreateProducer(bool boot)
     {
@@ -50,8 +47,6 @@ public abstract class ProducerFactory : ReliableBase
                     Filter = _producerConfig.Filter,
                     ConnectionClosedHandler = async (closeReason, partitionStream) =>
                     {
-                        s_reconnect.WaitOne(TimeSpan.FromSeconds(1));
-
                         if (closeReason == ConnectionClosedReason.Normal)
                         {
                             BaseLogger.LogDebug("{Identity} is closed normally", ToString());
@@ -61,8 +56,6 @@ public abstract class ProducerFactory : ReliableBase
                         var r = ((RawSuperStreamProducer)(_producer)).ReconnectPartition;
                         await OnEntityClosed(_producerConfig.StreamSystem, partitionStream, r)
                             .ConfigureAwait(false);
-                        s_reconnect.Set();
-                        s_reconnect.Reset();
                     },
                     MetadataHandler = async update =>
                     {

--- a/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
@@ -66,7 +66,7 @@ public abstract class ReliableBase
         }
     }
 
-    protected bool IsValidStatus()
+    private bool IsValidStatus()
     {
         lock (_lock)
         {
@@ -76,7 +76,7 @@ public abstract class ReliableBase
     }
 
     protected abstract ILogger BaseLogger { get; }
-    protected IReconnectStrategy _reconnectStrategy;
+    private IReconnectStrategy _reconnectStrategy;
     private IReconnectStrategy _resourceAvailableReconnectStrategy;
 
     internal async Task Init(IReconnectStrategy reconnectStrategy,
@@ -103,27 +103,20 @@ public abstract class ReliableBase
         {
             if (boot)
             {
+                BaseLogger.LogError("{Identity} Error during the first boot {EMessage}",
+                    ToString(), e.Message);
                 // if it is the first boot we don't need to reconnect
                 UpdateStatus(ReliableEntityStatus.Closed);
                 throw;
             }
 
-            reconnect = ClientExceptions.IsAKnownException(e);
-
+            reconnect = true;
             LogException(e);
-            if (!reconnect)
-            {
-                // We consider the client as closed
-                // since the exception is raised to the caller
-                UpdateStatus(ReliableEntityStatus.Closed);
-                throw;
-            }
+
         }
 
         if (reconnect)
-        {
             await MaybeReconnect().ConfigureAwait(false);
-        }
     }
 
     // <summary>
@@ -134,10 +127,9 @@ public abstract class ReliableBase
     {
         if (!boot && !IsValidStatus())
         {
-            BaseLogger.LogInformation("{Identity} is already closed", ToString());
+            BaseLogger.LogDebug("{Identity} is already closed. The init will be skipped", ToString());
             return;
         }
-
         // each time that the client is initialized, we need to reset the status
         // if we hare here it means that the entity is not open for some reason like:
         // first time initialization or reconnect due of a IsAKnownException
@@ -161,6 +153,14 @@ public abstract class ReliableBase
     /// </summary>
     protected abstract Task CreateNewEntity(bool boot);
 
+    /// <summary>
+    /// When the clients receives a meta data update, it doesn't know
+    /// If the stream exists or not. It just knows that the stream topology has changed.
+    /// the method CheckIfStreamIsAvailable checks if the stream exists.
+    /// </summary>
+    /// <param name="stream">stream name</param>
+    /// <param name="system">stream system</param>
+    /// <returns></returns>
     private async Task<bool> CheckIfStreamIsAvailable(string stream, StreamSystem system)
     {
         await Task.Delay(Consts.RandomMid()).ConfigureAwait(false);
@@ -183,18 +183,20 @@ public abstract class ReliableBase
             }
         }
 
-        if (!exists)
-        {
-            // In this case the stream doesn't exist anymore
-            // the  Entity is just closed.
-            BaseLogger.LogInformation(
-                "Meta data update stream: {StreamIdentifier}. The stream doesn't exist anymore {Identity} will be closed",
-                stream,
-                ToString()
-            );
-        }
+        if (exists)
+            return true;
+        // In this case the stream doesn't exist anymore or it failed to check if the stream exists
+        // too many tentatives for the reconnection strategy
+        // the  Entity is just closed.
+        var msg = tryAgain ? "The stream doesn't exist anymore" : "Failed to check if the stream exists";
 
-        return exists;
+        BaseLogger.LogInformation(
+            "Meta data update stream: {StreamIdentifier}. {Msg} {Identity} will be closed",
+            stream, msg,
+            ToString()
+        );
+
+        return false;
     }
 
     // <summary>
@@ -206,6 +208,7 @@ public abstract class ReliableBase
         var reconnect = await _reconnectStrategy.WhenDisconnected(ToString()).ConfigureAwait(false);
         if (!reconnect)
         {
+            BaseLogger.LogDebug("{Identity} is closed due of reconnect strategy", ToString());
             UpdateStatus(ReliableEntityStatus.Closed);
             return;
         }
@@ -219,21 +222,21 @@ public abstract class ReliableBase
             case false:
                 if (CompareStatus(ReliableEntityStatus.Reconnecting))
                 {
-                    BaseLogger.LogInformation("{Identity} is in Reconnecting", ToString());
+                    BaseLogger.LogDebug("{Identity} is in Reconnecting", ToString());
                 }
 
                 break;
         }
     }
-    
-    
-    protected async Task MaybeReconnectPartition(string stream, string info, Func<string, Task> reconnectPartitionFunc)
+
+    private async Task MaybeReconnectPartition(StreamInfo streamInfo, string info, Func<StreamInfo, Task> reconnectPartitionFunc)
     {
         var reconnect = await _reconnectStrategy
-            .WhenDisconnected($"Super Stream partition: {stream} for {info}").ConfigureAwait(false);
+            .WhenDisconnected($"Super Stream partition: {streamInfo.Stream} for {info}").ConfigureAwait(false);
 
         if (!reconnect)
         {
+            BaseLogger.LogDebug("{Identity} partition is closed due of reconnect strategy", ToString());
             UpdateStatus(ReliableEntityStatus.Closed);
             return;
         }
@@ -241,33 +244,19 @@ public abstract class ReliableBase
         try
         {
             UpdateStatus(ReliableEntityStatus.Reconnecting);
-            await reconnectPartitionFunc(stream).ConfigureAwait(false);
+            await reconnectPartitionFunc(streamInfo).ConfigureAwait(false);
             UpdateStatus(ReliableEntityStatus.Open);
             await _reconnectStrategy.WhenConnected(
-                $"Super Stream partition: {stream} for {info}").ConfigureAwait(false);
+                $"Super Stream partition: {streamInfo.Stream} for {info}").ConfigureAwait(false);
         }
         catch (Exception e)
         {
             LogException(e);
-            if (ClientExceptions.IsAKnownException(e))
-            {
-                await MaybeReconnectPartition(stream, info, reconnectPartitionFunc).ConfigureAwait(false);
-            }
+            await MaybeReconnectPartition(streamInfo, info, reconnectPartitionFunc).ConfigureAwait(false);
         }
     }
 
-    /// <summary>
-    /// When the clients receives a meta data update, it doesn't know
-    /// the reason.
-    /// Metadata update can be raised when:
-    /// - stream is deleted
-    /// - change the stream topology (ex: add a follower)
-    ///
-    /// HandleMetaDataMaybeReconnect checks if the stream still exists
-    /// and try to reconnect.
-    /// (internal because it is needed for tests)
-    /// </summary>
-    protected void LogException(Exception exception)
+    private void LogException(Exception exception)
     {
         const string KnownExceptionTemplate = "{Identity} trying to reconnect due to exception {Err}";
         const string UnknownExceptionTemplate = "{Identity} received an exception during initialization";
@@ -290,7 +279,13 @@ public abstract class ReliableBase
     /// </summary>
     protected abstract Task CloseEntity();
 
-    internal async Task OnEntityClosed(StreamSystem system, string stream, Func<string, Task> reconnectPartitionFunc)
+    /// <summary>
+    /// Handle the partition reconnection in case of super stream entity
+    /// </summary>
+    /// <param name="system">Stream System</param>
+    /// <param name="stream">Partition Stream</param>
+    /// <param name="reconnectPartitionFunc">Function to reconnect the partition</param>
+    internal async Task OnEntityClosed(StreamSystem system, string stream, Func<StreamInfo, Task> reconnectPartitionFunc)
     {
         var streamExists = false;
         await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
@@ -300,8 +295,8 @@ public abstract class ReliableBase
                 .ConfigureAwait(false);
             if (streamExists)
             {
-                await MaybeReconnectPartition(stream, ToString(), reconnectPartitionFunc).ConfigureAwait(false);
-                
+                var streamInfo = await system.StreamInfo(stream).ConfigureAwait(false);
+                await MaybeReconnectPartition(streamInfo, ToString(), reconnectPartitionFunc).ConfigureAwait(false);
             }
         }
         finally
@@ -315,6 +310,11 @@ public abstract class ReliableBase
         }
     }
 
+    /// <summary>
+    /// Handle the regular stream reconnection 
+    /// </summary>
+    /// <param name="system">Stream system</param>
+    /// <param name="stream">Stream</param>
     internal async Task OnEntityClosed(StreamSystem system, string stream)
     {
         var streamExists = false;

--- a/RabbitMQ.Stream.Client/RoutingClient.cs
+++ b/RabbitMQ.Stream.Client/RoutingClient.cs
@@ -170,15 +170,17 @@ namespace RabbitMQ.Stream.Client
         {
             var brokers = new List<Broker>() { metaDataInfo.Leader };
             brokers.AddRange(metaDataInfo.Replicas);
-            var br = brokers.OrderBy(x => Random.Shared.Next()).ToList();
             var exceptions = new List<Exception>();
+            var br = brokers.OrderBy(x => Random.Shared.Next()).ToList();
+
             foreach (var broker in br)
             {
                 try
                 {
                     return await pool.GetOrCreateClient(broker.ToString(),
                         async () =>
-                            await LookupConnection(clientParameters, broker, MaxAttempts(metaDataInfo), logger)
+                            await LookupConnection(clientParameters, broker, MaxAttempts(metaDataInfo),
+                                    logger)
                                 .ConfigureAwait(false)).ConfigureAwait(false);
                 }
                 catch (Exception ex)

--- a/RabbitMQ.Stream.Client/RoutingClient.cs
+++ b/RabbitMQ.Stream.Client/RoutingClient.cs
@@ -170,7 +170,6 @@ namespace RabbitMQ.Stream.Client
         {
             var brokers = new List<Broker>() { metaDataInfo.Leader };
             brokers.AddRange(metaDataInfo.Replicas);
-            // brokers.Sort((_, _) => Random.Shared.Next(-1, 1));
             var br = brokers.OrderBy(x => Random.Shared.Next()).ToList();
             var exceptions = new List<Exception>();
             foreach (var broker in br)

--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -162,7 +162,7 @@ namespace RabbitMQ.Stream.Client
             }
         }
 
-        public async Task<IProducer> CreateRawSuperStreamProducer(
+        public async Task<ISuperStreamProducer> CreateRawSuperStreamProducer(
             RawSuperStreamProducerConfig rawSuperStreamProducerConfig, ILogger logger = null)
         {
             await MayBeReconnectLocator().ConfigureAwait(false);
@@ -222,7 +222,7 @@ namespace RabbitMQ.Stream.Client
             return partitions.Streams;
         }
 
-        public async Task<IConsumer> CreateSuperStreamConsumer(
+        public async Task<ISuperStreamConsumer> CreateSuperStreamConsumer(
             RawSuperStreamConsumerConfig rawSuperStreamConsumerConfig,
             ILogger logger = null)
         {

--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -284,8 +284,6 @@ namespace RabbitMQ.Stream.Client
 
                 var p = await RawProducer.Create(s,
                     rawProducerConfig, metaStreamInfo, logger).ConfigureAwait(false);
-                _logger?.LogDebug("Raw Producer: {Reference} created for Stream: {Stream}",
-                    rawProducerConfig.Reference, rawProducerConfig.Stream);
                 return p;
             }
             finally
@@ -294,7 +292,7 @@ namespace RabbitMQ.Stream.Client
             }
         }
 
-        private async Task<StreamInfo> StreamInfo(string streamName)
+        public async Task<StreamInfo> StreamInfo(string streamName)
         {
             // force localhost connection for single node clusters and when address resolver is not provided
             // when theres 1 endpoint and an address resolver, there could be a cluster behind a load balancer

--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -350,7 +350,15 @@ namespace RabbitMQ.Stream.Client
         public async Task<bool> StreamExists(string stream)
         {
             await MayBeReconnectLocator().ConfigureAwait(false);
-            return await _client.StreamExists(stream).ConfigureAwait(false);
+            await _semClientProvidedName.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                return await _client.StreamExists(stream).ConfigureAwait(false);
+            }
+            finally
+            {
+                _semClientProvidedName.Release();
+            }
         }
 
         private static void MaybeThrowQueryException(string reference, string stream)

--- a/Tests/RawConsumerSystemTests.cs
+++ b/Tests/RawConsumerSystemTests.cs
@@ -621,7 +621,7 @@ namespace Tests
             SystemUtils.Wait();
             await system.DeleteStream(stream);
             new Utils<bool>(testOutputHelper).WaitUntilTaskCompletes(testPassed);
-            Assert.False(((RawConsumer)rawConsumer).IsOpen());
+            SystemUtils.WaitUntil(() => ((RawConsumer)rawConsumer).IsOpen() == false);
             await rawConsumer.Close();
             await system.Close();
         }

--- a/Tests/ReliableTests.cs
+++ b/Tests/ReliableTests.cs
@@ -505,7 +505,7 @@ public class ReliableTests
             _exceptionType = exceptionType;
         }
 
-        internal override Task CreateNewEntity(bool boot)
+        protected override Task CreateNewEntity(bool boot)
         {
             if (!_firstTime)
             {

--- a/Tests/SuperStreamConsumerTests.cs
+++ b/Tests/SuperStreamConsumerTests.cs
@@ -32,19 +32,26 @@ public class SuperStreamConsumerTests
     {
         SystemUtils.ResetSuperStreams();
         var system = await StreamSystem.Create(new StreamSystemConfig());
-        var connectionName = Guid.NewGuid().ToString();
+        var clientProvidedName = Guid.NewGuid().ToString();
         var consumer = await system.CreateSuperStreamConsumer(
             new RawSuperStreamConsumerConfig(SystemUtils.InvoicesExchange)
             {
-                ClientProvidedName = connectionName,
+                ClientProvidedName = clientProvidedName,
                 OffsetSpec =
                     await SystemUtils.OffsetsForSuperStreamConsumer(system, "invoices", new OffsetTypeFirst())
             });
 
         Assert.NotNull(consumer);
         SystemUtils.Wait();
-        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName(connectionName).Result == 3);
+        
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_0").Result == 1);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_1").Result == 1);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_2").Result == 1);
         Assert.Equal(ResponseCode.Ok, await consumer.Close());
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_0").Result == 0);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_1").Result == 0);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_2").Result == 0);
+
         await system.Close();
     }
 
@@ -113,14 +120,22 @@ public class SuperStreamConsumerTests
 
         Assert.NotNull(consumer);
         SystemUtils.Wait();
-        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName(clientProvidedName).Result == 3);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_2").Result == 1);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_1").Result == 1);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_0").Result == 1);
         SystemUtils.HttpDeleteQueue(SystemUtils.InvoicesStream0);
-        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName(clientProvidedName).Result == 2);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_2").Result == 1);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_1").Result == 1);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_0").Result == 0);
         SystemUtils.HttpDeleteQueue(SystemUtils.InvoicesStream1);
-        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName(clientProvidedName).Result == 1);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_2").Result == 1);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_1").Result == 0);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_0").Result == 0);
         await consumer.Close();
         // in this case we don't have any connection anymore since the super stream consumer is closed
-        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName(clientProvidedName).Result == 0);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_2").Result == 0);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_1").Result == 0);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_0").Result == 0);
         Assert.Equal(ResponseCode.Ok, await consumer.Close());
         await system.Close();
     }
@@ -382,7 +397,9 @@ public class SuperStreamConsumerTests
 
         SystemUtils.Wait(TimeSpan.FromSeconds(2));
         // we kill the connections of the first super stream consumer ( so 3 connections one per stream)
-        SystemUtils.WaitUntil(() => SystemUtils.HttpKillConnections(clientProvidedName).Result == 3);
+        SystemUtils.WaitUntil(() => SystemUtils.HttpKillConnections($"{clientProvidedName}_0").Result == 1);
+        SystemUtils.WaitUntil(() => SystemUtils.HttpKillConnections($"{clientProvidedName}_1").Result == 1);
+        SystemUtils.WaitUntil(() => SystemUtils.HttpKillConnections($"{clientProvidedName}_2").Result == 1);
         SystemUtils.Wait(TimeSpan.FromSeconds(3));
         //  at this point the second consumer should be active and consume the messages
         // and the consumerUpdateListener should be called and the offset should be restored
@@ -399,7 +416,10 @@ public class SuperStreamConsumerTests
         }
 
         // just to be sure that the connections are killed
-        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName(clientProvidedName).Result == 0);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_0").Result == 0);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_1").Result == 0);
+        SystemUtils.WaitUntil(() => SystemUtils.ConnectionsCountByName($"{clientProvidedName}_2").Result == 0);
+        await consumerSingle.Close();
 
         await system.Close();
     }

--- a/Tests/SuperStreamProducerTests.cs
+++ b/Tests/SuperStreamProducerTests.cs
@@ -424,7 +424,6 @@ public class SuperStreamProducerTests
         // the method ReconnectPartition is used to reconnect the partition
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var clientName = Guid.NewGuid().ToString();
-        RawSuperStreamProducer streamProducer = null;
 
         var c = new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
         {
@@ -432,7 +431,7 @@ public class SuperStreamProducerTests
             ClientProvidedName = clientName,
         };
         var completed = new TaskCompletionSource<bool>();
-        streamProducer = (RawSuperStreamProducer)await system.CreateRawSuperStreamProducer(c);
+        var streamProducer = await system.CreateRawSuperStreamProducer(c);
         c.ConnectionClosedHandler = async (reason, stream) =>
         {
             var streamInfo = await system.StreamInfo(stream);

--- a/Tests/SuperStreamProducerTests.cs
+++ b/Tests/SuperStreamProducerTests.cs
@@ -143,7 +143,6 @@ public class SuperStreamProducerTests
             {
                 Routing = message1 => message1.Properties.MessageId.ToString(),
                 Reference = "reference",
-
             });
         Assert.True(streamProducer.MessagesSent == 0);
         Assert.True(streamProducer.ConfirmFrames == 0);
@@ -421,16 +420,27 @@ public class SuperStreamProducerTests
         SystemUtils.ResetSuperStreams();
         // This test validates that the super stream producer is able to recreate the connection
         // if the connection is killed
-        // It is NOT meant to test the availability of the super stream producer
-        // just the reconnect mechanism
+        // we use the connection closed handler to recreate the connection
+        // the method ReconnectPartition is used to reconnect the partition
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var clientName = Guid.NewGuid().ToString();
-        var streamProducer =
-            await system.CreateRawSuperStreamProducer(new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
-            {
-                Routing = message1 => message1.Properties.MessageId.ToString(),
-                ClientProvidedName = clientName
-            });
+        RawSuperStreamProducer streamProducer = null;
+
+        var c = new RawSuperStreamProducerConfig(SystemUtils.InvoicesExchange)
+        {
+            Routing = message1 => message1.Properties.MessageId.ToString(),
+            ClientProvidedName = clientName,
+        };
+        var completed = new TaskCompletionSource<bool>();
+        streamProducer = (RawSuperStreamProducer)await system.CreateRawSuperStreamProducer(c);
+        c.ConnectionClosedHandler = async (reason, stream) =>
+        {
+            var streamInfo = await system.StreamInfo(stream);
+            await streamProducer.ReconnectPartition(streamInfo);
+            SystemUtils.Wait();
+            completed.SetResult(true);
+        };
+
         for (ulong i = 0; i < 20; i++)
         {
             var message = new Message(Encoding.Default.GetBytes("hello"))
@@ -440,8 +450,8 @@ public class SuperStreamProducerTests
 
             if (i == 10)
             {
-                SystemUtils.WaitUntil(() => SystemUtils.HttpKillConnections(clientName).Result == 3);
-                // We just decide to close the connections
+                SystemUtils.WaitUntil(() => SystemUtils.HttpKillConnections($"{clientName}_0").Result == 1);
+                completed.Task.Wait();
             }
 
             // Here the connection _must_ be recreated  and the send the message 
@@ -453,7 +463,7 @@ public class SuperStreamProducerTests
         // according to the routing strategy hello{i} that must be the correct routing
         SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount(SystemUtils.InvoicesStream0) == 9);
         SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount(SystemUtils.InvoicesStream1) == 7);
-        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount("invoices-2") == 4);
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount(SystemUtils.InvoicesStream2) == 4);
         Assert.True(await streamProducer.Close() == ResponseCode.Ok);
         await system.Close();
     }
@@ -533,7 +543,7 @@ public class SuperStreamProducerTests
                     }
                 }
             });
-        for (ulong i = 0; i < 10; i++)
+        for (ulong i = 0; i < 20; i++)
         {
             var message = new Message(Encoding.Default.GetBytes("hello"))
             {
@@ -549,12 +559,21 @@ public class SuperStreamProducerTests
             }
 
             Thread.Sleep(200);
-
-            await streamProducer.Send(i, message);
+            try
+            {
+                await streamProducer.Send(i, message);
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is AlreadyClosedException);
+            }
         }
 
         SystemUtils.Wait();
         new Utils<bool>(_testOutputHelper).WaitUntilTaskCompletes(testPassed);
+        // even we removed a stream the producer should be able to send messages and maintain the hash routing
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount(SystemUtils.InvoicesStream1) == 7);
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount(SystemUtils.InvoicesStream2) == 4);
         Assert.True(await streamProducer.Close() == ResponseCode.Ok);
         await system.Close();
     }
@@ -750,13 +769,29 @@ public class SuperStreamProducerTests
         // just the reconnect mechanism
         var system = await StreamSystem.Create(new StreamSystemConfig());
         var clientName = Guid.NewGuid().ToString();
+        var testPassed = new TaskCompletionSource<bool>() { };
+        var received = 0;
+        var error = 0;
         var streamProducer = await Producer.Create(new ProducerConfig(system, SystemUtils.InvoicesExchange)
         {
-            SuperStreamConfig = new SuperStreamConfig()
+            SuperStreamConfig =
+                new SuperStreamConfig() { Routing = message1 => message1.Properties.MessageId.ToString() },
+            TimeoutMessageAfter = TimeSpan.FromSeconds(1),
+            ConfirmationHandler = async confirmation =>
             {
-                Routing = message1 => message1.Properties.MessageId.ToString()
+                if (confirmation.Status != ConfirmationStatus.Confirmed)
+                {
+                    Interlocked.Increment(ref error);
+                }
+
+                if (Interlocked.Increment(ref received) == 20)
+                {
+                    testPassed.SetResult(true);
+                }
+
+                await Task.CompletedTask;
             },
-            ClientProvidedName = clientName
+            ClientProvidedName = clientName,
         });
         for (ulong i = 0; i < 20; i++)
         {
@@ -764,14 +799,11 @@ public class SuperStreamProducerTests
             {
                 Properties = new Properties() { MessageId = $"hello{i}" }
             };
-
             if (i == 10)
             {
-                SystemUtils.WaitUntil(() => SystemUtils.HttpKillConnections(clientName).Result == 3);
                 // We just decide to close the connections
-                // we just wait a bit to be sure that the connections 
-                // will be re-opened
-                SystemUtils.Wait(TimeSpan.FromSeconds(1));
+                // The messages will go in time out since not confirmed
+                SystemUtils.WaitUntil(() => SystemUtils.HttpKillConnections($"{clientName}_0").Result == 1);
             }
 
             // Here the connection _must_ be recreated  and the message sent
@@ -779,11 +811,13 @@ public class SuperStreamProducerTests
         }
 
         SystemUtils.Wait();
-        // Total messages must be 20
-        // according to the routing strategy hello{i} that must be the correct routing
-        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount(SystemUtils.InvoicesStream0) == 9);
+        new Utils<bool>(_testOutputHelper).WaitUntilTaskCompletes(testPassed);
+        // killed the connection for the InvoicesStream0. So received + error must be 9
+        SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount(SystemUtils.InvoicesStream0) + error == 9);
         SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount(SystemUtils.InvoicesStream1) == 7);
         SystemUtils.WaitUntil(() => SystemUtils.HttpGetQMsgCount(SystemUtils.InvoicesStream2) == 4);
+
+        await streamProducer.Close();
         await system.Close();
     }
 }

--- a/Tests/UnitTests.cs
+++ b/Tests/UnitTests.cs
@@ -32,10 +32,12 @@ namespace Tests
         }
 
         public IDictionary<byte, (string, ConsumerEvents)> Consumers { get; }
+        public bool IsClosed { get; }
 
         public FakeClient(ClientParameters clientParameters)
         {
             Parameters = clientParameters;
+            IsClosed = false;
             Publishers =
                 new Dictionary<byte, (string, (Action<ReadOnlyMemory<ulong>>, Action<(ulong, ResponseCode)[]>))>();
             Consumers = new Dictionary<byte, (string, ConsumerEvents)>();

--- a/Tests/Utils.cs
+++ b/Tests/Utils.cs
@@ -200,13 +200,10 @@ namespace Tests
                     Routing = message1 => message1.Properties.MessageId.ToString(),
                     ConfirmHandler = _ =>
                     {
-                        count++;
-                        if (count != numberOfMessages)
+                        if (Interlocked.Increment(ref count) == numberOfMessages)
                         {
-                            return;
+                            testPassed.SetResult(count);
                         }
-
-                        testPassed.SetResult(count);
                     }
                 });
 


### PR DESCRIPTION
Fixes: https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/discussions/333
Fixes: https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/335

# Preface
The PR is focused on making the client more stable during the server restart and better handling the metadata update event.

Most of the changes are in the super stream producer and consumer.
See the issue https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/discussions/333

# 1- What's changed in the super stream part


The RawSuperStreamProducer and RawSuperStreamConsumer expose two callbacks:
- `ConnectionClosedHandler (reason, stream)` 
- `MetadataHandler(update)` 
- `ISuperStreamProducer` and `ISuperStreamConsumer` interfaces 

ConnectionClosedHandler
--
The callback is raised each time a partition is closed for some reason. You can check the reason with:
```
1- public const string Normal = "TCP connection closed normal";
2- public const string Unexpected = "TCP connection closed unexpected";
```

1- The super stream partition is closed by the `Close()` method, so there are no problems. It can be helpful in terms of alerting or logs.

2- The super stream partition is closed in an unexpected way like kill the connection, network problems broker restart etc..

In that case, you can reconnect the partition with the `ReconnectPartition` method.
Like:
```csharp
var config = new RawSuperStreamProducerConfig("MySuperStream")
        {
            Routing = message1 => message1.Properties.MessageId.ToString(),
            ClientProvidedName = clientName,
        };
streamProducer = await system.CreateRawSuperStreamProducer(config);
        config.ConnectionClosedHandler = async (reason, stream) =>
        {
            // here, you can decide if it makes sense to wait a bit before reconnecting the 
			// partition
			var streamInfo = await system.StreamInfo(stream);
            await streamProducer.ReconnectPartition(streamInfo);
        };
```

MetadataHandler
---
It happens when there is a change in the stream topology.
See the document for more details.

In this case, the server drops all the producers and consumers. So, you need to react to the Metadata Handler event.  You can decide to reconnect the producer and consumer
using the `ReconnectPartition` 

Producer and Consumer classes
--

The `Producer` and `Consumer` classes handle automatically the `ConnectionClosedHandler` and the `MetadataHandler` events for stream and super stream.


# 2- Fail fast

The Producer and Consumer classes can restore the connection automatically when they are up and running.
The classes will fail immediately if there are problems during the first connection.
This behaviour is now like the Java Client's.


# 3- Survive a cluster restart

Please follow [this presentation](https://docs.google.com/presentation/d/111PccBLRGb-RNpYEKeIm2MQvdky-fXrQ/edit?usp=sharing&ouid=106772747306273309885&rtpof=true&sd=true
) to understand what happens during a cluster restart

You can create your own way to handle the reconnection based on Raw Classes.

