### PR TITLE
Add consumer flow control

### DIFF
--- a/RabbitMQ.Stream.Client/Consts.cs
+++ b/RabbitMQ.Stream.Client/Consts.cs
@@ -15,8 +15,6 @@ namespace RabbitMQ.Stream.Client
         internal static readonly TimeSpan MidWait = TimeSpan.FromSeconds(3);
         internal static readonly TimeSpan LongWait = TimeSpan.FromSeconds(10);
         internal const ushort ConsumerInitialCredits = 2;
-        internal const ushort MaxRequestsCredits = 20;
-        internal const ushort DefaultRequestsCredits = 1;
 
         internal const byte Version1 = 1;
         internal const byte Version2 = 2;

--- a/RabbitMQ.Stream.Client/Consts.cs
+++ b/RabbitMQ.Stream.Client/Consts.cs
@@ -15,6 +15,9 @@ namespace RabbitMQ.Stream.Client
         internal static readonly TimeSpan MidWait = TimeSpan.FromSeconds(3);
         internal static readonly TimeSpan LongWait = TimeSpan.FromSeconds(10);
         internal const ushort ConsumerInitialCredits = 2;
+        internal const ushort MaxRequestsCredits = 20;
+        internal const ushort DefaultRequestsCredits = 1;
+
         internal const byte Version1 = 1;
         internal const byte Version2 = 2;
         internal const string SubscriptionPropertyFilterPrefix = "filter.";

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -98,19 +98,20 @@ public enum ConsumerFlowStrategy
     /// Request credits before parsing the chunk.
     /// Default strategy. The best for performance.
     /// </summary>
-    CreditBeforeParseChunk,
+    CreditsBeforeParseChunk,
 
     /// <summary>
     /// Request credits after parsing the chunk.
     /// It can be useful if the parsing is expensive and you want to avoid requesting credits too early.
     /// Useful for slow processing of chunks.
     /// </summary>
-    CreditAfterParseChunk,
+    CreditsAfterParseChunk,
 
     /// <summary>
-    ///  The user manually requests credits.
+    /// The user manually requests credits.
+    /// With raw consumer, the user must call <see cref="RawConsumer.RequestCredits"/> after processing the chunk.
     /// </summary>
-    ManualRequestCredit
+    ManualCreditsRequest
 }
 
 /// <summary>
@@ -120,6 +121,6 @@ public enum ConsumerFlowStrategy
 /// </summary>ra
 public class FlowControl
 {
-    public ConsumerFlowStrategy Strategy { get; set; } = ConsumerFlowStrategy.CreditBeforeParseChunk;
+    public ConsumerFlowStrategy Strategy { get; set; } = ConsumerFlowStrategy.CreditsBeforeParseChunk;
 
 }

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -108,11 +108,9 @@ public enum ConsumerFlowStrategy
     CreditAfterParseChunk,
 
     /// <summary>
-    /// Request credits when half of the chunk is processed.
-    /// In the middle between CreditBeforeParseChunk and CreditAfterParseChunk.
-    /// Can be useful if you want to balance the performance and the processing time.
+    ///  The user manually requests credits.
     /// </summary>
-    CreditWhenHalfChunkProcessed
+    ManualRequestCredit
 }
 
 /// <summary>

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -108,10 +108,11 @@ public enum ConsumerFlowStrategy
     CreditsAfterParseChunk,
 
     /// <summary>
-    /// The user manually requests credits.
-    /// With raw consumer, the user must call <see cref="RawConsumer.RequestCredits()"/> after processing the chunk.
+    /// The user manually requests credits with <see cref="RawConsumer.Credits"/>
+    /// to request credits and
+    /// have more chunks to process.
     /// </summary>
-    ManualCreditsRequest
+    ConsumerCredits
 }
 
 /// <summary>

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -108,9 +108,8 @@ public enum ConsumerFlowStrategy
     CreditsAfterParseChunk,
 
     /// <summary>
-    /// The user manually requests credits with <see cref="RawConsumer.Credits"/>
-    /// to request credits and
-    /// have more chunks to process.
+    /// The user manually requests credits with <see cref="RawConsumer.Credits()"/>
+    /// Everything is done manually, so the user has full control over the flow of the consumer.
     /// </summary>
     ConsumerCredits
 }

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -109,7 +109,7 @@ public enum ConsumerFlowStrategy
 
     /// <summary>
     /// The user manually requests credits.
-    /// With raw consumer, the user must call <see cref="RawConsumer.RequestCredits"/> after processing the chunk.
+    /// With raw consumer, the user must call <see cref="RawConsumer.RequestCredits()"/> after processing the chunk.
     /// </summary>
     ManualCreditsRequest
 }

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -96,17 +96,30 @@ public enum ConsumerFlowStrategy
 {
     /// <summary>
     /// Request credits before parsing the chunk.
+    /// Default strategy. The best for performance.
     /// </summary>
     CreditBeforeParseChunk,
 
     /// <summary>
-    ///
+    /// Request credits after parsing the chunk.
+    /// It can be useful if the parsing is expensive and you want to avoid requesting credits too early.
+    /// Useful for slow processing of chunks.
     /// </summary>
     CreditAfterParseChunk,
 
+    /// <summary>
+    /// Request credits when half of the chunk is processed.
+    /// In the middle between CreditBeforeParseChunk and CreditAfterParseChunk.
+    /// Can be useful if you want to balance the performance and the processing time.
+    /// </summary>
     CreditWhenHalfChunkProcessed
 }
 
+/// <summary>
+/// FlowControl is used to control the flow of the consumer.
+/// See <see cref="ConsumerFlowStrategy"/> for the available strategies.
+/// Open for future extensions.
+/// </summary>ra
 public class FlowControl
 {
     public ConsumerFlowStrategy Strategy { get; set; } = ConsumerFlowStrategy.CreditBeforeParseChunk;

--- a/RabbitMQ.Stream.Client/IConsumer.cs
+++ b/RabbitMQ.Stream.Client/IConsumer.cs
@@ -74,17 +74,15 @@ public record IConsumerConfig : EntityCommonConfig, INamedEntity
     // It is enabled by default. You can disable it by setting it to null.
     // It is recommended to keep it enabled. Disable it only for performance reasons.
     public ICrc32 Crc32 { get; set; } = new StreamCrc32();
+
+    public FlowControl FlowControl { get; set; } = new FlowControl();
 }
 
