### PR TITLE
Ability to use memory from the pool

### DIFF
--- a/RabbitMQ.Stream.Client.PerfTest/Program.fs
+++ b/RabbitMQ.Stream.Client.PerfTest/Program.fs
@@ -40,7 +40,7 @@ let main argv =
         let! producer = system.CreateRawProducer producerConfig
         //make producer available to metrics async
         prod <- producer
-        let msg = Message "asdf"B
+        let msg = new Message "asdf"B
         while run do
             let! _ = producer.Send(publishingId, msg)
             publishingId <- publishingId + 1UL

--- a/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Shipped.txt
@@ -382,8 +382,11 @@ RabbitMQ.Stream.Client.Message.Annotations.get -> RabbitMQ.Stream.Client.AMQP.An
 RabbitMQ.Stream.Client.Message.ApplicationProperties.get -> RabbitMQ.Stream.Client.AMQP.ApplicationProperties
 RabbitMQ.Stream.Client.Message.ApplicationProperties.set -> void
 RabbitMQ.Stream.Client.Message.Data.get -> RabbitMQ.Stream.Client.AMQP.Data
+RabbitMQ.Stream.Client.Message.Message(System.Buffers.IMemoryOwner<byte> memory, int payloadSize) -> void
 RabbitMQ.Stream.Client.Message.Message(byte[] data) -> void
 RabbitMQ.Stream.Client.Message.Message(RabbitMQ.Stream.Client.AMQP.Data data) -> void
+RabbitMQ.Stream.Client.Message.Dispose() -> void
+RabbitMQ.Stream.Client.Message.~Message() -> void
 RabbitMQ.Stream.Client.Message.MessageHeader.get -> RabbitMQ.Stream.Client.AMQP.Header
 RabbitMQ.Stream.Client.Message.Properties.get -> RabbitMQ.Stream.Client.AMQP.Properties
 RabbitMQ.Stream.Client.Message.Properties.set -> void


### PR DESCRIPTION
Usage:
```csharp
var producerConfig = new DeduplicatingProducerConfig(...)
{
    ConfirmationHandler = async confirmation =>
    {
        // call dispose on each confirmation.Messages or do nothing
    },
};

var producer = await DeduplicatingProducer.Create(producerConfig, ...);
// start producer...

// send new message
var memory = MemoryPool<byte>.Shared.Rent(10);
// fill memory...

await producer.Send(
    messageId,
    new Message(memory, 10));
```