### PR TITLE
Check the entity status during the close

### DIFF
--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -219,6 +219,8 @@ RabbitMQ.Stream.Client.Reliable.ProducerConfig.Filter.set -> void
 RabbitMQ.Stream.Client.Reliable.ProducerConfig.Reference.set -> void
 RabbitMQ.Stream.Client.Reliable.ProducerFactory.CreateProducer(bool boot) -> System.Threading.Tasks.Task<RabbitMQ.Stream.Client.IProducer>
 RabbitMQ.Stream.Client.Reliable.ProducerFactory._producer -> RabbitMQ.Stream.Client.IProducer
+RabbitMQ.Stream.Client.Reliable.ReliableBase.IsClosedNormally() -> bool
+RabbitMQ.Stream.Client.Reliable.ReliableBase.IsClosedNormally(string closeReason) -> bool
 RabbitMQ.Stream.Client.Reliable.ReliableBase.UpdateStatus(RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus newStatus, RabbitMQ.Stream.Client.Reliable.ChangeStatusReason reason, string partition = null) -> void
 RabbitMQ.Stream.Client.Reliable.ReliableBase._status -> RabbitMQ.Stream.Client.Reliable.ReliableEntityStatus
 RabbitMQ.Stream.Client.Reliable.ReliableConfig.Identifier.get -> string

--- a/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ReliableBase.cs
@@ -114,6 +114,19 @@ public abstract class ReliableBase
         await Task.Delay(Consts.RandomMid()).ConfigureAwait(false);
     }
 
+    protected bool IsClosedNormally(string closeReason)
+    {
+        if (closeReason != ConnectionClosedReason.Normal && !CompareStatus(ReliableEntityStatus.Closed)) return false;
+        BaseLogger.LogInformation("{Identity} is closed normally", ToString());
+        return true;
+    }
+    protected bool IsClosedNormally()
+    {
+        if (!CompareStatus(ReliableEntityStatus.Closed)) return false;
+        BaseLogger.LogInformation("{Identity} is closed normally", ToString());
+        return true;
+    }
+
     protected void UpdateStatus(ReliableEntityStatus newStatus,
         ChangeStatusReason reason, string partition = null)
     {

--- a/docs/ReliableClient/Program.cs
+++ b/docs/ReliableClient/Program.cs
@@ -7,18 +7,18 @@ Console.WriteLine("Starting RabbitMQ Streaming Client");
 
 var rClient = RClient.Start(new RClient.Config()
 {
-    ProducersPerConnection = 2, 
+    ProducersPerConnection = 100, 
     ConsumersPerConnection = 100,
-    Host = "localhost",
+    Host = "node0",
     Port = 5552,
     LoadBalancer = true,
     SuperStream = false,
-    Streams = 10,
-    Producers = 4,
+    Streams = 3,
+    Producers = 10,
     MessagesPerProducer = 50_000_000,
-    Consumers = 4
-    // Username = "test",
-    // Password = "test"
+    Consumers = 10,
+    Username = "test",
+    Password = "test"
 });
 
 await rClient.ConfigureAwait(false);

--- a/docs/ReliableClient/RClient.cs
+++ b/docs/ReliableClient/RClient.cs
@@ -261,7 +261,7 @@ public class RClient
                                 Properties = new Properties() {MessageId = $"hello{i}"}
                             };
                             await MaybeSend(producer, message, publishEvent).ConfigureAwait(false);
-                            await Task.Delay(500).ConfigureAwait(false);
+                            await Task.Delay(20).ConfigureAwait(false);
                             Interlocked.Increment(ref totalSent);
                         }
                     });


### PR DESCRIPTION
Check the entity status when is closed on the disconnection. When the entity is closed normally and there is some network problem the client could receive an closed unexpected even the entity is closed normally. A double check helps to handle this edge case