-public class ConsumerInfo : Info
-{
-    public string Reference { get; }
-
-    public ConsumerInfo(string stream, string reference, string identifier, List<string> partitions) : base(stream,
+public class ConsumerInfo(string stream, string reference, string identifier, List<string> partitions)
+    : Info(stream,
         identifier, partitions)
-    {
-        Reference = reference;
-    }
+{
+    public string Reference { get; } = reference;
 
     public override string ToString()
     {
@@ -92,4 +90,25 @@ public class ConsumerInfo : Info
         return
             $"ConsumerInfo(Stream={Stream}, Reference={Reference}, Identifier={Identifier}, Partitions={string.Join(",", partitions)})";
     }
+}
+
+public enum ConsumerFlowStrategy
+{
+    /// <summary>
+    /// Request credits before parsing the chunk.
+    /// </summary>
+    CreditBeforeParseChunk,
+
+    /// <summary>
+    ///
+    /// </summary>
+    CreditAfterParseChunk,
+
+    CreditWhenHalfChunkProcessed
+}
+
+public class FlowControl
+{
+    public ConsumerFlowStrategy Strategy { get; set; } = ConsumerFlowStrategy.CreditBeforeParseChunk;
+
 }

--- a/RabbitMQ.Stream.Client/ICrc32.cs
+++ b/RabbitMQ.Stream.Client/ICrc32.cs
@@ -36,6 +36,6 @@ namespace RabbitMQ.Stream.Client
         /// It is possible to add custom logic to handle the failure, such as logging.
         /// The code here should be safe 
         /// </summary>
-        Func<IConsumer, ChunkAction> FailAction { get; set; }
+        Func<IConsumer, ChunkAction> FailAction { get; init; }
     }
 }

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -110,9 +110,9 @@ RabbitMQ.Stream.Client.ConsumerFilter.PostFilter.set -> void
 RabbitMQ.Stream.Client.ConsumerFilter.Values.get -> System.Collections.Generic.List<string>
 RabbitMQ.Stream.Client.ConsumerFilter.Values.set -> void
 RabbitMQ.Stream.Client.ConsumerFlowStrategy
-RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditAfterParseChunk = 1 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
-RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditBeforeParseChunk = 0 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
-RabbitMQ.Stream.Client.ConsumerFlowStrategy.ManualRequestCredit = 2 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
+RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditsAfterParseChunk = 1 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
+RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditsBeforeParseChunk = 0 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
+RabbitMQ.Stream.Client.ConsumerFlowStrategy.ManualCreditsRequest = 2 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
 RabbitMQ.Stream.Client.ConsumerInfo
 RabbitMQ.Stream.Client.ConsumerInfo.ConsumerInfo(string stream, string reference, string identifier, System.Collections.Generic.List<string> partitions) -> void
 RabbitMQ.Stream.Client.ConsumerInfo.Reference.get -> string

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -110,9 +110,9 @@ RabbitMQ.Stream.Client.ConsumerFilter.PostFilter.set -> void
 RabbitMQ.Stream.Client.ConsumerFilter.Values.get -> System.Collections.Generic.List<string>
 RabbitMQ.Stream.Client.ConsumerFilter.Values.set -> void
 RabbitMQ.Stream.Client.ConsumerFlowStrategy
+RabbitMQ.Stream.Client.ConsumerFlowStrategy.ConsumerCredits = 2 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
 RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditsAfterParseChunk = 1 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
 RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditsBeforeParseChunk = 0 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
-RabbitMQ.Stream.Client.ConsumerFlowStrategy.ManualCreditsRequest = 2 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
 RabbitMQ.Stream.Client.ConsumerInfo
 RabbitMQ.Stream.Client.ConsumerInfo.ConsumerInfo(string stream, string reference, string identifier, System.Collections.Generic.List<string> partitions) -> void
 RabbitMQ.Stream.Client.ConsumerInfo.Reference.get -> string
@@ -238,8 +238,8 @@ RabbitMQ.Stream.Client.PublishFilter.PublishFilter() -> void
 RabbitMQ.Stream.Client.PublishFilter.PublishFilter(byte publisherId, System.Collections.Generic.List<(ulong, RabbitMQ.Stream.Client.Message)> messages, System.Func<RabbitMQ.Stream.Client.Message, string> filterValueExtractor, Microsoft.Extensions.Logging.ILogger logger) -> void
 RabbitMQ.Stream.Client.PublishFilter.SizeNeeded.get -> int
 RabbitMQ.Stream.Client.PublishFilter.Write(System.Span<byte> span) -> int
+RabbitMQ.Stream.Client.RawConsumer.Credits() -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.RawConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
-RabbitMQ.Stream.Client.RawConsumer.RequestCredits() -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.RawConsumerConfig.ConnectionClosedHandler.get -> System.Func<string, System.Threading.Tasks.Task>
 RabbitMQ.Stream.Client.RawConsumerConfig.ConnectionClosedHandler.set -> void
 RabbitMQ.Stream.Client.RawProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -112,7 +112,7 @@ RabbitMQ.Stream.Client.ConsumerFilter.Values.set -> void
 RabbitMQ.Stream.Client.ConsumerFlowStrategy
 RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditAfterParseChunk = 1 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
 RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditBeforeParseChunk = 0 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
-RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditWhenHalfChunkProcessed = 2 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
+RabbitMQ.Stream.Client.ConsumerFlowStrategy.ManualRequestCredit = 2 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
 RabbitMQ.Stream.Client.ConsumerInfo
 RabbitMQ.Stream.Client.ConsumerInfo.ConsumerInfo(string stream, string reference, string identifier, System.Collections.Generic.List<string> partitions) -> void
 RabbitMQ.Stream.Client.ConsumerInfo.Reference.get -> string
