### PR TITLE
Guard PipeReader.AdvanceTo on closed socket

### DIFF
--- a/RabbitMQ.Stream.Client/Connection.cs
+++ b/RabbitMQ.Stream.Client/Connection.cs
@@ -189,7 +189,10 @@ namespace RabbitMQ.Stream.Client
                         numFrames += 1;
                     }
 
-                    reader.AdvanceTo(buffer.Start, buffer.End);
+                    if (socket.Connected)
+                    {
+                        reader.AdvanceTo(buffer.Start, buffer.End);
+                    }
                 }
             }
             catch (OperationCanceledException e)


### PR DESCRIPTION
Problem: A race during shutdown could call reader.AdvanceTo(buffer.Start, buffer.End) after the TCP socket is closed, risking exceptions that propagate via reader.CompleteAsync(caught) and noisy logs.
Change: In Connection.ProcessIncomingFrames, only call reader.AdvanceTo(...) when socket.Connected is true.