### PR TITLE
Follow-up to #385

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -976,10 +976,12 @@ namespace RabbitMQ.Stream.Client
         public void SetException(Exception error)
         {
             // https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/384
-            // we need to check if the task is pending before setting the exception
-            if (_logic.GetStatus(_logic.Version) == ValueTaskSourceStatus.Pending)
+            try
             {
                 _logic.SetException(error);
+            }
+            catch (InvalidOperationException)
+            {
             }
         }
 


### PR DESCRIPTION
There is still a slim chance that the code in #385 will throw `InvalidOperationException`, since the check and call to `SetException` is not atomic.

`ManualResetValueTaskSource` does not have `TrySetException` like `TaskCompletionSource`.