@@ -239,6 +239,7 @@ RabbitMQ.Stream.Client.PublishFilter.PublishFilter(byte publisherId, System.Coll
 RabbitMQ.Stream.Client.PublishFilter.SizeNeeded.get -> int
 RabbitMQ.Stream.Client.PublishFilter.Write(System.Span<byte> span) -> int
 RabbitMQ.Stream.Client.RawConsumer.Info.get -> RabbitMQ.Stream.Client.ConsumerInfo
+RabbitMQ.Stream.Client.RawConsumer.RequestCredits() -> System.Threading.Tasks.Task
 RabbitMQ.Stream.Client.RawConsumerConfig.ConnectionClosedHandler.get -> System.Func<string, System.Threading.Tasks.Task>
 RabbitMQ.Stream.Client.RawConsumerConfig.ConnectionClosedHandler.set -> void
 RabbitMQ.Stream.Client.RawProducer.Info.get -> RabbitMQ.Stream.Client.ProducerInfo

--- a/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.Stream.Client/PublicAPI.Unshipped.txt
@@ -109,6 +109,10 @@ RabbitMQ.Stream.Client.ConsumerFilter.PostFilter.get -> System.Func<RabbitMQ.Str
 RabbitMQ.Stream.Client.ConsumerFilter.PostFilter.set -> void
 RabbitMQ.Stream.Client.ConsumerFilter.Values.get -> System.Collections.Generic.List<string>
 RabbitMQ.Stream.Client.ConsumerFilter.Values.set -> void
+RabbitMQ.Stream.Client.ConsumerFlowStrategy
+RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditAfterParseChunk = 1 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
+RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditBeforeParseChunk = 0 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
+RabbitMQ.Stream.Client.ConsumerFlowStrategy.CreditWhenHalfChunkProcessed = 2 -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
 RabbitMQ.Stream.Client.ConsumerInfo
 RabbitMQ.Stream.Client.ConsumerInfo.ConsumerInfo(string stream, string reference, string identifier, System.Collections.Generic.List<string> partitions) -> void
 RabbitMQ.Stream.Client.ConsumerInfo.Reference.get -> string
@@ -137,6 +141,10 @@ RabbitMQ.Stream.Client.EntityCommonConfig.Identifier.get -> string
 RabbitMQ.Stream.Client.EntityCommonConfig.Identifier.set -> void
 RabbitMQ.Stream.Client.EntityCommonConfig.MetadataHandler.get -> System.Func<RabbitMQ.Stream.Client.MetaDataUpdate, System.Threading.Tasks.Task>
 RabbitMQ.Stream.Client.EntityCommonConfig.MetadataHandler.set -> void
+RabbitMQ.Stream.Client.FlowControl
+RabbitMQ.Stream.Client.FlowControl.FlowControl() -> void
+RabbitMQ.Stream.Client.FlowControl.Strategy.get -> RabbitMQ.Stream.Client.ConsumerFlowStrategy
+RabbitMQ.Stream.Client.FlowControl.Strategy.set -> void
 RabbitMQ.Stream.Client.HashRoutingMurmurStrategy.Route(RabbitMQ.Stream.Client.Message message, System.Collections.Generic.List<string> partitions) -> System.Threading.Tasks.Task<System.Collections.Generic.List<string>>
 RabbitMQ.Stream.Client.HeartBeatHandler.HeartBeatHandler(System.Func<System.Threading.Tasks.ValueTask<bool>> sendHeartbeatFunc, System.Func<string, string, System.Threading.Tasks.Task<RabbitMQ.Stream.Client.CloseResponse>> close, int heartbeat, Microsoft.Extensions.Logging.ILogger<RabbitMQ.Stream.Client.HeartBeatHandler> logger = null) -> void
 RabbitMQ.Stream.Client.IClient.ClientId.get -> string
@@ -173,11 +181,13 @@ RabbitMQ.Stream.Client.ICommandVersions.Command.get -> ushort
 RabbitMQ.Stream.Client.ICommandVersions.MaxVersion.get -> ushort
 RabbitMQ.Stream.Client.ICommandVersions.MinVersion.get -> ushort
 RabbitMQ.Stream.Client.IConsumerConfig.ConsumerFilter.set -> void
+RabbitMQ.Stream.Client.IConsumerConfig.FlowControl.get -> RabbitMQ.Stream.Client.FlowControl
+RabbitMQ.Stream.Client.IConsumerConfig.FlowControl.set -> void
 RabbitMQ.Stream.Client.IConsumerConfig.InitialCredits.get -> ushort
 RabbitMQ.Stream.Client.IConsumerConfig.InitialCredits.set -> void
 RabbitMQ.Stream.Client.ICrc32
 RabbitMQ.Stream.Client.ICrc32.FailAction.get -> System.Func<RabbitMQ.Stream.Client.IConsumer, RabbitMQ.Stream.Client.ChunkAction>
-RabbitMQ.Stream.Client.ICrc32.FailAction.set -> void
+RabbitMQ.Stream.Client.ICrc32.FailAction.init -> void
 RabbitMQ.Stream.Client.ICrc32.Hash(byte[] data) -> byte[]
 RabbitMQ.Stream.Client.Info
 RabbitMQ.Stream.Client.Info.Identifier.get -> string
@@ -257,6 +267,8 @@ RabbitMQ.Stream.Client.Reliable.ConsumerConfig.Crc32.get -> RabbitMQ.Stream.Clie
 RabbitMQ.Stream.Client.Reliable.ConsumerConfig.Crc32.set -> void
 RabbitMQ.Stream.Client.Reliable.ConsumerConfig.Filter.get -> RabbitMQ.Stream.Client.ConsumerFilter
 RabbitMQ.Stream.Client.Reliable.ConsumerConfig.Filter.set -> void
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.FlowControl.get -> RabbitMQ.Stream.Client.FlowControl
+RabbitMQ.Stream.Client.Reliable.ConsumerConfig.FlowControl.set -> void
 RabbitMQ.Stream.Client.Reliable.ConsumerConfig.InitialCredits.get -> ushort
 RabbitMQ.Stream.Client.Reliable.ConsumerConfig.InitialCredits.set -> void
 RabbitMQ.Stream.Client.Reliable.ConsumerFactory._consumer -> RabbitMQ.Stream.Client.IConsumer
@@ -327,7 +339,7 @@ RabbitMQ.Stream.Client.RoutingStrategyType.Hash = 0 -> RabbitMQ.Stream.Client.Ro
 RabbitMQ.Stream.Client.RoutingStrategyType.Key = 1 -> RabbitMQ.Stream.Client.RoutingStrategyType
 RabbitMQ.Stream.Client.StreamCrc32
 RabbitMQ.Stream.Client.StreamCrc32.FailAction.get -> System.Func<RabbitMQ.Stream.Client.IConsumer, RabbitMQ.Stream.Client.ChunkAction>
-RabbitMQ.Stream.Client.StreamCrc32.FailAction.set -> void
+RabbitMQ.Stream.Client.StreamCrc32.FailAction.init -> void
 RabbitMQ.Stream.Client.StreamCrc32.Hash(byte[] data) -> byte[]
 RabbitMQ.Stream.Client.StreamCrc32.StreamCrc32() -> void
 RabbitMQ.Stream.Client.StreamStats

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -473,7 +473,7 @@ namespace RabbitMQ.Stream.Client
                                     break;
                                 // Request the credit to the server
                                 if (_config.FlowControl.Strategy ==
-                                    ConsumerFlowStrategy.CreditBeforeParseChunk)
+                                    ConsumerFlowStrategy.CreditsBeforeParseChunk)
                                 {
                                     // Request the credit before processing the chunk
                                     // this is the default behavior
@@ -517,7 +517,7 @@ namespace RabbitMQ.Stream.Client
                                     // That's what happens most of the time, and this is the default action
                                     await ParseChunk(chunk).ConfigureAwait(false);
 
-                                    if (_config.FlowControl.Strategy == ConsumerFlowStrategy.CreditAfterParseChunk)
+                                    if (_config.FlowControl.Strategy == ConsumerFlowStrategy.CreditsAfterParseChunk)
                                     {
                                         // Request the credit after processing the chunk
                                         // this is useful when processing the chunk takes time
@@ -820,7 +820,7 @@ namespace RabbitMQ.Stream.Client
                     $"Credits must be greater than 0");
             }
 
