### PR TITLE
Add RCP timeout

### DIFF
--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -54,6 +54,8 @@ RabbitMQ.Stream.Client.ClientParameters.AuthMechanism.get -> RabbitMQ.Stream.Cli
 RabbitMQ.Stream.Client.ClientParameters.AuthMechanism.set -> void
 RabbitMQ.Stream.Client.ClientParameters.MetadataUpdateHandler
 RabbitMQ.Stream.Client.ClientParameters.OnMetadataUpdate -> RabbitMQ.Stream.Client.ClientParameters.MetadataUpdateHandler
+RabbitMQ.Stream.Client.ClientParameters.RpcTimeOut.get -> System.TimeSpan
+RabbitMQ.Stream.Client.ClientParameters.RpcTimeOut.set -> void
 RabbitMQ.Stream.Client.Connection.UpdateCloseStatus(string reason) -> void
 RabbitMQ.Stream.Client.ConnectionItem
 RabbitMQ.Stream.Client.ConnectionItem.Available.get -> bool
@@ -324,6 +326,8 @@ RabbitMQ.Stream.Client.StreamSystemConfig.AuthMechanism.get -> RabbitMQ.Stream.C
 RabbitMQ.Stream.Client.StreamSystemConfig.AuthMechanism.set -> void
 RabbitMQ.Stream.Client.StreamSystemConfig.ConnectionPoolConfig.get -> RabbitMQ.Stream.Client.ConnectionPoolConfig
 RabbitMQ.Stream.Client.StreamSystemConfig.ConnectionPoolConfig.set -> void
+RabbitMQ.Stream.Client.StreamSystemConfig.RpcTimeOut.get -> System.TimeSpan
+RabbitMQ.Stream.Client.StreamSystemConfig.RpcTimeOut.set -> void
 RabbitMQ.Stream.Client.SuperStreamSpec
 RabbitMQ.Stream.Client.SuperStreamSpec.Args.get -> System.Collections.Generic.IDictionary<string, string>
 RabbitMQ.Stream.Client.SuperStreamSpec.LeaderLocator.set -> void

--- a/RabbitMQ.Stream.Client/StreamSystem.cs
+++ b/RabbitMQ.Stream.Client/StreamSystem.cs
@@ -20,6 +20,11 @@ namespace RabbitMQ.Stream.Client
             {
                 throw new ArgumentException("ConnectionPoolConfig can't be null");
             }
+
+            if (RpcTimeOut < TimeSpan.FromSeconds(1))
+            {
+                throw new ArgumentException("RpcTimeOut must be at least 1 second");
+            }
         }
 
         public string UserName { get; set; } = "guest";
@@ -44,6 +49,13 @@ namespace RabbitMQ.Stream.Client
         ///  Configure the connection pool for producers and consumers.
         /// </summary>
         public ConnectionPoolConfig ConnectionPoolConfig { get; set; } = new();
+
+        /// <summary>
+        ///  The timeout for RPC calls, like PeerProperties, QueryMetadata, etc.
+        /// Default value is 10 seconds and in most cases it should be enough.
+        /// Low value can cause false errors in the client.
+        /// </summary>
+        public TimeSpan RpcTimeOut { get; set; } = TimeSpan.FromSeconds(10);
     }
 
     public class StreamSystem
@@ -85,7 +97,8 @@ namespace RabbitMQ.Stream.Client
                 ClientProvidedName = config.ClientProvidedName,
                 Heartbeat = config.Heartbeat,
                 Endpoints = config.Endpoints,
-                AuthMechanism = config.AuthMechanism
+                AuthMechanism = config.AuthMechanism,
+                RpcTimeOut = config.RpcTimeOut
             };
             // create the metadata client connection
             foreach (var endPoint in clientParams.Endpoints)

--- a/Tests/SystemTests.cs
+++ b/Tests/SystemTests.cs
@@ -275,6 +275,15 @@ namespace Tests
         }
 
         [Fact]
+        public async void ValidateRpCtimeOut()
+        {
+            var config = new StreamSystemConfig() { RpcTimeOut = TimeSpan.FromMilliseconds(1) };
+            await Assert.ThrowsAsync<ArgumentException>(
+                async () => { await StreamSystem.Create(config); }
+            );
+        }
+
+        [Fact]
         public async void CloseProducerConsumerAfterForceCloseShouldNotRaiseError()
         {
             // This tests that the producers and consumers

--- a/kubernetes/stream_cluster.yaml
+++ b/kubernetes/stream_cluster.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: stream-clients-test
 spec:
   replicas: 3
-  image: rabbitmq:3.13-rc-management
+  image: rabbitmq:3.13-management
   service:
     type: LoadBalancer
   # tls:


### PR DESCRIPTION
configuration. Check the logic status before setting the event.
Fixes: https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/384

Thanks to @mbaillargeon-ubi for the debug.  

The PR adds also the `RpcTimeOut` configuration:
```
      var config = new StreamSystemConfig() { RpcTimeOut = TimeSpan.Seconds(5) };
    
```