### PR TITLE
Last offset fix

### DIFF
--- a/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
@@ -76,12 +76,13 @@ public abstract class ConsumerFactory : ReliableBase
             MessageHandler = async (consumer, ctx, message) =>
             {
                 _consumedFirstTime = true;
-                _lastOffsetConsumed[_consumerConfig.Stream] = ctx.Offset;
                 if (_consumerConfig.MessageHandler != null)
                 {
                     await _consumerConfig.MessageHandler(_consumerConfig.Stream, consumer, ctx, message)
                         .ConfigureAwait(false);
                 }
+                _lastOffsetConsumed[_consumerConfig.Stream] = ctx.Offset;
+
             },
         }, BaseLogger).ConfigureAwait(false);
     }

--- a/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
@@ -75,12 +75,12 @@ public abstract class ConsumerFactory : ReliableBase
             },
             MessageHandler = async (consumer, ctx, message) =>
             {
-                _consumedFirstTime = true;
                 if (_consumerConfig.MessageHandler != null)
                 {
                     await _consumerConfig.MessageHandler(_consumerConfig.Stream, consumer, ctx, message)
                         .ConfigureAwait(false);
                 }
+                _consumedFirstTime = true;
                 _lastOffsetConsumed[_consumerConfig.Stream] = ctx.Offset;
 
             },
@@ -147,13 +147,14 @@ public abstract class ConsumerFactory : ReliableBase
                     },
                     MessageHandler = async (partitionStream, consumer, ctx, message) =>
                     {
-                        _consumedFirstTime = true;
-                        _lastOffsetConsumed[_consumerConfig.Stream] = ctx.Offset;
                         if (_consumerConfig.MessageHandler != null)
                         {
                             await _consumerConfig.MessageHandler(partitionStream, consumer, ctx,
                                 message).ConfigureAwait(false);
                         }
+                        _consumedFirstTime = true;
+                        _lastOffsetConsumed[_consumerConfig.Stream] = ctx.Offset;
+
                     },
                 }, BaseLogger).ConfigureAwait(false);
         }

--- a/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
@@ -80,9 +80,9 @@ public abstract class ConsumerFactory : ReliableBase
                     await _consumerConfig.MessageHandler(_consumerConfig.Stream, consumer, ctx, message)
                         .ConfigureAwait(false);
                 }
+
                 _consumedFirstTime = true;
                 _lastOffsetConsumed[_consumerConfig.Stream] = ctx.Offset;
-
             },
         }, BaseLogger).ConfigureAwait(false);
     }
@@ -152,9 +152,9 @@ public abstract class ConsumerFactory : ReliableBase
                             await _consumerConfig.MessageHandler(partitionStream, consumer, ctx,
                                 message).ConfigureAwait(false);
                         }
+
                         _consumedFirstTime = true;
                         _lastOffsetConsumed[_consumerConfig.Stream] = ctx.Offset;
-
                     },
                 }, BaseLogger).ConfigureAwait(false);
         }


### PR DESCRIPTION
This change ensures that the reliable consumer tracks the lastOffsetConsumed correctly, allowing it to reconnect to the correct offset in the event of a reconnection.

**Before this PR:**
The lastOffsetConsumed was recorded before the message handler was executed, which could result in potential message loss during connection issues or consumer reconnections.

**After this PR:**
The lastOffsetConsumed will be stored after the message handler is executed, preventing message loss in the event of connection issues or reconnections.