-            if (_config.FlowControl.Strategy != ConsumerFlowStrategy.ManualRequestCredit)
+            if (_config.FlowControl.Strategy != ConsumerFlowStrategy.ManualCreditsRequest)
             {
                 throw new InvalidOperationException(
                     "RequestCredits can be used only with ConsumerFlowStrategy.ManualRequestCredit.");

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -808,11 +808,11 @@ namespace RabbitMQ.Stream.Client
             await _client.StoreOffset(_config.Reference, _config.Stream, offset).ConfigureAwait(false);
         }
 
-        public async Task RequestCredits()
+        public async Task Credits()
         {
-            await RequestCredits(1).ConfigureAwait(false);
+            await Credits(1).ConfigureAwait(false);
         }
-        private async Task RequestCredits(ushort credits)
+        private async Task Credits(ushort credits)
         {
             if (credits < 1)
             {
@@ -820,7 +820,7 @@ namespace RabbitMQ.Stream.Client
                     $"Credits must be greater than 0");
             }
 
-            if (_config.FlowControl.Strategy != ConsumerFlowStrategy.ManualCreditsRequest)
+            if (_config.FlowControl.Strategy != ConsumerFlowStrategy.ConsumerCredits)
             {
                 throw new InvalidOperationException(
                     "RequestCredits can be used only with ConsumerFlowStrategy.ManualRequestCredit.");

--- a/RabbitMQ.Stream.Client/RawConsumer.cs
+++ b/RabbitMQ.Stream.Client/RawConsumer.cs
@@ -105,6 +105,9 @@ namespace RabbitMQ.Stream.Client
                 case { Values.Count: 0 }:
                     throw new ArgumentException("Values must be provided when Filter is set");
             }
+
+            FlowControl ??= new FlowControl();
+
         }
 
         internal bool IsFiltering => ConsumerFilter is { Values.Count: > 0 };
@@ -177,7 +180,7 @@ namespace RabbitMQ.Stream.Client
             ProcessChunks();
         }
 
-        // if a user specify a custom offset 
+        // if a user specifies a custom offset, 
         // the _client must filter messages
         // and dispatch only the messages starting from the 
         // user offset.
@@ -201,7 +204,7 @@ namespace RabbitMQ.Stream.Client
         // by default is active
         // in case of single active consumer can be not active
         // it is important to skip the messages in the chunk that 
-        // it is in progress. In this way the promotion will be faster
+        // it is in progress. In this way, the promotion will be faster
         // avoiding to block the consumer handler if the user put some
         // long task
         private bool IsPromotedAsActive { get; set; }
@@ -214,8 +217,8 @@ namespace RabbitMQ.Stream.Client
 
         /// <summary>
         /// MaybeLockDispatch locks the dispatch of the messages
-        /// it is needed only when the consumer is single active consumer
-        /// MaybeLockDispatch is an optimization to avoid to lock the dispatch
+        /// it is needed only when the consumer is single active consumer.
+        /// MaybeLockDispatch is an optimization to avoid lock the dispatch
         /// when the consumer is not single active consumer
         /// </summary>
         private async Task MaybeLockDispatch()
