### PR TITLE
Fix Client memory leak caused by not detaching UnhandledException event handler

### DIFF
--- a/RabbitMQ.Stream.Client/Client.cs
+++ b/RabbitMQ.Stream.Client/Client.cs
@@ -59,7 +59,6 @@ namespace RabbitMQ.Stream.Client
         public delegate Task MetadataUpdateHandler(MetaDataUpdate update);
 
         public event MetadataUpdateHandler OnMetadataUpdate;
-        public Action<Exception> UnhandledExceptionHandler { get; set; } = _ => { };
         public TimeSpan Heartbeat { get; set; } = TimeSpan.FromMinutes(1);
 
         public string ClientProvidedName
@@ -164,11 +163,6 @@ namespace RabbitMQ.Stream.Client
             IsClosed = false;
             _logger = logger ?? NullLogger.Instance;
             ClientId = Guid.NewGuid().ToString();
-            AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
-            {
-                _logger.LogError(args.ExceptionObject as Exception, "Unhandled exception");
-                Parameters.UnhandledExceptionHandler(args.ExceptionObject as Exception);
-            };
         }
 
         public bool IsClosed

--- a/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
@@ -200,8 +200,6 @@ RabbitMQ.Stream.Client.ClientParameters.Password.set -> void
 RabbitMQ.Stream.Client.ClientParameters.Properties.get -> System.Collections.Generic.IDictionary<string, string>
 RabbitMQ.Stream.Client.ClientParameters.Ssl.get -> RabbitMQ.Stream.Client.SslOption
 RabbitMQ.Stream.Client.ClientParameters.Ssl.set -> void
-RabbitMQ.Stream.Client.ClientParameters.UnhandledExceptionHandler.get -> System.Action<System.Exception>
-RabbitMQ.Stream.Client.ClientParameters.UnhandledExceptionHandler.set -> void
 RabbitMQ.Stream.Client.ClientParameters.UserName.get -> string
 RabbitMQ.Stream.Client.ClientParameters.UserName.set -> void
 RabbitMQ.Stream.Client.ClientParameters.VirtualHost.get -> string


### PR DESCRIPTION
The event handler registered in the client's constructor closes over the client, and is never detached. The AppDomain.CurrentDomain UnhandledException event invocation list lives for the length of the program and acts as a GC root for any created clients (due to the addition of this handler), this means clients will get leaked even if they are no longer reachable from elsewhere in the program.

In this PR I have just removed the registration of the handler, I think it's fairly unusual for a client library to need to register a handler to receive notification for all unhandled exceptions in the current app domain. But please let me know if you disagree.

(On a separate but related note, I have also noticed that the underlying socket in Connection is not deterministically cleaned up, for example if Client.Create throws, connection is not disposed of and we rely on the finalizer of Socket to clean up underlying resources (at the moment the finalizer never runs because of the reference chain Client -> Connection -> Socket and the event handler never being detached) 