### PR TITLE
Initialize Properties and ApplicationProperties in Message class constructor

### DIFF
--- a/RabbitMQ.Stream.Client/Message.cs
+++ b/RabbitMQ.Stream.Client/Message.cs
@@ -18,6 +18,8 @@ namespace RabbitMQ.Stream.Client
         public Message(Data data)
         {
             Data = data;
+            Properties = new Properties();
+            ApplicationProperties = new ApplicationProperties();
         }
 
         public Annotations Annotations { get; internal set; }


### PR DESCRIPTION
Initialize Properties and ApplicationProperties in Message class constructor to avoid checking for null on every property access like message.Properties.MessageId.