@@ -487,7 +490,7 @@ namespace RabbitMQ.Stream.Client
                             {
                                 // The client has been closed
                                 // Suppose a scenario where the client is closed and the ProcessChunks task is still running
-                                // we remove the the subscriber from the client and we close the client
+                                // we remove the subscriber from the client and we close the client
                                 // The ProcessChunks task will try to send the credit to the server
                                 // The client will throw an InvalidOperationException
                                 // since the connection is closed
@@ -519,8 +522,6 @@ namespace RabbitMQ.Stream.Client
 
                                     if (_config.FlowControl.Strategy == ConsumerFlowStrategy.CreditsAfterParseChunk)
                                     {
-                                        // Request the credit after processing the chunk
-                                        // this is useful when processing the chunk takes time
                                         // it avoids flooding the network with credits
                                         await _client.Credit(EntityId, 1)
                                             .ConfigureAwait(false);
@@ -610,7 +611,7 @@ namespace RabbitMQ.Stream.Client
                         chunkConsumed++;
                         // Send the chunk to the _chunksBuffer
                         // in this way the chunks are processed in a separate thread
-                        // this wont' block the socket thread
+                        // this won't block the socket thread
                         // introduced https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/pull/250
                         if (Token.IsCancellationRequested)
                         {
@@ -654,7 +655,7 @@ namespace RabbitMQ.Stream.Client
                     {
                         // The consumer is closing from the user but some chunks are still in the buffer
                         // simply skip the chunk since the Token.IsCancellationRequested is true
-                        // the catch is needed to avoid to propagate the exception to the socket thread.
+                        // the catch is needed to avoid propagating the exception to the socket thread.
                         Logger?.LogWarning(
                             "OperationCanceledException. {EntityInfo} has been closed while consuming messages. " +
                             "Token.IsCancellationRequested: {IsCancellationRequested}",
@@ -731,7 +732,7 @@ namespace RabbitMQ.Stream.Client
                 // at this point the server has removed the consumer from the list 
                 // and the unsubscribe is not needed anymore (ignoreIfClosed = true)
                 // we call the Close to re-enter to the standard behavior
-                // ignoreIfClosed is an optimization to avoid to send the unsubscribe
+                // ignoreIfClosed is an optimization to avoid sending the unsubscribe
                 _config.Pool.RemoveConsumerEntityFromStream(_client.ClientId, EntityId, _config.Stream);
                 await Shutdown(_config, true).ConfigureAwait(false);
                 _config.MetadataHandler?.Invoke(metaDataUpdate);
@@ -782,7 +783,7 @@ namespace RabbitMQ.Stream.Client
         public override async Task<ResponseCode> Close()
         {
             // when the consumer is closed we must be sure that the 
-            // the subscription is completed to avoid problems with the connection
+            // subscription is completed to avoid problems with the connection
             // It could happen when the closing is called just after the creation
             _completeSubscription.Task.Wait();
             return await Shutdown(_config).ConfigureAwait(false);
@@ -808,10 +809,15 @@ namespace RabbitMQ.Stream.Client
             await _client.StoreOffset(_config.Reference, _config.Stream, offset).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Request credits from the server.
+        /// Valid only if the ConsumerFlowStrategy is set to ConsumerFlowStrategy.ConsumerCredits.
+        /// </summary>
         public async Task Credits()
         {
             await Credits(1).ConfigureAwait(false);
         }
+
         private async Task Credits(ushort credits)
         {
             if (credits < 1)

--- a/RabbitMQ.Stream.Client/Reliable/Consumer.cs
+++ b/RabbitMQ.Stream.Client/Reliable/Consumer.cs
@@ -115,21 +115,10 @@ public record ConsumerConfig : ReliableConfig
     /// <summary>
     /// Enable the check of the crc on the delivery when set to an implementation
     /// of <see cref="ICrc32"><code>ICrc32</code></see>.
-    /// The server will send the crc for each chunk and the client will check it.
-    /// It is not enabled by default. In some case it is could reduce the performance.
-    /// ICrc32 is an interface that can be implemented by the user with the desired implementation.
-    /// The client is tested with the System.IO.Hashing.Crc32 implementation, like:
-    ///<c>
-    /// private class UserCrc32 : ICrc32 
-    /// {
-    /// public byte[] Hash(byte[] data)
-    /// {
-    /// return System.IO.Hashing.Crc32.Hash(data);
-    /// }
-    /// }
-    /// </c>
     /// </summary>
-    public ICrc32 Crc32 { get; set; } = null;
+    public ICrc32 Crc32 { get; set; } = new StreamCrc32();
+
+    public FlowControl FlowControl { get; set; } = new FlowControl();
 
     public ConsumerConfig(StreamSystem streamSystem, string stream) : base(streamSystem, stream)
     {

--- a/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
+++ b/RabbitMQ.Stream.Client/Reliable/ConsumerFactory.cs
@@ -58,6 +58,7 @@ public abstract class ConsumerFactory : ReliableBase
             ConsumerFilter = _consumerConfig.Filter,
             Crc32 = _consumerConfig.Crc32,
             Identifier = _consumerConfig.Identifier,
+            FlowControl = _consumerConfig.FlowControl,
             ConnectionClosedHandler = async (closeReason) =>
             {
                 if (IsClosedNormally(closeReason))
@@ -154,6 +155,7 @@ public abstract class ConsumerFactory : ReliableBase
                     Crc32 = _consumerConfig.Crc32,
                     OffsetSpec = offsetSpecs,
                     Identifier = _consumerConfig.Identifier,
+                    FlowControl = _consumerConfig.FlowControl,
                     ConnectionClosedHandler = async (closeReason, partitionStream) =>
                     {
                         if (IsClosedNormally(closeReason))

--- a/RabbitMQ.Stream.Client/StreamCrc32.cs
+++ b/RabbitMQ.Stream.Client/StreamCrc32.cs
@@ -19,5 +19,5 @@ public class StreamCrc32 : ICrc32
         return System.IO.Hashing.Crc32.Hash(data);
     }
 
-    public Func<IConsumer, ChunkAction> FailAction { get; set; } = null;
+    public Func<IConsumer, ChunkAction> FailAction { get; init; } = null;
 }

--- a/Tests/Crc32Tests.cs
+++ b/Tests/Crc32Tests.cs
@@ -26,7 +26,7 @@ public class FirstCrc32IsWrong : ICrc32
             : System.IO.Hashing.Crc32.Hash(data);
     }
 
-    public Func<IConsumer, ChunkAction> FailAction { get; set; }
+    public Func<IConsumer, ChunkAction> FailAction { get; init; }
 }
 
 public class Crc32Tests(ITestOutputHelper testOutputHelper)

--- a/Tests/FlowControlTests.cs
+++ b/Tests/FlowControlTests.cs
@@ -1,0 +1,87 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2023 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+using System;
+using System.Threading.Tasks;
+using RabbitMQ.Stream.Client;
+using RabbitMQ.Stream.Client.Reliable;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests;
+
+public class FlowControlTests(ITestOutputHelper testOutputHelper)
+{
+    [Theory]
+    [InlineData(ConsumerFlowStrategy.CreditAfterParseChunk)]
+    [InlineData(ConsumerFlowStrategy.CreditBeforeParseChunk)]
+    [InlineData(ConsumerFlowStrategy.CreditWhenHalfChunkProcessed)]
+    public async Task ConsumerShouldConsumeMessagesWithAllFlowStrategy(ConsumerFlowStrategy strategy)
+    {
+        SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
+        await SystemUtils.PublishMessages(system, stream, 130, "1", testOutputHelper);
+        await SystemUtils.WaitAsync(TimeSpan.FromMilliseconds(600));
+        await SystemUtils.PublishMessages(system, stream, 160, "2", testOutputHelper);
+
+        var completionSource = new TaskCompletionSource<int>();
+        var consumed = 0;
+        var consumerConfig = new ConsumerConfig(system, stream)
+        {
+            FlowControl = new FlowControl() { Strategy = strategy, },
+            OffsetSpec = new OffsetTypeFirst(),
+            MessageHandler = (_, _, _, _) =>
+            {
+                consumed++;
+                if (consumed == 290)
+                {
+                    completionSource.TrySetResult(consumed);
+                }
+
+                return Task.CompletedTask;
+            }
+        };
+
+        var consumer = await Consumer.Create(consumerConfig);
+        var result = await completionSource.Task;
+        Assert.Equal(290, result);
+        await consumer.Close();
+        await SystemUtils.CleanUpStreamSystem(system, stream);
+    }
+
+    [Theory]
+    [InlineData(ConsumerFlowStrategy.CreditAfterParseChunk)]
+    [InlineData(ConsumerFlowStrategy.CreditBeforeParseChunk)]
+    [InlineData(ConsumerFlowStrategy.CreditWhenHalfChunkProcessed)]
+    public async Task RawConsumerShouldConsumeMessagesWithAllFlowStrategy(ConsumerFlowStrategy strategy)
+    {
+        SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
+        await SystemUtils.PublishMessages(system, stream, 130, "1", testOutputHelper);
+        await SystemUtils.WaitAsync(TimeSpan.FromMilliseconds(600));
+        await SystemUtils.PublishMessages(system, stream, 160, "2", testOutputHelper);
+
+        var completionSource = new TaskCompletionSource<int>();
+        var consumed = 0;
+        var consumerConfig = new RawConsumerConfig(stream)
+        {
+            FlowControl = new FlowControl() { Strategy = strategy, },
+            OffsetSpec = new OffsetTypeFirst(),
+            MessageHandler = (_, _, _) =>
+            {
+                consumed++;
+                if (consumed == 290)
+                {
+                    completionSource.TrySetResult(consumed);
+                }
+
+                return Task.CompletedTask;
+            }
+        };
+
+        var consumer = await system.CreateRawConsumer(consumerConfig);
+        var result = await completionSource.Task;
+        Assert.Equal(290, result);
+        await consumer.Close();
+        await SystemUtils.CleanUpStreamSystem(system, stream);
+    }
+}

--- a/Tests/FlowControlTests.cs
+++ b/Tests/FlowControlTests.cs
@@ -16,7 +16,7 @@ public class FlowControlTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(ConsumerFlowStrategy.CreditsAfterParseChunk)]
     [InlineData(ConsumerFlowStrategy.CreditsBeforeParseChunk)]
-    [InlineData(ConsumerFlowStrategy.ManualCreditsRequest)]
+    [InlineData(ConsumerFlowStrategy.ConsumerCredits)]
     public async Task ConsumerShouldConsumeMessagesWithAllFlowStrategy(ConsumerFlowStrategy strategy)
     {
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
@@ -43,18 +43,18 @@ public class FlowControlTests(ITestOutputHelper testOutputHelper)
                     case ConsumerFlowStrategy.CreditsAfterParseChunk:
                         // No action needed, credit is requested automatically after parsing the chunk
                         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-                            await sourceConsumer.RequestCredits());
+                            await sourceConsumer.Credits());
                         break;
                     case ConsumerFlowStrategy.CreditsBeforeParseChunk:
                         // No action needed, credit is requested automatically before parsing the chunk
                         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-                            await sourceConsumer.RequestCredits());
+                            await sourceConsumer.Credits());
                         break;
-                    case ConsumerFlowStrategy.ManualCreditsRequest:
+                    case ConsumerFlowStrategy.ConsumerCredits:
                         // In manual request credit mode, we need to request credit explicitly
                         // here we simulate the finish of processing the chunk
                         if (consumed % 10 == 0)
-                            await sourceConsumer.RequestCredits().ConfigureAwait(false);
+                            await sourceConsumer.Credits().ConfigureAwait(false);
 
                         break;
                     default:
@@ -73,7 +73,7 @@ public class FlowControlTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(ConsumerFlowStrategy.CreditsAfterParseChunk)]
     [InlineData(ConsumerFlowStrategy.CreditsBeforeParseChunk)]
-    [InlineData(ConsumerFlowStrategy.ManualCreditsRequest)]
+    [InlineData(ConsumerFlowStrategy.ConsumerCredits)]
     public async Task RawConsumerShouldConsumeMessagesWithAllFlowStrategy(ConsumerFlowStrategy strategy)
     {
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
@@ -98,19 +98,19 @@ public class FlowControlTests(ITestOutputHelper testOutputHelper)
                     case ConsumerFlowStrategy.CreditsAfterParseChunk:
                         // No action needed, credit is requested automatically after parsing the chunk
                         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-                            await sourceConsumer.RequestCredits());
+                            await sourceConsumer.Credits());
 
                         break;
                     case ConsumerFlowStrategy.CreditsBeforeParseChunk:
                         // No action needed, credit is requested automatically before parsing the chunk
                         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-                            await sourceConsumer.RequestCredits());
+                            await sourceConsumer.Credits());
                         break;
-                    case ConsumerFlowStrategy.ManualCreditsRequest:
+                    case ConsumerFlowStrategy.ConsumerCredits:
                         // In manual request credit mode, we need to request credit explicitly
                         // here we simulate the finish of processing the chunk
                         if (consumed % 10 == 0)
-                            await sourceConsumer.RequestCredits().ConfigureAwait(false);
+                            await sourceConsumer.Credits().ConfigureAwait(false);
 
                         break;
                     default:

--- a/Tests/FlowControlTests.cs
+++ b/Tests/FlowControlTests.cs
@@ -14,9 +14,9 @@ namespace Tests;
 public class FlowControlTests(ITestOutputHelper testOutputHelper)
 {
     [Theory]
-    [InlineData(ConsumerFlowStrategy.CreditAfterParseChunk)]
-    [InlineData(ConsumerFlowStrategy.CreditBeforeParseChunk)]
-    [InlineData(ConsumerFlowStrategy.ManualRequestCredit)]
+    [InlineData(ConsumerFlowStrategy.CreditsAfterParseChunk)]
+    [InlineData(ConsumerFlowStrategy.CreditsBeforeParseChunk)]
+    [InlineData(ConsumerFlowStrategy.ManualCreditsRequest)]
     public async Task ConsumerShouldConsumeMessagesWithAllFlowStrategy(ConsumerFlowStrategy strategy)
     {
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
@@ -40,20 +40,21 @@ public class FlowControlTests(ITestOutputHelper testOutputHelper)
 
                 switch (strategy)
                 {
-                    case ConsumerFlowStrategy.CreditAfterParseChunk:
+                    case ConsumerFlowStrategy.CreditsAfterParseChunk:
                         // No action needed, credit is requested automatically after parsing the chunk
-                        await Assert.ThrowsAsync<InvalidOperationException>(async () => await sourceConsumer.RequestCredits());
+                        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                            await sourceConsumer.RequestCredits());
                         break;
-                    case ConsumerFlowStrategy.CreditBeforeParseChunk:
+                    case ConsumerFlowStrategy.CreditsBeforeParseChunk:
                         // No action needed, credit is requested automatically before parsing the chunk
-                        await Assert.ThrowsAsync<InvalidOperationException>(async () => await sourceConsumer.RequestCredits());
+                        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                            await sourceConsumer.RequestCredits());
                         break;
-                    case ConsumerFlowStrategy.ManualRequestCredit:
+                    case ConsumerFlowStrategy.ManualCreditsRequest:
                         // In manual request credit mode, we need to request credit explicitly
+                        // here we simulate the finish of processing the chunk
                         if (consumed % 10 == 0)
-                        {
                             await sourceConsumer.RequestCredits().ConfigureAwait(false);
-                        }
 
                         break;
                     default:
@@ -70,9 +71,9 @@ public class FlowControlTests(ITestOutputHelper testOutputHelper)
     }
 
     [Theory]
-    [InlineData(ConsumerFlowStrategy.CreditAfterParseChunk)]
-    [InlineData(ConsumerFlowStrategy.CreditBeforeParseChunk)]
-    [InlineData(ConsumerFlowStrategy.ManualRequestCredit)]
+    [InlineData(ConsumerFlowStrategy.CreditsAfterParseChunk)]
+    [InlineData(ConsumerFlowStrategy.CreditsBeforeParseChunk)]
+    [InlineData(ConsumerFlowStrategy.ManualCreditsRequest)]
     public async Task RawConsumerShouldConsumeMessagesWithAllFlowStrategy(ConsumerFlowStrategy strategy)
     {
         SystemUtils.InitStreamSystemWithRandomStream(out var system, out var stream);
@@ -90,27 +91,26 @@ public class FlowControlTests(ITestOutputHelper testOutputHelper)
             {
                 consumed++;
                 if (consumed == 290)
-                {
                     completionSource.TrySetResult(consumed);
-                }
 
                 switch (strategy)
                 {
-                    case ConsumerFlowStrategy.CreditAfterParseChunk:
+                    case ConsumerFlowStrategy.CreditsAfterParseChunk:
                         // No action needed, credit is requested automatically after parsing the chunk
-                        await Assert.ThrowsAsync<InvalidOperationException>(async () => await sourceConsumer.RequestCredits());
+                        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                            await sourceConsumer.RequestCredits());
 
                         break;
-                    case ConsumerFlowStrategy.CreditBeforeParseChunk:
+                    case ConsumerFlowStrategy.CreditsBeforeParseChunk:
                         // No action needed, credit is requested automatically before parsing the chunk
-                        await Assert.ThrowsAsync<InvalidOperationException>(async () => await sourceConsumer.RequestCredits());
+                        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                            await sourceConsumer.RequestCredits());
                         break;
-                    case ConsumerFlowStrategy.ManualRequestCredit:
+                    case ConsumerFlowStrategy.ManualCreditsRequest:
                         // In manual request credit mode, we need to request credit explicitly
+                        // here we simulate the finish of processing the chunk
                         if (consumed % 10 == 0)
-                        {
                             await sourceConsumer.RequestCredits().ConfigureAwait(false);
-                        }
 
                         break;
                     default:

--- a/docs/Documentation/ConsumerUsage.cs
+++ b/docs/Documentation/ConsumerUsage.cs
@@ -140,6 +140,7 @@ public class ConsumerUsage
                 streamSystem,
                 "my-stream")
             {
+                // tag::consumer-creation-crc[]
                 Crc32 = new StreamCrc32() // <1>
                 {
                     FailAction = (consumerInstance) => ChunkAction.Skip // <2>

--- a/docs/Documentation/SetFlowControl.cs
+++ b/docs/Documentation/SetFlowControl.cs
@@ -37,11 +37,11 @@ public class SetFlowControl
         {
             FlowControl = new FlowControl() // <1>
             {
-                Strategy = ConsumerFlowStrategy.ManualCreditsRequest, // <2>
+                Strategy = ConsumerFlowStrategy.ConsumerCredits, // <2>
             },
             // here we simulate a manual flow control
             // when the consumer has consumed 10 messages, it will request more credits
-            MessageHandler = (_, rawConsumer, _, _) => consumed++ % 10 == 0 ? rawConsumer.RequestCredits() : // <3>
+            MessageHandler = (_, rawConsumer, _, _) => consumed++ % 10 == 0 ? rawConsumer.Credits() : // <3>
                 Task.CompletedTask
         };
         // end::set-flow-control-manual[]

--- a/docs/Documentation/SetFlowControl.cs
+++ b/docs/Documentation/SetFlowControl.cs
@@ -1,0 +1,51 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2023 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+using RabbitMQ.Stream.Client;
+using RabbitMQ.Stream.Client.Reliable;
+
+namespace Documentation;
+
+public class SetFlowControl
+{
+    public static async Task ConsumerFlowControl()
+    {
+        var streamSystem = await StreamSystem.Create(
+            new StreamSystemConfig()
+        ).ConfigureAwait(false);
+        // tag::set-flow-control[]
+        var consumerConfig = new ConsumerConfig(streamSystem, "MyStream")
+        {
+            FlowControl = new FlowControl() // <1>
+            {
+                Strategy = ConsumerFlowStrategy.CreditsAfterParseChunk, // <2>
+            },
+        };
+        // end::set-flow-control[]
+    }
+
+
+    public static async Task ManualFlowControl()
+    {
+        var streamSystem = await StreamSystem.Create(
+            new StreamSystemConfig()
+        ).ConfigureAwait(false);
+        var consumed = 0;
+        // tag::set-flow-control-manual[]
+        var consumerConfig = new ConsumerConfig(streamSystem, "MyStream")
+        {
+            FlowControl = new FlowControl() // <1>
+            {
+                Strategy = ConsumerFlowStrategy.ManualCreditsRequest, // <2>
+            },
+            // here we simulate a manual flow control
+            // when the consumer has consumed 10 messages, it will request more credits
+            MessageHandler = (_, rawConsumer, _, _) => consumed++ % 10 == 0 ? rawConsumer.RequestCredits() : // <3>
+                Task.CompletedTask
+        };
+        // end::set-flow-control-manual[]
+
+        var consumer = await Consumer.Create(consumerConfig).ConfigureAwait(false);
+    }
+}

--- a/docs/ManualCredits/ManualCredits.csproj
+++ b/docs/ManualCredits/ManualCredits.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\RabbitMQ.Stream.Client\RabbitMQ.Stream.Client.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/docs/ManualCredits/Program.cs
+++ b/docs/ManualCredits/Program.cs
@@ -27,7 +27,7 @@ _ = Task.Run(async () =>
     while (!cts.IsCancellationRequested)
     {
         await Task.Delay(2000, cts.Token).ConfigureAwait(false);
-        if (rawConsumer != null) await rawConsumer.RequestCredits().ConfigureAwait(false);
+        if (rawConsumer != null) await rawConsumer.Credits().ConfigureAwait(false);
         else Console.WriteLine("Credits requested...");
     }
 }).ConfigureAwait(false);
@@ -37,7 +37,7 @@ var consumer = await Consumer.Create(
     new ConsumerConfig(streamSystem, StreamName)
     {
         OffsetSpec = new OffsetTypeFirst(),
-        FlowControl = new FlowControl() { Strategy = ConsumerFlowStrategy.ManualCreditsRequest },
+        FlowControl = new FlowControl() { Strategy = ConsumerFlowStrategy.ConsumerCredits },
         MessageHandler = (_, sourceConsumer, _, message) =>
         {
             rawConsumer ??= sourceConsumer;

--- a/docs/ManualCredits/Program.cs
+++ b/docs/ManualCredits/Program.cs
@@ -22,8 +22,9 @@ var cts = new CancellationTokenSource();
 RawConsumer? rawConsumer = null;
 _ = Task.Run(async () =>
 {
-    // simulate a background task that requests credits periodically
-    // each 2 seconds request credits from the raw consumer
+    // Simulate a background task that requests credits periodically
+    // each two-second request credits from the raw consumer.
+    // You will see the messages coming in the console each time the credits are requested.
     while (!cts.IsCancellationRequested)
     {
         await Task.Delay(2000, cts.Token).ConfigureAwait(false);

--- a/docs/ManualCredits/Program.cs
+++ b/docs/ManualCredits/Program.cs
@@ -1,0 +1,63 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using System.Text;
+using RabbitMQ.Stream.Client;
+using RabbitMQ.Stream.Client.Reliable;
+
+Console.WriteLine("Manual Credits Example");
+
+var streamSystem = await StreamSystem.Create(
+    new StreamSystemConfig()
+).ConfigureAwait(false);
+
+const string StreamName = "manual-credits-stream";
+await streamSystem.CreateStream(new StreamSpec(StreamName)).ConfigureAwait(false);
+
+var producer = await Producer.Create(
+    new ProducerConfig(streamSystem, StreamName)
+).ConfigureAwait(false);
+
+
+var cts = new CancellationTokenSource();
+RawConsumer? rawConsumer = null;
+_ = Task.Run(async () =>
+{
+    // simulate a background task that requests credits periodically
+    // each 2 seconds request credits from the raw consumer
+    while (!cts.IsCancellationRequested)
+    {
+        await Task.Delay(2000, cts.Token).ConfigureAwait(false);
+        if (rawConsumer != null) await rawConsumer.RequestCredits().ConfigureAwait(false);
+        else Console.WriteLine("Credits requested...");
+    }
+}).ConfigureAwait(false);
+
+
+var consumer = await Consumer.Create(
+    new ConsumerConfig(streamSystem, StreamName)
+    {
+        OffsetSpec = new OffsetTypeFirst(),
+        FlowControl = new FlowControl() { Strategy = ConsumerFlowStrategy.ManualCreditsRequest },
+        MessageHandler = (_, sourceConsumer, _, message) =>
+        {
+            rawConsumer ??= sourceConsumer;
+            Console.WriteLine($"Received: {Encoding.UTF8.GetString(message.Data.Contents)}");
+            return Task.CompletedTask;
+        }
+    }
+).ConfigureAwait(false);
+
+for (var i = 0; i < 10_000; i++)
+{
+    var message = new Message(Encoding.UTF8.GetBytes($"Message {i}"));
+    await producer.Send(message).ConfigureAwait(false);
+}
+
+
+Console.WriteLine("Press any key to exit...");
+Console.ReadKey();
+cts.Cancel();
+await producer.Close().ConfigureAwait(false);
+await consumer.Close().ConfigureAwait(false);
+await streamSystem.DeleteStream(StreamName).ConfigureAwait(false);
+await streamSystem.Close().ConfigureAwait(false);

--- a/docs/asciidoc/api.adoc
+++ b/docs/asciidoc/api.adoc
@@ -873,7 +873,14 @@ the code in the `FailAction`  should be short, fast and safe, as it is executed 
 It is recommended to leave it enabled, as it allows the client library to detect corrupted chunks and avoid parsing them.
 Disabling the CRC32 _could_ improve performance, but it is not recommended as it can lead to parsing corrupted chunks and unexpected behavior.
 
-[[consumer-reconnect-strategy]]
+[[consumer-flow-control]]
+===== Flow Control
+
+This section covers how a consumer can tell the broker when to send more messages.
+By default, the broker keeps sending messages as long as messages are processed and the `MessageHandler` method returns.
+
+
+
 [[specifying-an-offset]]
 ===== Specifying an Offset
 

--- a/docs/asciidoc/api.adoc
+++ b/docs/asciidoc/api.adoc
@@ -904,7 +904,7 @@ include::{test-examples}/SetFlowControl.cs[tag=set-flow-control-manual]
 --------
 
 <1> Set the flow control strategy
-<2> Set the flow control strategy to `ConsumerFlowStrategy.Manual` to control when the broker sends more messages.
+<2> Set the flow control strategy to `ConsumerFlowStrategy.ConsumerCredits` to control when the broker sends more messages.
 <3> Request credits when the consumer is ready to receive more messages.
 
 `ConsumerFlowStrategy` values:
@@ -920,12 +920,12 @@ include::{test-examples}/SetFlowControl.cs[tag=set-flow-control-manual]
 |`CreditsAfterParseChunk`
 |The broker sends messages to the consumer after parsing the chunk.
 
-|`ManualCreditsRequest`
+|`ConsumerCredits`
 |The broker sends messages to the consumer only when the consumer requests credits.
 |===
 
 [NOTE]
-.Manual flow control
+.Manual flow control with `ConsumerCredits` 
 ====
 With manual flow control, the consumer can control when the broker sends more messages.
 It gives all the control user side. If the server doesn't receive a request for credits, it will not send more messages.

--- a/docs/asciidoc/api.adoc
+++ b/docs/asciidoc/api.adoc
@@ -877,8 +877,60 @@ Disabling the CRC32 _could_ improve performance, but it is not recommended as it
 ===== Flow Control
 
 This section covers how a consumer can tell the broker when to send more messages.
-By default, the broker keeps sending messages as long as messages are processed and the `MessageHandler` method returns.
+By default, the broker keeps sending messages as soon as a chunk is received. This strategy works fine if message processing is fast enough. 
 
+With `ConsumerFlowStrategy` it is possible to control when the broker sends more messages to the consumer.
+
+.Setting a consumer flow control strategy
+[source,c#,indent=0]
+--------
+include::{test-examples}/SetFlowControl.cs[tag=set-flow-control]
+--------
+
+<1> Set the flow control strategy
+<2> Set the flow control strategy to `ConsumerFlowStrategy.CreditAfterParseChunk` as soon as the chunk is parsed. See `ConsumerFlowStrategy` for more details.
+If message processing takes longer, one can be tempted to process messages in parallel with `Tasks`.
+This will make the handle method return immediately and the broker will keep sending messages, potentially overflowing the consumer.
+
+What we miss in the parallel processing case is a way to tell the library we are done processing a message and that we are ready at some point to handle more messages. 
+This is the goal of the `consumer.RequestCredits()` method.
+With `consumer.RequestCredits()` the consumer can tell the broker it is ready to receive more messages.
+It is possible also the `Pause` the consumer by not asking for credits.
+
+.Setting a consumer manual control strategy
+[source,c#,indent=0]
+--------
+include::{test-examples}/SetFlowControl.cs[tag=set-flow-control-manual]
+--------
+
+<1> Set the flow control strategy
+<2> Set the flow control strategy to `ConsumerFlowStrategy.Manual` to control when the broker sends more messages.
+<3> Request credits when the consumer is ready to receive more messages.
+
+`ConsumerFlowStrategy` values:
+
+[%header,cols=2*]
+|===
+|Parameter Name
+|Description
+
+|`CreditsBeforeParseChunk`
+|The broker sends messages to the consumer before parsing the chunk. (Default)
+
+|`CreditsAfterParseChunk`
+|The broker sends messages to the consumer after parsing the chunk.
+
+|`ManualCreditsRequest`
+|The broker sends messages to the consumer only when the consumer requests credits.
+|===
+
+[NOTE]
+.Manual flow control
+====
+With manual flow control, the consumer can control when the broker sends more messages.
+It gives all the control user side. If the server doesn't receive a request for credits, it will not send more messages.
+So you could end up with a consumer not consuming anything.
+====
 
 
 [[specifying-an-offset]]


### PR DESCRIPTION
Add Consumer Flow control.
Configure the way to request the credits with the following parameters:
```csharp
public enum ConsumerFlowStrategy
{
    CreditsBeforeParseChunk,
    CreditsAfterParseChunk,
    ConsumerCredits
}
var consumerConfig = new RawConsumerConfig(stream)
 {
     FlowControl = new FlowControl() { 
        Strategy = ConsumerFlowStrategy.CreditsBeforeParseChunk
     },
```

Add `rawConsumer.Credits` to manually request `Credits`

Closes https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/issues/420